### PR TITLE
Update Claude Code action to use Anthropic API key

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflows to use the new `anthropic_api_key` secret instead of the deprecated `claude_code_oauth_token` for authenticating with the Claude Code action.

## Changes
- Updated `.github/workflows/claude-code-review.yml` to use `anthropic_api_key` secret
- Updated `.github/workflows/claude.yml` to use `anthropic_api_key` secret
- Changed the input parameter from `claude_code_oauth_token` to `anthropic_api_key` in both workflows

## Notes
This change aligns with the updated authentication method for the `anthropics/claude-code-action@v1`. The `ANTHROPIC_API_KEY` secret should be configured in the repository settings to replace the previous `CLAUDE_CODE_OAUTH_TOKEN` secret.

https://claude.ai/code/session_013XPXfNLFau5uvtTDd2nHi1