### PR TITLE
Update default branch from master to main and clean old snapshots

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,7 +2,7 @@ name: Build, Test and Publish Snapshot
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 
@@ -36,7 +36,7 @@ jobs:
           path: target/*.jar
 
   # ---------------------------------------------------------------------------
-  # Publish snapshot — only on push to master
+  # Publish snapshot — only on push to main
   # ---------------------------------------------------------------------------
 
   publish-snapshot:
@@ -69,6 +69,13 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+      - name: Delete old snapshot versions from GitHub Packages
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: 'net.ladenthin.bitcoinaddressfinder'
+          package-type: 'maven'
+          min-versions-to-keep: 0
+        continue-on-error: true
       - name: Publish to GitHub Packages
         run: |
           mvn --batch-mode deploy -s .mvn/settings.xml -Dmaven.test.skip=true


### PR DESCRIPTION
## Summary
This PR updates the snapshot workflow to use the new default branch name and adds automatic cleanup of old snapshot versions from GitHub Packages.

## Key Changes
- Updated workflow trigger branch from `master` to `main` in the push configuration
- Updated workflow documentation comment to reflect the new default branch name
- Added a new step to delete old snapshot versions from GitHub Packages before publishing, keeping 0 versions (effectively removing all previous snapshots)
  - Uses the `actions/delete-package-versions@v5` action
  - Configured to handle Maven packages
  - Set to continue on error to prevent workflow failures if deletion encounters issues

## Implementation Details
The new cleanup step runs after the Java 21 setup and before the Maven publish step, ensuring old snapshots are removed before the new version is published. This helps maintain a clean package registry and prevents accumulation of old snapshot artifacts.

https://claude.ai/code/session_01BYbSQEhXmcXudk2kBwfnSQ