### PR TITLE
Add CI/CD pipeline for snapshot builds and GitHub Packages publishing

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,75 @@
+name: Build, Test and Publish Snapshot
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  # ---------------------------------------------------------------------------
+  # Build and test
+  # ---------------------------------------------------------------------------
+
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -s .mvn/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+      - name: Upload JARs
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-jars
+          path: target/*.jar
+
+  # ---------------------------------------------------------------------------
+  # Publish snapshot — only on push to master
+  # ---------------------------------------------------------------------------
+
+  publish-snapshot:
+    name: Publish Snapshot to GitHub Releases and GitHub Packages
+    needs: [ build ]
+    if: github.event_name == 'push' && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: plugin-jars
+          path: snapshot-jars/
+      - name: Publish rolling snapshot release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release delete snapshot --yes --cleanup-tag || true
+          gh release create snapshot snapshot-jars/*.jar \
+            --title "Snapshot Build" \
+            --notes "Snapshot from ${{ github.sha }} — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --prerelease \
+            --target ${{ github.sha }}
+      - name: Set up Maven for GitHub Packages
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+      - name: Publish to GitHub Packages
+        run: |
+          mvn --batch-mode deploy -s .mvn/settings.xml -Dmaven.test.skip=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${env.GITHUB_ACTOR}</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,15 @@
         <logback.version>1.5.32</logback.version>
         <argLine>-Xmx2g -Xms1g --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</argLine>
     </properties>
-    
-    
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/bernardladenthin/bitcoinaddressfinder</url>
+        </repository>
+    </distributionManagement>
+
     <repositories>
         <repository>
           <id>jitpack.io</id>


### PR DESCRIPTION
## Summary
This PR introduces automated continuous integration and deployment infrastructure to build, test, and publish snapshot releases of the project to GitHub Releases and GitHub Packages.

## Key Changes
- **GitHub Actions Workflow** (`.github/workflows/snapshot.yml`): Added a new workflow that:
  - Builds and tests the project on every push to master and pull request
  - Publishes snapshot artifacts to GitHub Releases as a rolling "snapshot" release
  - Deploys snapshot packages to GitHub Packages Maven repository
  - Uses Java 21 with Zulu distribution and Maven caching for faster builds

- **Maven Configuration** (`pom.xml`): 
  - Added `distributionManagement` section to configure GitHub Packages as the deployment repository
  - Cleaned up whitespace formatting

- **Maven Settings** (`.mvn/settings.xml`): 
  - Added server credentials configuration for GitHub Packages authentication using GitHub token and actor environment variables

## Implementation Details
- The workflow only publishes snapshots on successful pushes to the master branch, while still running tests on all pull requests
- Snapshot releases are marked as pre-releases and include a link to the triggering workflow run
- The rolling snapshot release automatically deletes the previous snapshot tag/release before creating a new one
- Maven deployment skips tests to avoid redundant test execution (tests already ran in the build step)

https://claude.ai/code/session_01ResEx8tuBxzY42xq1R9V9X