### PR TITLE
Refactor CI/CD workflow: add conditional checks for snapshot and tag builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,7 +183,7 @@ jobs:
           name: jars
           path: release-assets/
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: release-assets/*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,12 +102,30 @@ jobs:
           files: target/site/jacoco/jacoco.xml
         continue-on-error: true
 
-  github-snapshot:
-    name: Update Snapshot Pre-release on GitHub
+  check-snapshot:
+    name: Check: main branch / SNAPSHOT
     needs: [report]
+    runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      (github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/v'))
+    steps:
+      - name: Confirm snapshot ref
+        run: echo "Confirmed on snapshot ref ${{ github.ref }}"
+
+  check-tag:
+    name: Check: v* tag
+    needs: [report]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Confirm tag ref
+        run: echo "Confirmed on tag ${{ github.ref }}"
+
+  github-snapshot:
+    name: Update Snapshot Pre-release on GitHub
+    needs: [check-snapshot]
+    if: needs.check-snapshot.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -132,10 +150,8 @@ jobs:
 
   publish-snapshot:
     name: Publish Snapshot to Central
-    needs: [github-snapshot]
-    if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+    needs: [github-snapshot, check-snapshot]
+    if: needs.check-snapshot.result == 'success'
     runs-on: ubuntu-latest
     environment: maven-central
     steps:
@@ -156,8 +172,8 @@ jobs:
 
   github-release:
     name: Attach Binaries to GitHub Release
-    needs: [report]
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [check-tag]
+    if: needs.check-tag.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -173,8 +189,8 @@ jobs:
 
   publish-release:
     name: Publish Release to Central
-    needs: [github-release]
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [github-release, check-tag]
+    if: needs.check-tag.result == 'success'
     runs-on: ubuntu-latest
     environment: maven-central
     steps:


### PR DESCRIPTION
## Summary

Refactored the GitHub Actions publish workflow to introduce explicit conditional check jobs that separate snapshot (main branch) and release (tag) build paths. This improves workflow clarity and reduces conditional logic duplication across dependent jobs.

## Key Changes

- **New `check-snapshot` job**: Validates that the workflow is running on the main branch or via manual dispatch (excluding tag refs). Replaces inline conditionals in downstream jobs.
- **New `check-tag` job**: Validates that the workflow is running on a `v*` tag ref. Replaces inline conditionals in downstream jobs.
- **Refactored `github-snapshot` job**: Now depends on `check-snapshot` instead of duplicating the conditional logic. Uses `needs.check-snapshot.result == 'success'` to gate execution.
- **Refactored `publish-snapshot` job**: Updated dependencies to include both `github-snapshot` and `check-snapshot`, with conditional gated by `check-snapshot` result.
- **Refactored `github-release` job**: Now depends on `check-tag` instead of inline `startsWith()` check. Uses `needs.check-tag.result == 'success'` to gate execution.
- **Refactored `publish-release` job**: Updated dependencies to include both `github-release` and `check-tag`, with conditional gated by `check-tag` result.
- **Dependency update**: Upgraded `softprops/action-gh-release` from `v2` to `v3`.

## Implementation Details

- Both check jobs include explicit `runs-on: ubuntu-latest` and simple confirmation steps for visibility.
- The `check-snapshot` job's condition now explicitly excludes tag refs: `(github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/v'))`.
- Downstream jobs now rely on job result checks (`needs.check-*.result == 'success'`) rather than duplicating complex conditional expressions, improving maintainability.

https://claude.ai/code/session_01RsBMg3pmHqUppCG6b88n2V