### PR TITLE
Update default branch from main to master in CI workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,7 +2,7 @@ name: Build, Test and Publish Snapshot
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
   workflow_dispatch:
 
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -34,7 +36,7 @@ jobs:
           path: target/*.jar
 
   # ---------------------------------------------------------------------------
-  # Publish snapshot — only on push to main
+  # Publish snapshot — only on push to master
   # ---------------------------------------------------------------------------
 
   publish-snapshot:


### PR DESCRIPTION
## Summary
Updates the GitHub Actions snapshot workflow to use `master` as the default branch instead of `main`, and adds explicit permissions configuration to the build job.

## Key Changes
- Changed the trigger branch for the snapshot workflow from `main` to `master`
- Added explicit `contents: read` permission to the build job for improved security posture
- Updated workflow comments to reflect the branch name change

## Implementation Details
The workflow now triggers on pushes to the `master` branch instead of `main`. The addition of explicit permissions follows GitHub's security best practices by using the principle of least privilege, ensuring the build job only has read access to repository contents.

https://claude.ai/code/session_018GqGrJWwE6Fhw9UPy6ViEv