### PR TITLE
Downgrade jacoco-maven-plugin from 0.8.15 to 0.8.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                   <groupId>org.jacoco</groupId>
                   <artifactId>jacoco-maven-plugin</artifactId>
-                  <version>0.8.15</version>
+                  <version>0.8.14</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- Downgrade JaCoCo Maven plugin from version 0.8.15 to 0.8.14
- This is a minor version adjustment in the code coverage tooling

## Test plan

- [x] CI is green on this branch
- No functional code changes; coverage reporting tool version adjustment only

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_019ChutLUhAfj7eoC7hESTTK