### PR TITLE
ci: Replace CodeQL autobuild with explicit Maven compile

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,8 +46,8 @@ jobs:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+      - name: Build with Maven
+        run: mvn --batch-mode compile
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- Replace the generic CodeQL autobuild action with an explicit Maven compile step in the CodeQL workflow
- This ensures the build process uses the project's standard Maven configuration and respects all compiler settings (Error Prone, NullAway, JVM flags, etc.)
- Improves consistency between local builds and CI analysis

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01VDAzqXPDgejeWrWSEd1MZZ