### PR TITLE
improve(dumpwallet): named variable + existence check before db.open()

### DIFF
--- a/helper/dumpwallet/dumpwallet.py
+++ b/helper/dumpwallet/dumpwallet.py
@@ -4,6 +4,7 @@
 # License.....: MIT
 #
 import sys
+import os
 import struct
 from bsddb3.db import *
 from bitcoinaddress import Wallet
@@ -26,8 +27,14 @@ if not len(sys.argv) == 2:
     print("Usage: %s <wallet_file>" % sys.argv[0])
     sys.exit(1)
 
+wallet_path = os.path.realpath(sys.argv[1])
+
+if not os.path.isfile(wallet_path):
+    print("Error: not a regular file: %s" % wallet_path)
+    sys.exit(1)
+
 db = DB()
-db.open(sys.argv[1], "main", DB_BTREE, DB_RDONLY)
+db.open(wallet_path, "main", DB_BTREE, DB_RDONLY)
 
 items = db.items()
 


### PR DESCRIPTION
## Summary

- Store the wallet file argument once as `wallet_path` via `os.path.realpath()` so `sys.argv[1]` is not repeated raw in the code.
- Validate the resolved path is a regular file before calling `db.open()`, giving a clear error message instead of a cryptic BerkeleyDB exception.

This extracts the genuinely useful parts originally suggested in PR #166, without the misleading "path traversal" framing that did not apply to a local CLI tool.

## Changes

- `helper/dumpwallet/dumpwallet.py`

## Test plan

- [ ] `python3 helper/dumpwallet/dumpwallet.py` → prints usage
- [ ] `python3 helper/dumpwallet/dumpwallet.py /tmp/nonexistent.dat` → prints `Error: not a regular file: ...`
- [ ] `python3 helper/dumpwallet/dumpwallet.py <real-wallet.dat>` → dumps keys as before

https://claude.ai/code/session_01FmLitsbHWNDq3nDhjbRmf5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmLitsbHWNDq3nDhjbRmf5)_