### PR TITLE
Reorder GitHub release job to run after Maven publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -187,29 +187,14 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
 
-  github-release:
-    name: Attach Binaries to GitHub Release
+  publish-release:
+    name: Publish Release to Central
     needs: [check-tag]
     if: needs.check-tag.result == 'success'
     runs-on: ubuntu-latest
+    environment: maven-central
     permissions:
       contents: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: jars
-          path: release-assets/
-      - name: Upload release assets
-        uses: softprops/action-gh-release@v3
-        with:
-          files: release-assets/*
-
-  publish-release:
-    name: Publish Release to Central
-    needs: [github-release, check-tag]
-    if: needs.check-tag.result == 'success'
-    runs-on: ubuntu-latest
-    environment: maven-central
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -228,3 +213,29 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Collect signed artifacts
+        run: |
+          mkdir -p signed-release-assets
+          cp target/*.jar signed-release-assets/ 2>/dev/null || true
+          cp target/*.jar.asc signed-release-assets/ 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: signed-release-assets
+          path: signed-release-assets/
+
+  github-release:
+    name: Attach Binaries to GitHub Release
+    needs: [publish-release]
+    if: needs.publish-release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: signed-release-assets
+          path: release-assets/
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v3
+        with:
+          files: release-assets/*


### PR DESCRIPTION
## Summary

- Moved the `github-release` job to execute **after** `publish-release` instead of in parallel with it
- The `github-release` job now downloads signed artifacts (JARs and ASC files) produced by the Maven publish step, rather than unsigned JARs from the build step
- This ensures GitHub releases contain cryptographically signed binaries matching those published to Maven Central

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01BBhFKwrqBMNHGhLgcSznpu