### PR TITLE
Reformat setup-java action configuration for readability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -134,7 +134,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
-        with: { java-version: ${{ env.JAVA_VERSION }}, distribution: temurin }
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
       - uses: actions/download-artifact@v8
         with: { name: jacoco-report, path: target/site/jacoco/ }
         continue-on-error: true


### PR DESCRIPTION
## Summary
Reformatted the `setup-java` action configuration in the publish workflow to use multi-line YAML syntax for improved readability and consistency.

## Changes
- Converted the `setup-java` action's `with` block from inline format to multi-line format
- Separated `java-version` and `distribution` parameters onto individual lines
- Maintains identical functionality while improving code formatting

## Details
This is a formatting-only change that makes the workflow configuration more readable and easier to maintain. The behavior of the workflow remains unchanged.

https://claude.ai/code/session_017Ct1wCX85tkB7Wxyj1Aieq