### PR TITLE
Add JUnit 5 support alongside existing JUnit 4 tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ BitcoinAddressFinder/
 │   │       └── simplelogger.properties
 │   └── test/
 │       └── java/net/ladenthin/bitcoinaddressfinder/
-│           └── *.java                # JUnit 4 tests
+│           └── *.java                # JUnit 4 tests (run via JUnit 5 vintage engine)
 ├── examples/                         # Sample JSON configs and run scripts
 │   ├── config_*.json
 │   ├── run_*.bat
@@ -217,7 +217,8 @@ See `examples/config_*.json` for all configuration variants.
 
 ### Frameworks
 
-- **JUnit 4** (4.13.2) — test runner
+- **JUnit 4** (4.13.2) — existing tests (run unchanged via JUnit 5 vintage engine)
+- **JUnit 5** (5.12.0) — `junit-vintage-engine` runs all JUnit 4 tests on the JUnit Platform; `junit-jupiter` available for new tests
 - **Hamcrest** (3.0) — matchers
 - **Mockito** (5.22.0) — mocking
 - **junit4-dataprovider** (2.12) — data-driven tests
@@ -336,7 +337,9 @@ GPU code is bound through JOCL (`jocl` 2.0.6). `OpenCLBuilder` constructs the pl
 | `logback-classic` | 1.5.32 | SLF4J implementation |
 
 Test-only:
-| `junit` | 4.13.2 | Test runner |
+| `junit` | 4.13.2 | Existing JUnit 4 tests (compile + run via vintage engine) |
+| `junit-vintage-engine` | 5.12.0 | Runs JUnit 4 tests on JUnit Platform |
+| `junit-jupiter` | 5.12.0 | JUnit 5 support for new tests |
 | `hamcrest` | 3.0 | Assertion matchers |
 | `mockito-core` | 5.23.0 | Mocking |
 | `junit4-dataprovider` | 2.12 | Data-driven tests |

--- a/pom.xml
+++ b/pom.xml
@@ -420,6 +420,18 @@ SPDX-License-Identifier: Apache-2.0
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>3.0</version>


### PR DESCRIPTION
## Summary

- Add `junit-vintage-engine` (5.12.0) to run existing JUnit 4 tests on the JUnit Platform
- Add `junit-jupiter` (5.12.0) to enable writing new tests with JUnit 5
- Update documentation to reflect the dual test framework setup

This change allows the project to gradually migrate to JUnit 5 while maintaining full compatibility with the existing JUnit 4 test suite. All JUnit 4 tests will run unchanged via the vintage engine.

## Test plan

- [x] Existing JUnit 4 tests pass locally via JUnit 5 vintage engine
- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01H8G3USmHYGix3ZEq6ue3pn