### PR TITLE
Refactor GitHub release workflow to upload assets before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,9 +102,37 @@ jobs:
           files: target/site/jacoco/jacoco.xml
         continue-on-error: true
 
+  github-snapshot:
+    name: Update Snapshot Pre-release on GitHub
+    needs: [report]
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: jars
+          path: snapshot-assets/
+      - name: Update snapshot pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view snapshot --repo ${{ github.repository }} 2>/dev/null \
+            || gh release create snapshot \
+                 --repo ${{ github.repository }} \
+                 --prerelease \
+                 --title "Snapshot (latest)" \
+                 --notes "Latest snapshot build from the main branch."
+          gh release upload snapshot snapshot-assets/* \
+            --repo ${{ github.repository }} \
+            --clobber
+
   publish-snapshot:
     name: Publish Snapshot to Central
-    needs: [report]
+    needs: [github-snapshot]
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
@@ -126,9 +154,26 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
 
+  github-release:
+    name: Attach Binaries to GitHub Release
+    needs: [report]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: jars
+          path: release-assets/
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*
+
   publish-release:
     name: Publish Release to Central
-    needs: [report]
+    needs: [github-release]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven-central
@@ -150,20 +195,3 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-  github-release:
-    name: Attach Binaries to GitHub Release
-    needs: [publish-release]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: jars
-          path: release-assets/
-      - name: Upload release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          files: release-assets/*


### PR DESCRIPTION
## Summary
Restructured the GitHub Actions publish workflow to upload release binaries to GitHub before publishing to Maven Central, ensuring artifacts are available on GitHub releases immediately.

## Key Changes
- **New `github-snapshot` job**: Added dedicated job to manage snapshot pre-releases on GitHub, uploading snapshot artifacts with `--clobber` flag to keep only the latest build
- **New `github-release` job**: Moved GitHub release asset upload to execute before Maven Central publishing (previously ran after), ensuring binaries are available on GitHub releases immediately upon tag creation
- **Updated job dependencies**: 
  - `publish-snapshot` now depends on `github-snapshot` instead of `report`
  - `publish-release` now depends on `github-release` instead of `report`
  - `github-release` now depends on `report` instead of `publish-release`

## Implementation Details
- The snapshot job creates or updates a "snapshot" pre-release with the latest build artifacts from the main branch
- Both snapshot and release jobs download the pre-built JAR artifacts and upload them to their respective GitHub releases
- The workflow maintains the same trigger conditions: snapshots on main branch pushes/manual dispatch, releases on version tags
- Job ordering ensures GitHub releases are populated before Maven Central publishing completes

https://claude.ai/code/session_01RehtKrFzDfPPisTDxpNaDA