### PR TITLE
Pin bitcoinj-core transitive dependencies to secure versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,7 @@ GPU code is bound through JOCL (`jocl` 2.0.6). `OpenCLBuilder` constructs the pl
 | Dependency | Version | Purpose |
 |---|---|---|
 | `bitcoinj-core` | 0.17.1 | Bitcoin crypto, address derivation |
+| `bcprov-jdk15to18` | 1.84 | Bouncy Castle crypto provider (transitive of bitcoinj; pinned to fix GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) |
 | `lmdbjava` | 0.9.3 | LMDB database bindings |
 | `jocl` | 2.0.6 | Java OpenCL bindings |
 | `jackson-databind` | 2.21.3 | JSON config parsing |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,10 @@ GPU code is bound through JOCL (`jocl` 2.0.6). `OpenCLBuilder` constructs the pl
 | Dependency | Version | Purpose |
 |---|---|---|
 | `bitcoinj-core` | 0.17.1 | Bitcoin crypto, address derivation |
-| `bcprov-jdk15to18` | 1.84 | Bouncy Castle crypto provider (transitive of bitcoinj; pinned to fix GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) |
+| `bcprov-jdk15to18` | 1.84 | Bouncy Castle crypto provider (bitcoinj transitive; pinned to fix GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) |
+| `protobuf-javalite` | 4.34.1 | Protocol Buffers (bitcoinj transitive; pinned to latest) |
+| `jsr305` | 3.0.2 | Findbugs nullability annotations (bitcoinj transitive, runtime) |
+| `jcip-annotations` | 1.0 | JCIP concurrency annotations (bitcoinj transitive, runtime) |
 | `lmdbjava` | 0.9.3 | LMDB database bindings |
 | `jocl` | 2.0.6 | Java OpenCL bindings |
 | `jackson-databind` | 2.21.3 | JSON config parsing |

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,11 @@ SPDX-License-Identifier: Apache-2.0
             <version>0.17.1</version>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15to18</artifactId>
+            <version>1.84</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.6.0-jre</version>

--- a/pom.xml
+++ b/pom.xml
@@ -335,10 +335,31 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>bitcoinj-core</artifactId>
             <version>0.17.1</version>
         </dependency>
+        <!-- Required by bitcoinj-core (transitive). Pinned here to keep on the latest secure version. -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15to18</artifactId>
             <version>1.84</version>
+        </dependency>
+        <!-- Required by bitcoinj-core (transitive). Pinned here to keep on the latest secure version. -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-javalite</artifactId>
+            <version>4.34.1</version>
+        </dependency>
+        <!-- Required by bitcoinj-core (transitive, runtime). Pinned here to keep on the latest version. -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Required by bitcoinj-core (transitive, runtime). Pinned here to keep on the latest version. -->
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Summary

- Explicitly pin four transitive dependencies of `bitcoinj-core` to their latest secure versions in `pom.xml`
- Update `CLAUDE.md` to document these pinned dependencies and their purposes
- Addresses security vulnerabilities in Bouncy Castle (GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) and ensures latest stable versions of Protocol Buffers and annotation libraries

## Test plan

- CI is green on this branch
- No code changes; dependency pinning only

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] Security-sensitive changes: pinning Bouncy Castle to fix known CVEs (GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3)

https://claude.ai/code/session_01K5kACHReQfdH2F3Mrwecju