### PR TITLE
Refactor coverage reporting into separate workflow job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           file: target/site/jacoco/jacoco.xml
           format: jacoco
         continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Test
+        shell: bash
         run: mvn --batch-mode -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=${{ matrix.disable-lmdb }} --update-snapshots test jacoco:report
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,9 +71,39 @@ jobs:
           path: target/site/jacoco/jacoco.xml
           if-no-files-found: ignore
 
+  report:
+    name: Report
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+      - uses: actions/download-artifact@v8
+        with: { name: jacoco-report, path: target/site/jacoco/ }
+        continue-on-error: true
+      - uses: advanced-security/maven-dependency-submission-action@v5
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/site/jacoco/jacoco.xml
+          format: jacoco
+        continue-on-error: true
+      - name: Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/site/jacoco/jacoco.xml
+        continue-on-error: true
+
   publish-snapshot:
     name: Publish Snapshot to Central
-    needs: [test]
+    needs: [report]
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
@@ -97,7 +127,7 @@ jobs:
 
   publish-release:
     name: Publish Release to Central
-    needs: [test]
+    needs: [report]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven-central
@@ -136,38 +166,3 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: release-assets/*
-
-  post-publish:
-    name: Post-Publish
-    needs: [test, publish-snapshot, publish-release]
-    if: >-
-      always() &&
-      needs.test.result == 'success' &&
-      (needs.publish-snapshot.result == 'success' ||
-       needs.publish-release.result == 'success')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: temurin
-      - uses: actions/download-artifact@v8
-        with: { name: jacoco-report, path: target/site/jacoco/ }
-        continue-on-error: true
-      - uses: advanced-security/maven-dependency-submission-action@v5
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/site/jacoco/jacoco.xml
-          format: jacoco
-        continue-on-error: true
-      - name: Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: target/site/jacoco/jacoco.xml
-        continue-on-error: true


### PR DESCRIPTION
## Summary
Restructured the GitHub Actions workflow to decouple coverage reporting from the publish jobs by extracting it into a dedicated `report` job that runs after tests complete.

## Key Changes
- **New `report` job**: Created a standalone job that handles all coverage-related tasks (Coveralls and Codecov submissions) and Maven dependency submission
- **Simplified job dependencies**: Updated `publish-snapshot` and `publish-release` jobs to depend on the new `report` job instead of directly on `test`
- **Removed `post-publish` job**: Eliminated the conditional post-publish job that previously ran after successful publishes, consolidating its responsibilities into the new `report` job
- **Improved token handling**: Changed Coveralls token from `secrets.COVERALLS_TOKEN` to `secrets.GITHUB_TOKEN` for consistency
- **Better separation of concerns**: Coverage reporting now runs independently of publish operations, improving workflow clarity and maintainability

## Implementation Details
- The new `report` job runs unconditionally after tests (with `continue-on-error: true` for individual coverage steps)
- Both coverage submission steps are configured to continue on error, ensuring one failure doesn't block the other
- The job requires `contents: write` permission for Maven dependency submission
- Artifact download includes `continue-on-error: true` to handle cases where coverage reports may not be generated

https://claude.ai/code/session_015QvayxAG8vHDVH1fcqUZ8w