### PR TITLE
Handle full queue gracefully in shutdown signal

### DIFF
--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/AbstractKeyProducerQueueBuffered.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/AbstractKeyProducerQueueBuffered.java
@@ -130,7 +130,9 @@ public abstract class AbstractKeyProducerQueueBuffered<T extends CKeyProducerJav
      */
     protected void signalShutdown() {
         shouldStop = true;
-        secretQueue.offer(SHUTDOWN_SENTINEL);
+        if (!secretQueue.offer(SHUTDOWN_SENTINEL)) {
+            logger.trace("Shutdown sentinel not enqueued (queue full); consumer will observe shouldStop after drain.");
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Added defensive check in `signalShutdown()` to handle the case where the shutdown sentinel cannot be enqueued due to a full queue
- Logs a trace message when the sentinel is not enqueued, noting that the consumer will observe the `shouldStop` flag after draining the queue
- Improves robustness of the shutdown sequence in bounded queue scenarios

## Test plan

- Existing unit tests for `AbstractKeyProducerQueueBuffered` and shutdown behavior pass
- CI is green on this branch
- Change is defensive and non-breaking; no new test coverage required for this edge case

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_014nu1RR3Apj4TpB39juqKAZ