### PR TITLE
Fix InterruptedException handling in KeyProducerJavaSocketTest

### DIFF
--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaSocketTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaSocketTest.java
@@ -617,6 +617,8 @@ public class KeyProducerJavaSocketTest {
                 Socket client = serverSocket.accept();
                 // Do nothing, just hang the connection
                 Thread.sleep(Long.MAX_VALUE);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             } catch (Exception ignored) {}
         }).start();
         return serverSocket;


### PR DESCRIPTION
## Summary

- Added proper handling for `InterruptedException` in the `hangServer()` helper method of `KeyProducerJavaSocketTest`
- When the thread is interrupted, the interrupt status is now restored via `Thread.currentThread().interrupt()` to preserve the interrupted state for upstream handlers
- This follows Java best practices for exception handling in threads and prevents silent suppression of interrupts

## Test plan

- [x] Affected unit tests pass locally (`KeyProducerJavaSocketTest`)
- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01GvaEjG16YNNtRv9HNoc6yZ