### PR TITLE
Add start gate (abort window) to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,21 @@ env:
   JAVA_VERSION: '21'
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Start gate — single cancellable abort window before the pipeline starts.
+  # The wait duration lives in the `startgate` GitHub Environment (Settings →
+  # Environments → startgate → Wait timer).
+  # ---------------------------------------------------------------------------
+  startgate:
+    name: Start gate (abort window)
+    runs-on: ubuntu-latest
+    environment: startgate
+    steps:
+      - run: echo "Start gate elapsed — proceeding with pipeline."
+
   build:
     name: Build
+    needs: startgate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Introduces a new `startgate` job to the publish workflow that acts as a cancellable abort window before the pipeline proceeds. This allows operators a configurable grace period to cancel the release if needed.

## Changes

- **Added `startgate` job** — A new gating job that runs before the `build` job with a configurable wait duration
  - Runs on `ubuntu-latest`
  - Uses the `startgate` GitHub Environment to manage the wait timer duration (configurable via Settings → Environments → startgate → Wait timer)
  - Includes documentation comments explaining the purpose and configuration location
  
- **Updated `build` job** — Added `needs: startgate` dependency to ensure the build only proceeds after the start gate completes

## Implementation Details

The start gate is implemented as a simple job that echoes a completion message. The actual abort window duration is controlled via GitHub's environment-level wait timer feature, which provides a native mechanism for operators to cancel the workflow during the grace period without requiring code changes.

https://claude.ai/code/session_01TGzxSDP2uzsGiJupDsNad1