### PR TITLE
Reorder snapshot publishing workflow and update action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,17 +139,51 @@ jobs:
       - name: Confirm tag ref
         run: echo "Confirmed on tag ${{ github.ref }}"
 
-  github-snapshot:
-    name: Update Snapshot Pre-release on GitHub
+  publish-snapshot:
+    name: Publish Snapshot to Central
     needs: [check-snapshot]
     if: needs.check-snapshot.result == 'success'
+    runs-on: ubuntu-latest
+    environment: maven-central
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+          cache: maven
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Deploy snapshot
+        run: mvn --batch-mode -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true -P release deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Collect signed artifacts
+        run: |
+          mkdir -p signed-snapshot-assets
+          cp target/*.jar signed-snapshot-assets/ 2>/dev/null || true
+          cp target/*.jar.asc signed-snapshot-assets/ 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: signed-snapshot-assets
+          path: signed-snapshot-assets/
+
+  github-snapshot:
+    name: Update Snapshot Pre-release on GitHub
+    needs: [publish-snapshot]
+    if: needs.publish-snapshot.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: jars
+          name: signed-snapshot-assets
           path: snapshot-assets/
       - name: Update snapshot pre-release
         env:
@@ -164,28 +198,6 @@ jobs:
           gh release upload snapshot snapshot-assets/* \
             --repo ${{ github.repository }} \
             --clobber
-
-  publish-snapshot:
-    name: Publish Snapshot to Central
-    needs: [github-snapshot, check-snapshot]
-    if: needs.check-snapshot.result == 'success'
-    runs-on: ubuntu-latest
-    environment: maven-central
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: temurin
-          cache: maven
-          server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Deploy snapshot
-        run: mvn --batch-mode -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true deploy -DskipTests
-        env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
 
   publish-release:
     name: Publish Release to Central

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: fsfe/reuse-action@v5
+      - uses: fsfe/reuse-action@v6

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- **Reorder snapshot publishing jobs**: Move `publish-snapshot` before `github-snapshot` so artifacts are deployed to Maven Central before updating the GitHub pre-release. This ensures the GitHub release references artifacts that are already available in the repository.
- **Add GPG signing to snapshot deployment**: Include GPG private key configuration and signing passphrase in the Maven deployment step for snapshot artifacts.
- **Collect and upload signed artifacts**: Add a step to gather signed JAR files and their `.asc` signatures, uploading them as build artifacts for the subsequent GitHub release job to consume.
- **Update workflow action versions**: Bump `fsfe/reuse-action` from v5 to v6 and `github/codeql-action/upload-sarif` from v3 to v4 for security and feature updates.

## Test plan

- CI is green on this branch
- Snapshot deployment workflow executes in correct order with proper artifact handoff between jobs

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01SxxLmcu9vgaPjKnSPeTjEx