### PR TITLE
Migrate test framework from JUnit 4 + DataProvider to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,18 +414,6 @@ SPDX-License-Identifier: Apache-2.0
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.12.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.12.0</version>
@@ -441,12 +429,6 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>5.23.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.tngtech.junit.dataprovider</groupId>
-            <artifactId>junit4-dataprovider</artifactId>
-            <version>2.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AbstractPlaintextFileTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AbstractPlaintextFileTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import org.lmdbjava.LmdbException;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -102,7 +103,7 @@ public class AbstractPlaintextFileTest {
         ThrowingPlaintextFile sut = new ThrowingPlaintextFile(file, readStatistic, mockLmdbException);
 
         // act
-        sut.readFile();
+        assertThrows(LmdbException.class, () -> sut.readFile());
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AbstractPlaintextFileTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AbstractPlaintextFileTest.java
@@ -10,9 +10,9 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import org.jspecify.annotations.NonNull;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
 import org.lmdbjava.LmdbException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -24,14 +24,14 @@ import static org.mockito.Mockito.mock;
 
 public class AbstractPlaintextFileTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
 
     // <editor-fold defaultstate="collapsed" desc="readFile">
     @Test
     public void readFile_emptyFile_processLineNeverCalled() throws IOException {
         // arrange
-        File emptyFile = folder.newFile("empty.txt");
+        File emptyFile = Files.createFile(folder.resolve("empty.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         RecordingPlaintextFile sut = new RecordingPlaintextFile(emptyFile, readStatistic);
 
@@ -45,7 +45,7 @@ public class AbstractPlaintextFileTest {
     @Test
     public void readFile_singleLine_processLineCalledOnceWithCorrectContent() throws IOException {
         // arrange
-        File file = folder.newFile("single.txt");
+        File file = Files.createFile(folder.resolve("single.txt")).toFile();
         Files.writeString(file.toPath(), "hello world");
         ReadStatistic readStatistic = new ReadStatistic();
         RecordingPlaintextFile sut = new RecordingPlaintextFile(file, readStatistic);
@@ -61,7 +61,7 @@ public class AbstractPlaintextFileTest {
     @Test
     public void readFile_multipleLines_processLineCalledForEachLine() throws IOException {
         // arrange
-        File file = folder.newFile("multi.txt");
+        File file = Files.createFile(folder.resolve("multi.txt")).toFile();
         Files.writeString(file.toPath(), "line1\nline2\nline3");
         ReadStatistic readStatistic = new ReadStatistic();
         RecordingPlaintextFile sut = new RecordingPlaintextFile(file, readStatistic);
@@ -79,7 +79,7 @@ public class AbstractPlaintextFileTest {
     @Test
     public void readFile_processLineThrowsRuntimeException_errorAddedToReadStatistic() throws IOException {
         // arrange
-        File file = folder.newFile("error.txt");
+        File file = Files.createFile(folder.resolve("error.txt")).toFile();
         Files.writeString(file.toPath(), "bad line");
         ReadStatistic readStatistic = new ReadStatistic();
         ThrowingPlaintextFile sut = new ThrowingPlaintextFile(file, readStatistic, new RuntimeException("parse error"));
@@ -92,10 +92,10 @@ public class AbstractPlaintextFileTest {
         assertThat(readStatistic.errors.get(0), is(equalTo("bad line")));
     }
 
-    @Test(expected = LmdbException.class)
+    @org.junit.jupiter.api.Test
     public void readFile_processLineThrowsLmdbException_exceptionPropagated() throws IOException {
         // arrange
-        File file = folder.newFile("lmdb.txt");
+        File file = Files.createFile(folder.resolve("lmdb.txt")).toFile();
         Files.writeString(file.toPath(), "some line");
         ReadStatistic readStatistic = new ReadStatistic();
         LmdbException mockLmdbException = mock(LmdbException.class);
@@ -108,7 +108,7 @@ public class AbstractPlaintextFileTest {
     @Test
     public void readFile_multipleExceptionLines_allErrorsAddedToReadStatistic() throws IOException {
         // arrange
-        File file = folder.newFile("multierror.txt");
+        File file = Files.createFile(folder.resolve("multierror.txt")).toFile();
         Files.writeString(file.toPath(), "bad1\nbad2\nbad3");
         ReadStatistic readStatistic = new ReadStatistic();
         ThrowingPlaintextFile sut = new ThrowingPlaintextFile(file, readStatistic, new RuntimeException("error"));
@@ -125,7 +125,7 @@ public class AbstractPlaintextFileTest {
     @Test
     public void interrupt_calledBeforeReadFile_readFileProcessesNoLines() throws IOException {
         // arrange
-        File file = folder.newFile("lines.txt");
+        File file = Files.createFile(folder.resolve("lines.txt")).toFile();
         Files.writeString(file.toPath(), "line1\nline2\nline3");
         ReadStatistic readStatistic = new ReadStatistic();
         RecordingPlaintextFile sut = new RecordingPlaintextFile(file, readStatistic);
@@ -143,7 +143,7 @@ public class AbstractPlaintextFileTest {
     @Test
     public void readFile_singleLineFile_fileProgressIsSetToNonZero() throws IOException {
         // arrange
-        File file = folder.newFile("progress.txt");
+        File file = Files.createFile(folder.resolve("progress.txt")).toFile();
         Files.writeString(file.toPath(), "content");
         ReadStatistic readStatistic = new ReadStatistic();
         RecordingPlaintextFile sut = new RecordingPlaintextFile(file, readStatistic);
@@ -158,7 +158,7 @@ public class AbstractPlaintextFileTest {
     @Test
     public void readFile_fileWithContent_fileProgressReachesHundredPercent() throws IOException {
         // arrange
-        File file = folder.newFile("full.txt");
+        File file = Files.createFile(folder.resolve("full.txt")).toFile();
         Files.writeString(file.toPath(), "line1\nline2");
         ReadStatistic readStatistic = new ReadStatistic();
         RecordingPlaintextFile sut = new RecordingPlaintextFile(file, readStatistic);
@@ -175,7 +175,7 @@ public class AbstractPlaintextFileTest {
     @Test
     public void readFile_asciiContent_contentPreserved() throws IOException {
         // arrange
-        File file = folder.newFile("ascii.txt");
+        File file = Files.createFile(folder.resolve("ascii.txt")).toFile();
         Files.write(file.toPath(), "simple ascii".getBytes(StandardCharsets.ISO_8859_1));
         ReadStatistic readStatistic = new ReadStatistic();
         RecordingPlaintextFile sut = new RecordingPlaintextFile(file, readStatistic);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AbstractProducerTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AbstractProducerTest.java
@@ -18,6 +18,7 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.bitcoinj.base.Network;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import org.mockito.ArgumentCaptor;
@@ -229,7 +230,7 @@ public class AbstractProducerTest {
         AbstractProducerTestImpl abstractProducerTestImpl = new AbstractProducerTestImpl(cProducer, mockConsumer, keyUtility, mockKeyProducer, bitHelper);
 
         // act
-        abstractProducerTestImpl.run();
+        assertThrows(IllegalStateException.class, () -> abstractProducerTestImpl.run());
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AbstractProducerTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AbstractProducerTest.java
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -20,7 +20,6 @@ import org.bitcoinj.base.Network;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -28,11 +27,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.slf4j.Logger;
 
-@RunWith(DataProviderRunner.class)
 public class AbstractProducerTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
 
     private final Network network = new NetworkParameterFactory().getNetwork();
     private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
@@ -65,8 +63,8 @@ public class AbstractProducerTest {
     // </editor-fold>
     
     // <editor-fold defaultstate="collapsed" desc="createSecretBase">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_CREATE_SECRET_BASE_LOGGED, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_CREATE_SECRET_BASE_LOGGED)
     public void createSecretBase_secretGiven_bitsKilledAndLogged(String givenSecret, int batchSizeInBits, String expectedSecretBase, String logInfo0, String logTrace0, String logTrace1, String logTrace2, String logTrace3, String logTrace4) throws IOException, InterruptedException, DecoderException {
         // arrange
         CProducer cProducer = new CProducer();
@@ -221,7 +219,7 @@ public class AbstractProducerTest {
     }
 
     // <editor-fold defaultstate="collapsed" desc="run">
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void run_notInitialized_illegalStateExceptionThrown() throws IOException, InterruptedException {
         // arrange
         CProducer cProducer = new CProducer();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressFileTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressFileTest.java
@@ -15,9 +15,10 @@ import org.bitcoinj.base.Network;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import java.nio.file.Files;
 
 /**
  * Unit tests for {@link AddressFile}.
@@ -26,14 +27,14 @@ public class AddressFileTest {
 
     private final Network network = new NetworkParameterFactory().getNetwork();
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
 
     // <editor-fold defaultstate="collapsed" desc="processLine">
     @Test
     public void processLine_validBitcoinAddress_addressConsumerCalledOnce() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<AddressToCoin> addressCapture = new ArrayList<>();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressCapture::add, line -> {});
@@ -49,7 +50,7 @@ public class AddressFileTest {
     @Test
     public void processLine_validBitcoinAddress_readStatisticSuccessfulIncrements() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressToCoin -> {}, line -> {});
 
@@ -63,7 +64,7 @@ public class AddressFileTest {
     @Test
     public void processLine_validSegwitAddress_addressConsumerCalledOnce() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<AddressToCoin> addressCapture = new ArrayList<>();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressCapture::add, line -> {});
@@ -79,7 +80,7 @@ public class AddressFileTest {
     @Test
     public void processLine_emptyLine_unsupportedConsumerReceivesEmptyString() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<String> unsupportedCapture = new ArrayList<>();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressToCoin -> {}, unsupportedCapture::add);
@@ -95,7 +96,7 @@ public class AddressFileTest {
     @Test
     public void processLine_emptyLine_readStatisticUnsupportedIncrements() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressToCoin -> {}, line -> {});
 
@@ -109,7 +110,7 @@ public class AddressFileTest {
     @Test
     public void processLine_commentLine_unsupportedConsumerReceivesCommentString() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<String> unsupportedCapture = new ArrayList<>();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressToCoin -> {}, unsupportedCapture::add);
@@ -125,7 +126,7 @@ public class AddressFileTest {
     @Test
     public void processLine_addressHeaderLine_unsupportedConsumerReceivesHeaderString() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<String> unsupportedCapture = new ArrayList<>();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressToCoin -> {}, unsupportedCapture::add);
@@ -141,7 +142,7 @@ public class AddressFileTest {
     @Test
     public void processLine_calledTwiceWithValidAddresses_successfulCountIsTwo() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<AddressToCoin> addressCapture = new ArrayList<>();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressCapture::add, line -> {});
@@ -162,7 +163,7 @@ public class AddressFileTest {
     @Test
     public void readFile_fileWithOneBitcoinAddress_addressConsumerCalledOnce() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         FileUtils.writeStringToFile(file, P2PKH.Bitcoin.getPublicAddress() + "\n", StandardCharsets.UTF_8.name());
         ReadStatistic readStatistic = new ReadStatistic();
         List<AddressToCoin> addressCapture = new ArrayList<>();
@@ -180,7 +181,7 @@ public class AddressFileTest {
     @Test
     public void readFile_emptyFile_consumersNeverCalled() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         AddressFile addressFile = new AddressFile(file, readStatistic, network, addressToCoin -> {}, line -> {});
 
@@ -195,7 +196,7 @@ public class AddressFileTest {
     @Test
     public void readFile_mixedValidAndCommentLines_correctCountsUpdated() throws IOException {
         // arrange
-        File file = folder.newFile("addresses.txt");
+        File file = Files.createFile(folder.resolve("addresses.txt")).toFile();
         String content = P2PKH.Bitcoin.getPublicAddress() + "\n"
                 + "# comment line\n"
                 + P2PKH.Litecoin.getPublicAddress() + "\n";

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressFilesToLMDBTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressFilesToLMDBTest.java
@@ -3,11 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import net.ladenthin.bitcoinaddressfinder.configuration.CAddressFilesToLMDB;
 import net.ladenthin.bitcoinaddressfinder.configuration.CLMDBConfigurationWrite;
 import net.ladenthin.bitcoinaddressfinder.persistence.Persistence;
@@ -17,41 +16,41 @@ import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesFiles;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.enums.P2PKH;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.LegacyAddress;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Direct unit tests for {@link AddressFilesToLMDB}.
  *
  * Tests the run() and interrupt() methods with parameterized test data from existing test providers.
  */
-@RunWith(DataProviderRunner.class)
 public class AddressFilesToLMDBTest extends LMDBBase {
 
-    @Before
+    @BeforeEach
     public void init() throws IOException {
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void addressFilesToLMDB_addressFileDoesNotExists_throwsIllegalArgumentException() throws IOException {
         // arrange, act
         CAddressFilesToLMDB addressFilesToLMDBConfigurationWrite = new CAddressFilesToLMDB();
         
         addressFilesToLMDBConfigurationWrite.addressesFiles.add("thisFileDoesNotExists.txt");
         addressFilesToLMDBConfigurationWrite.lmdbConfigurationWrite = new CLMDBConfigurationWrite();
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
         String lmdbFolderPath = lmdbFolder.getAbsolutePath();
         addressFilesToLMDBConfigurationWrite.lmdbConfigurationWrite.lmdbDirectory = lmdbFolderPath;
         AddressFilesToLMDB addressFilesToLMDB = new AddressFilesToLMDB(addressFilesToLMDBConfigurationWrite);
         addressFilesToLMDB.run();
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT)
     public void addressFilesToLMDB_createLMDB_containingTestAddressesHashesWithCorrectAmount(boolean compressed, boolean useStaticAmount) throws Exception {
         // arrange, act
         AddressesFiles addressesFiles = new TestAddressesFiles(compressed);
@@ -76,8 +75,8 @@ public class AddressFilesToLMDBTest extends LMDBBase {
         }
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_STATIC_AMOUNT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_STATIC_AMOUNT)
     public void addressFilesToLMDB_createLMDBWithStaticAddresses_containingStaticHashes(boolean useStaticAmount) throws Exception {
         // arrange, act
         StaticAddressesFiles staticAddressesFiles = new StaticAddressesFiles();
@@ -94,8 +93,8 @@ public class AddressFilesToLMDBTest extends LMDBBase {
         }
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BLOOM_FILTER_ENABLED, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BLOOM_FILTER_ENABLED)
     public void containsAddress_behavesCorrectly_withOrWithoutBloomFilter(boolean useBloomFilter) throws Exception {
         AddressesFiles addressesFiles = new TestAddressesFiles(true);
 
@@ -135,8 +134,8 @@ public class AddressFilesToLMDBTest extends LMDBBase {
         }
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BLOOM_FILTER_ENABLED, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BLOOM_FILTER_ENABLED)
     public void containsAddress_returnsFalseForUnknownAddress(boolean useBloomFilter) throws Exception {
         AddressesFiles addressesFiles = new TestAddressesFiles(true);
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressFilesToLMDBTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressFilesToLMDBTest.java
@@ -18,6 +18,7 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.LegacyAddress;
 import org.junit.jupiter.api.BeforeEach;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public class AddressFilesToLMDBTest extends LMDBBase {
         String lmdbFolderPath = lmdbFolder.getAbsolutePath();
         addressFilesToLMDBConfigurationWrite.lmdbConfigurationWrite.lmdbDirectory = lmdbFolderPath;
         AddressFilesToLMDB addressFilesToLMDB = new AddressFilesToLMDB(addressFilesToLMDBConfigurationWrite);
-        addressFilesToLMDB.run();
+        assertThrows(IllegalArgumentException.class, () -> addressFilesToLMDB.run());
     }
 
     @ParameterizedTest

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressFormatNotAcceptedExceptionTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressFormatNotAcceptedExceptionTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link AddressFormatNotAcceptedException}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressToCoinTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressToCoinTest.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -14,6 +14,7 @@ import org.bitcoinj.crypto.ECKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AddressToCoinTest {
 
@@ -40,12 +41,12 @@ public class AddressToCoinTest {
         assertThat(addressToCoinCompressed.toString(), is(equalTo("AddressToCoin{hash160=6970dea35c48e1c78e931117fab833354cddf9b4, coin=100000000, type=P2PKH_OR_P2SH}")));
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createAddressToCoin_invalidAddressSizeGiven_ToStringAndEqualsAndHashCode() throws IOException, InterruptedException {
         // arrange
         ByteBuffer byteBuffer32bytes = keyUtility.byteBufferUtility().getByteBufferFromHex("0000000000000000000000000000000000000000000000000000000000000000");
         // act
-        new AddressToCoin(byteBuffer32bytes, Coin.COIN, AddressType.P2PKH_OR_P2SH);
+        assertThrows(IllegalArgumentException.class, () -> new AddressToCoin(byteBuffer32bytes, Coin.COIN, AddressType.P2PKH_OR_P2SH));
         // assert
     }
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressTxtLineTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressTxtLineTest.java
@@ -3,14 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.apache.commons.codec.DecoderException;
 import org.bitcoinj.base.Base58;
 import org.bitcoinj.base.Coin;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.StaticKey;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddresses42;
@@ -21,9 +20,8 @@ import net.ladenthin.bitcoinaddressfinder.staticaddresses.enums.StaticUnsupporte
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(DataProviderRunner.class)
 public class AddressTxtLineTest {
 
     private final TestAddresses42 testAddresses = new TestAddresses42(0, false);
@@ -98,8 +96,8 @@ public class AddressTxtLineTest {
         assertThatDefaultCoinIsSet(addressToCoin);
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR)
     public void fromLine_uncompressedBitcoinAddressGivenWithValidAmount_returnHash160AndSpecifiedCoin(String addressSeparator) throws AddressFormatNotAcceptedException {
         // arrange
         long coin = 123987L;
@@ -115,8 +113,8 @@ public class AddressTxtLineTest {
         assertThat(addressToCoin.coin(), is(equalTo(Coin.valueOf(coin))));
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR)
     public void fromLine_uncompressedBitcoinAddressGivenWithInvalidAmount_returnHash160AndDefaultCoin(String addressSeparator) throws AddressFormatNotAcceptedException {
         // act
         AddressToCoin addressToCoin = new AddressTxtLine().fromLine(staticKey.publicKeyUncompressed + addressSeparator + "XYZ", keyUtility);
@@ -141,8 +139,8 @@ public class AddressTxtLineTest {
         }
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_STATIC_UNSUPPORTED_ADDRESSES, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_STATIC_UNSUPPORTED_ADDRESSES)
     public void fromLine_staticUnsupportedAddress_throwsAddressFormatNotAcceptedException(StaticUnsupportedAddress address) {
         // act
         try {
@@ -155,8 +153,8 @@ public class AddressTxtLineTest {
     }
 
     // <editor-fold defaultstate="collapsed" desc="staticaddresses.enums">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_STATIC_P2PKH_ADDRESSES, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_STATIC_P2PKH_ADDRESSES)
     public void fromLine_staticP2PKHAddress_returnPublicKeyHash(P2PKH address) throws AddressFormatNotAcceptedException {
         // act
         AddressToCoin addressToCoin = new AddressTxtLine().fromLine(address.getPublicAddress(), keyUtility);
@@ -171,8 +169,8 @@ public class AddressTxtLineTest {
         assertThatDefaultCoinIsSet(addressToCoin);
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_STATIC_P2SH_ADDRESSES, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_STATIC_P2SH_ADDRESSES)
     public void fromLine_staticP2SHAddress_returnScriptHash(P2SH address) throws AddressFormatNotAcceptedException {
         // act
         AddressToCoin addressToCoin = new AddressTxtLine().fromLine(address.getPublicAddress(), keyUtility);
@@ -187,8 +185,8 @@ public class AddressTxtLineTest {
         assertThatDefaultCoinIsSet(addressToCoin);
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_STATIC_P2WPKH_ADDRESSES, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_STATIC_P2WPKH_ADDRESSES)
     public void fromLine_staticP2WPKHAddress_returnWitnessProgram(P2WPKH address) throws AddressFormatNotAcceptedException {
         // act
         AddressToCoin addressToCoin = new AddressTxtLine().fromLine(address.getPublicAddress(), keyUtility);
@@ -203,8 +201,8 @@ public class AddressTxtLineTest {
         assertThatDefaultCoinIsSet(addressToCoin);
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_INVALID_P2WPKH_ADDRESSES_VALID_BASE58, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_INVALID_P2WPKH_ADDRESSES_VALID_BASE58)
     public void fromLine_invalidP2WPKHAddressWithValidBase58Given_parseAnyway(String base58, String hash) throws AddressFormatNotAcceptedException {
         // act
         AddressToCoin addressToCoin = new AddressTxtLine().fromLine(base58, keyUtility);
@@ -218,8 +216,8 @@ public class AddressTxtLineTest {
     }
     // </editor-fold>
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_INVALID_BECH32_WITNESS_VERSION_2, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_INVALID_BECH32_WITNESS_VERSION_2)
     public void fromLine_invalidBech32WitnessVersion2_throwsAddressFormatNotAcceptedException(String base58) {
         // act
         try {
@@ -231,8 +229,8 @@ public class AddressTxtLineTest {
         }
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_INVALID_BASE58, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_INVALID_BASE58)
     public void fromLine_invalidP2WPKHAddressWithInvalidBase58Given_throwsAddressFormatNotAcceptedException(String base58) {
         // act
         try {
@@ -244,8 +242,8 @@ public class AddressTxtLineTest {
         }
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_CHECKSUM_INVALID, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_CHECKSUM_INVALID)
     public void fromLine_bitcoinCashAddressChecksumInvalid_parseAnyway(String base58, String expectedHash160) throws AddressFormatNotAcceptedException {
         // act
         AddressToCoin addressToCoin = new AddressTxtLine().fromLine(base58, keyUtility);
@@ -258,8 +256,8 @@ public class AddressTxtLineTest {
         assertThat(hash160AsHex, is(equalTo(expectedHash160)));
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_INTERNAL_PURPOSE, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_INTERNAL_PURPOSE)
     public void fromLine_bitcoinCashAddressInternalPurpose_throwsAddressFormatNotAcceptedException(String base58) {
         // act
         try {
@@ -271,8 +269,8 @@ public class AddressTxtLineTest {
         }
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BITCOIN_ADDRESSES_CORRECT_BASE_58, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BITCOIN_ADDRESSES_CORRECT_BASE_58)
     public void fromLine_bitcoinAddressChecksumInvalid_parseAnyway(String base58, String expectedHash160) throws AddressFormatNotAcceptedException {
         // act
         AddressToCoin addressToCoin = new AddressTxtLine().fromLine(base58, keyUtility);
@@ -285,8 +283,8 @@ public class AddressTxtLineTest {
         assertThat(hash160AsHex, is(equalTo(expectedHash160)));
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_CORRECT_BASE_58, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_CORRECT_BASE_58)
     public void fromLine_correctBase58_hash160equals(String base58, String expectedHash160) throws AddressFormatNotAcceptedException, DecoderException {
         // act
         AddressToCoin addressToCoin = new AddressTxtLine().fromLine(base58, keyUtility);
@@ -301,8 +299,8 @@ public class AddressTxtLineTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="parseBase58Address">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_SRC_POS, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_SRC_POS)
     public void parseBase58Address_correctBase58UseHigherSrcPos_copiedPartial(int versionBytes) throws DecoderException {
         // arrange
         String encoded = Base58.encode(Hex.decode("1f" + "ffffffffffffffffffffffffffffffffffffffff"));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressTypeTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/AddressTypeTest.java
@@ -7,7 +7,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link AddressType}.
@@ -70,10 +71,10 @@ public class AddressTypeTest {
         assertThat(actual, is(equalTo(AddressType.P2WPKH)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void valueOf_unknownConstantName_throwsIllegalArgumentException() {
         // act
-        AddressType.valueOf("UNKNOWN_TYPE");
+        assertThrows(IllegalArgumentException.class, () -> AddressType.valueOf("UNKNOWN_TYPE"));
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39DataProvider.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39DataProvider.java
@@ -5,7 +5,6 @@ package net.ladenthin.bitcoinaddressfinder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tngtech.java.junit.dataprovider.DataProvider;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.Map;
@@ -15,12 +14,11 @@ public class BIP39DataProvider {
     /**
      * For {@link net.ladenthin.bitcoinaddressfinder.BIP39KeyProducerTest}.
      */
-    public final static String DATA_PROVIDER_BIP39_TEST_VECTORS = "bip39TestVectors";
+    public final static String DATA_PROVIDER_BIP39_TEST_VECTORS = "net.ladenthin.bitcoinaddressfinder.BIP39DataProvider#bip39TestVectors";
     
     public final static String FILENAME = "vectors.json";
     public final static String PASSPHRASE = "TREZOR";
 
-    @DataProvider
     /**
      * from https://github.com/trezor/python-mnemonic/blob/master/vectors.json
      */

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39DataProvider.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39DataProvider.java
@@ -11,10 +11,13 @@ import java.util.Map;
 
 public class BIP39DataProvider {
 
+    /** Must remain a string literal — annotation values require compile-time constants. */
+    private static final String CLASS_NAME = "net.ladenthin.bitcoinaddressfinder.BIP39DataProvider";
+
     /**
      * For {@link net.ladenthin.bitcoinaddressfinder.BIP39KeyProducerTest}.
      */
-    public final static String DATA_PROVIDER_BIP39_TEST_VECTORS = "net.ladenthin.bitcoinaddressfinder.BIP39DataProvider#bip39TestVectors";
+    public final static String DATA_PROVIDER_BIP39_TEST_VECTORS = CLASS_NAME + "#bip39TestVectors";
     
     public final static String FILENAME = "vectors.json";
     public final static String PASSPHRASE = "TREZOR";

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39KeyProducerTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39KeyProducerTest.java
@@ -4,8 +4,6 @@
 package net.ladenthin.bitcoinaddressfinder;
 
 import net.ladenthin.bitcoinaddressfinder.keyproducer.NoMoreSecretsAvailableException;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.time.Instant;
 import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -15,17 +13,17 @@ import java.text.Normalizer.Form;
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaBip39;
 import static org.hamcrest.Matchers.*;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.HDKeyDerivation;
 import org.bitcoinj.crypto.MnemonicCode;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.wallet.DeterministicSeed;
-import static org.junit.Assert.fail;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(DataProviderRunner.class)
 public class BIP39KeyProducerTest {
 
     @Test
@@ -111,8 +109,8 @@ public class BIP39KeyProducerTest {
         assertThat(masterKey.serializePrivB58(MainNetParams.get().network()), is(expectedXprv));
     }
     
-    @Test
-    @UseDataProvider(value = BIP39DataProvider.DATA_PROVIDER_BIP39_TEST_VECTORS, location = BIP39DataProvider.class)
+    @ParameterizedTest
+    @MethodSource(BIP39DataProvider.DATA_PROVIDER_BIP39_TEST_VECTORS)
     public void bip39Vector_givenTestVector_returnsExpectedSeedAndXprvForLanguage(String language, String entropyHex, String mnemonicStr, String passphrase, String expectedSeedHex, String expectedXprv) throws Exception {
         // Arrange
         byte[] entropy = Hex.decodeHex(entropyHex);
@@ -145,7 +143,7 @@ public class BIP39KeyProducerTest {
         assertThat("Language: " + language, masterKey.serializePrivB58(MainNetParams.get().network()), is(expectedXprv));
     }
     
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void nextKey_counterOverflow_throwsException() {
         // arrange
         String mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39KeyProducerTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39KeyProducerTest.java
@@ -7,6 +7,7 @@ import net.ladenthin.bitcoinaddressfinder.keyproducer.NoMoreSecretsAvailableExce
 import java.time.Instant;
 import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.equalTo;
 import java.text.Normalizer;
 import java.text.Normalizer.Form;
@@ -163,7 +164,7 @@ public class BIP39KeyProducerTest {
         }
 
         // This call should overflow and throw NoMoreSecretsAvailableException
-        producer.nextKey();
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.nextKey());
     }
     
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39WordlistTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BIP39WordlistTest.java
@@ -8,7 +8,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link BIP39Wordlist}.
@@ -255,10 +256,10 @@ public class BIP39WordlistTest {
         assertThat(result, is(equalTo(BIP39Wordlist.CHINESE_SIMPLIFIED)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void fromLanguageName_unknownLanguage_throwsException() {
         // act
-        BIP39Wordlist.fromLanguageName("klingon");
+        assertThrows(IllegalArgumentException.class, () -> BIP39Wordlist.fromLanguageName("klingon"));
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/Base36DecoderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/Base36DecoderTest.java
@@ -8,8 +8,9 @@ import java.util.Arrays;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Base36DecoderTest {
 
@@ -187,31 +188,31 @@ public class Base36DecoderTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="decodeBase36ToFixedLengthBytes - invalid input">
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void decodeBase36ToFixedLengthBytes_invalidCharacters_throwsException() {
         // arrange
         String invalidBase36 = "O0I1L$%"; // invalid characters for BigInteger(36)
 
         // act
-        decoder.decodeBase36ToFixedLengthBytes(invalidBase36, 20);
+        assertThrows(NumberFormatException.class, () -> decoder.decodeBase36ToFixedLengthBytes(invalidBase36, 20));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void decodeBase36ToFixedLengthBytes_emptyString_throwsException() {
         // arrange
         String emptyString = "";
 
         // act
-        decoder.decodeBase36ToFixedLengthBytes(emptyString, 20);
+        assertThrows(NumberFormatException.class, () -> decoder.decodeBase36ToFixedLengthBytes(emptyString, 20));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void decodeBase36ToFixedLengthBytes_invalidCharacterSpace_throwsException() {
         // arrange
         String invalidBase36 = "123 456"; // space is invalid in base36
 
         // act
-        decoder.decodeBase36ToFixedLengthBytes(invalidBase36, 20);
+        assertThrows(NumberFormatException.class, () -> decoder.decodeBase36ToFixedLengthBytes(invalidBase36, 20));
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/Bech32HelperTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/Bech32HelperTest.java
@@ -7,11 +7,12 @@ import java.nio.ByteBuffer;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.enums.P2PKH;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.enums.P2WPKH;
 import org.bitcoinj.base.Bech32;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Bech32HelperTest {
 
@@ -31,14 +32,14 @@ public class Bech32HelperTest {
         assertThat(result, is(expected));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void decodeBech32CharsetToValues_invalidCharacter_throwsException() {
         // arrange
         Bech32Helper sut = new Bech32Helper();
 
         // act
         // 'i' is not part of the Bech32 character set (excluded to avoid visual ambiguity with '1')
-        sut.decodeBech32CharsetToValues("i");
+        assertThrows(IllegalArgumentException.class, () -> sut.decodeBech32CharsetToValues("i"));
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BitHelperTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BitHelperTest.java
@@ -6,6 +6,7 @@ package net.ladenthin.bitcoinaddressfinder;
 import java.io.IOException;
 import java.math.BigInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Test;
@@ -45,16 +46,16 @@ public class BitHelperTest {
         BitHelper bitHelper = new BitHelper();
 
         // act, assert
-        bitHelper.assertBatchSizeInBitsIsInRange(-1);
+        assertThrows(IllegalArgumentException.class, () -> bitHelper.assertBatchSizeInBitsIsInRange(-1));
     }
-    
+
     @Test
     public void assertBatchSizeInBitsCorrect_bitsGivenOverMaximum_exceptionThrown() throws IOException {
         // arrange
         BitHelper bitHelper = new BitHelper();
 
         // act, assert
-        bitHelper.assertBatchSizeInBitsIsInRange(PublicKeyBytes.BIT_COUNT_FOR_MAX_CHUNKS_ARRAY + 1);
+        assertThrows(IllegalArgumentException.class, () -> bitHelper.assertBatchSizeInBitsIsInRange(PublicKeyBytes.BIT_COUNT_FOR_MAX_CHUNKS_ARRAY + 1));
     }
     
     @ParameterizedTest

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BitHelperTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BitHelperTest.java
@@ -3,22 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.IOException;
 import java.math.BigInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(DataProviderRunner.class)
 public class BitHelperTest {
     
     // <editor-fold defaultstate="collapsed" desc="getKillBits">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_KILL_BITS, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_KILL_BITS)
     public void getKillBits_bitsGiven_killBitsEqualsExpectation(int bits, BigInteger killBits) throws IOException {
         // arrange
         BitHelper bitHelper = new BitHelper();
@@ -29,8 +27,8 @@ public class BitHelperTest {
     // </editor-fold>
     
     // <editor-fold defaultstate="collapsed" desc="convertBitsToSize">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BITS_TO_SIZE, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BITS_TO_SIZE)
     public void convertBitsToSize_bitsGiven_sizeEqualsExpectation(int bits, int size) throws IOException {
         // arrange
         BitHelper bitHelper = new BitHelper();
@@ -41,7 +39,7 @@ public class BitHelperTest {
     // </editor-fold>
     
     // <editor-fold defaultstate="collapsed" desc="assertBatchSizeInBitsIsInRange">
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertBatchSizeInBitsIsInRange_bitsGivenBelowMinimum_exceptionThrown() throws IOException {
         // arrange
         BitHelper bitHelper = new BitHelper();
@@ -50,7 +48,7 @@ public class BitHelperTest {
         bitHelper.assertBatchSizeInBitsIsInRange(-1);
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertBatchSizeInBitsCorrect_bitsGivenOverMaximum_exceptionThrown() throws IOException {
         // arrange
         BitHelper bitHelper = new BitHelper();
@@ -59,8 +57,8 @@ public class BitHelperTest {
         bitHelper.assertBatchSizeInBitsIsInRange(PublicKeyBytes.BIT_COUNT_FOR_MAX_CHUNKS_ARRAY + 1);
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX)
     public void assertBatchSizeInBitsIsInRange_bitsGivenInRange_exceptionThrown(int bits) throws IOException {
         // arrange
         BitHelper bitHelper = new BitHelper();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtilityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtilityTest.java
@@ -208,22 +208,10 @@ public class ByteBufferUtilityTest {
     }
     // </editor-fold>
     
-    private long getAddressFromDirectBuffer(DirectBuffer directBuffer) throws IllegalArgumentException, NoSuchFieldException, SecurityException, IllegalAccessException {
-        Cleaner cleaner = directBuffer.cleaner();
-        Field thunkField = cleaner.getClass().getDeclaredField("thunk");
-        thunkField.setAccessible(true);
-        Object deallocator = thunkField.get(cleaner);
-        
-        Field addressField = deallocator.getClass().getDeclaredField("address");
-        addressField.setAccessible(true);
-        return addressField.getLong(deallocator);
-    }
-
     private boolean isDirectBufferFreed(DirectBuffer directBuffer) throws IllegalArgumentException, NoSuchFieldException, SecurityException, IllegalAccessException {
-        // does not work with newer JVMs (21) anymore
-        boolean testWithAddress = false;
-        boolean addressTest = true;
-        
+        // In Java 21, a fresh Cleaner has next=null and prev=null.
+        // After invocation, the Cleaner sets next=this and prev=this (self-reference).
+        // So freed state is: next != null && next == prev.
         Cleaner cleaner = directBuffer.cleaner();
 
         Field nextField = cleaner.getClass().getDeclaredField("next");
@@ -234,12 +222,7 @@ public class ByteBufferUtilityTest {
         prevField.setAccessible(true);
         Object prev = prevField.get(cleaner);
 
-        if (testWithAddress) {
-            long address = getAddressFromDirectBuffer(directBuffer);
-            addressTest = address == 0L;
-        }
-
-        return next == prev && addressTest;
+        return next != null && next == prev;
     }
 
     // <editor-fold defaultstate="collapsed" desc="ensureByteBufferCapacityFitsInt">

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtilityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtilityTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
 import jdk.internal.ref.Cleaner;
@@ -284,7 +285,7 @@ public class ByteBufferUtilityTest {
         long capacity = (long) Integer.MAX_VALUE + 1L;
 
         // act
-        ByteBufferUtility.ensureByteBufferCapacityFitsInt(capacity);
+        assertThrows(IllegalArgumentException.class, () -> ByteBufferUtility.ensureByteBufferCapacityFitsInt(capacity));
 
         // assert is handled by exception rule
     }
@@ -295,7 +296,7 @@ public class ByteBufferUtilityTest {
         long capacity = -1L;
 
         // act
-        ByteBufferUtility.ensureByteBufferCapacityFitsInt(capacity);
+        assertThrows(IllegalArgumentException.class, () -> ByteBufferUtility.ensureByteBufferCapacityFitsInt(capacity));
 
         // assert is handled by exception rule
     }
@@ -327,7 +328,7 @@ public class ByteBufferUtilityTest {
         final ByteBufferUtility byteBufferUtility = new ByteBufferUtility(false);
 
         // act
-        byteBufferUtility.allocateByteBufferDirectStrict(16);
+        assertThrows(IllegalStateException.class, () -> byteBufferUtility.allocateByteBufferDirectStrict(16));
 
         // assert handled by exception
     }
@@ -448,7 +449,7 @@ public class ByteBufferUtilityTest {
        ByteBuffer buffer = ByteBuffer.allocate(1);
        byte[] input = { 0x11, 0x22 };
 
-       ByteBufferUtility.putToByteBuffer(buffer, input);
+       assertThrows(BufferOverflowException.class, () -> ByteBufferUtility.putToByteBuffer(buffer, input));
     }
     // </editor-fold>
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtilityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtilityTest.java
@@ -208,6 +208,17 @@ public class ByteBufferUtilityTest {
     }
     // </editor-fold>
     
+    private long getAddressFromDirectBuffer(DirectBuffer directBuffer) throws IllegalArgumentException, NoSuchFieldException, SecurityException, IllegalAccessException {
+        Cleaner cleaner = directBuffer.cleaner();
+        Field thunkField = cleaner.getClass().getDeclaredField("thunk");
+        thunkField.setAccessible(true);
+        Object deallocator = thunkField.get(cleaner);
+
+        Field addressField = deallocator.getClass().getDeclaredField("address");
+        addressField.setAccessible(true);
+        return addressField.getLong(deallocator);
+    }
+
     private boolean isDirectBufferFreed(DirectBuffer directBuffer) throws IllegalArgumentException, NoSuchFieldException, SecurityException, IllegalAccessException {
         // In Java 21, a fresh Cleaner has next=null and prev=null.
         // After invocation, the Cleaner sets next=this and prev=this (self-reference).

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtilityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtilityTest.java
@@ -3,24 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
-import org.junit.runner.RunWith;
 import jdk.internal.ref.Cleaner;
 import sun.nio.ch.DirectBuffer;
 
-@RunWith(DataProviderRunner.class)
 public class ByteBufferUtilityTest {
     
     /**
@@ -28,14 +26,14 @@ public class ByteBufferUtilityTest {
      */
     private final static boolean ALLOCATE_DIRECT_DOES_NOT_MATTER = false;
     
-    @Before
+    @BeforeEach
     public void init() throws IOException {
     }
     
     
     // <editor-fold defaultstate="collapsed" desc="freeByteBuffer">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT)
     public void freeByteBuffer_nullGiven_noExceptionThrown(boolean allocateDirect) throws IOException {
         // arrange
         
@@ -70,8 +68,8 @@ public class ByteBufferUtilityTest {
         // assert
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT)
     public void freeByteBuffer_freeAGivenByteBuffer_noExceptionThrown(boolean allocateDirect) throws IOException, IllegalArgumentException, IllegalAccessException, NoSuchFieldException {
         // arrange
         byte[] bytesGiven = createDummyByteArray(7);
@@ -93,8 +91,8 @@ public class ByteBufferUtilityTest {
         }
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT)
     public void freeByteBuffer_freeAGivenByteBufferGivenTwice_noExceptionThrown(boolean allocateDirect) throws IOException {
         // arrange
         byte[] bytesGiven = createDummyByteArray(7);
@@ -158,8 +156,8 @@ public class ByteBufferUtilityTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="byteArrayToByteBuffer">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT)
     public void byteArrayToByteBuffer_wrapped_allBytesEquals(boolean allocateDirect) throws IOException {
         // arrange
         byte[] bytes = createDummyByteArray(7);
@@ -175,8 +173,8 @@ public class ByteBufferUtilityTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="ByteBuffer Hex conversion">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT)
     public void getHexFromByteBuffer_byteBufferProvided_returnHex(boolean allocateDirect) throws IOException {
         // arrange
         String hexExpected = "00010203040506";
@@ -192,8 +190,8 @@ public class ByteBufferUtilityTest {
         assertThat(hex, is(equalTo(hexExpected)));
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ALLOCATE_DIRECT)
     public void getByteBufferFromHex_HexProvided_returnByteBuffer(boolean allocateDirect) throws IOException {
         // arrange
         String hexGiven = "00010203040506";
@@ -280,7 +278,7 @@ public class ByteBufferUtilityTest {
         assertThat(result, is(equalTo(Integer.MAX_VALUE)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ensureByteBufferCapacityFitsInt_valueTooLarge_throwsException() {
         // arrange
         long capacity = (long) Integer.MAX_VALUE + 1L;
@@ -291,7 +289,7 @@ public class ByteBufferUtilityTest {
         // assert is handled by exception rule
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ensureByteBufferCapacityFitsInt_negativeValueGiven_throwsException() {
         // arrange
         long capacity = -1L;
@@ -323,7 +321,7 @@ public class ByteBufferUtilityTest {
     /**
      * Ensures that an exception is thrown when trying to allocate a direct ByteBuffer while direct allocation is disabled.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void allocateByteBufferDirectStrict_directAllocationDisabled_throwsException() {
         // arrange
         final ByteBufferUtility byteBufferUtility = new ByteBufferUtility(false);
@@ -337,8 +335,8 @@ public class ByteBufferUtilityTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="bigIntegerToBytes">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BIG_INTEGER_VARIANTS, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BIG_INTEGER_VARIANTS)
     public void bigIntegerToBytes_leadingZeroStripped(BigInteger input, int expectedLength, byte expectedFirstByte) {
         // act
         byte[] actualBytes = ByteBufferUtility.bigIntegerToBytes(input);
@@ -445,7 +443,7 @@ public class ByteBufferUtilityTest {
         assertThat(buffer.get(), is((byte) 0x22));
     }
 
-    @Test(expected = BufferOverflowException.class)
+    @Test
     public void putToByteBuffer_arrayLargerThanBuffer_throwsBufferOverflowException() {
        ByteBuffer buffer = ByteBuffer.allocate(1);
        byte[] input = { 0x11, 0x22 };

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteConversionTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ByteConversionTest.java
@@ -3,24 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.IOException;
 import org.apache.commons.codec.DecoderException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(DataProviderRunner.class)
 public class ByteConversionTest {
 
     private final ByteConversion byteConversion = new ByteConversion();
 
     // <editor-fold defaultstate="collapsed" desc="bytesToMib">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BYTES_TO_MIB, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BYTES_TO_MIB)
     public void bytesToMib_bytesGiven_returnExpectedMib(long bytes, double expectedMib) throws IOException, InterruptedException, DecoderException {
         // act
         double result = byteConversion.bytesToMib(bytes);
@@ -95,8 +93,8 @@ public class ByteConversionTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="mibToBytes">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_MIB_TO_BYTES, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_MIB_TO_BYTES)
     public void mibToBytes_mibGiven_returnExpectedBytes(long mib, long expectedBytes) throws IOException, InterruptedException, DecoderException {
         // act
         long result = byteConversion.mibToBytes(mib);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/CommonDataProvider.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/CommonDataProvider.java
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.nio.ByteOrder;
@@ -19,11 +18,11 @@ public class CommonDataProvider {
     /**
      * For {@link #cSecretFormat()}.
      */
-    public final static String DATA_PROVIDER_LARGE_SECRETS_AS_HEX = "largeSecretsAsHex";
+    public final static String DATA_PROVIDER_LARGE_SECRETS_AS_HEX = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#largeSecretsAsHex";
 
     /**
     * Provides valid 64-character (32-byte) hex strings representing large unsigned secrets.
-    * 
+    *
     * These values are used to verify correct conversion from hex to BigInteger and back to hex,
     * without losing leading zero bytes — a common issue with BigInteger.toByteArray().
     *
@@ -35,7 +34,6 @@ public class CommonDataProvider {
     *
     * These test cases help detect and avoid those pitfalls.
     */
-    @DataProvider
     public static Object[][] largeSecretsAsHex() {
         return new Object[][] {
             {"0000000000000000000000000000000000000000000000000000000000000000"},
@@ -51,9 +49,8 @@ public class CommonDataProvider {
     /**
      * For {@link #cSecretFormat()}.
      */
-    public final static String DATA_PROVIDER_CSECRET_FORMAT = "cSecretFormat";
+    public final static String DATA_PROVIDER_CSECRET_FORMAT = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#cSecretFormat";
 
-    @DataProvider
     public static Object[][] cSecretFormat() {
         return transformFlatToObjectArrayArray(CSecretFormat.values());
     }
@@ -61,9 +58,8 @@ public class CommonDataProvider {
     /**
      * For {@link EndiannessConverterTest}.
      */
-    public static final String DATA_PROVIDER_ENDIANNESS = "endiannessScenarios";
+    public static final String DATA_PROVIDER_ENDIANNESS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#endiannessScenarios";
 
-    @DataProvider
     public static Object[][] endiannessScenarios() {
         return new Object[][] {
             {ByteOrder.LITTLE_ENDIAN, ByteOrder.LITTLE_ENDIAN, false},
@@ -85,9 +81,8 @@ public class CommonDataProvider {
     /**
      * For {@link FinderTest}.
      */
-    public static final String DATA_PROVIDER_KEY_PRODUCER_TYPES = "keyProducerTypes";
+    public static final String DATA_PROVIDER_KEY_PRODUCER_TYPES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#keyProducerTypes";
 
-    @DataProvider
     public static Object[][] keyProducerTypes() {
         return Arrays.stream(KeyProducerTypesLocal.values())
             .map(type -> new Object[]{type})
@@ -97,9 +92,8 @@ public class CommonDataProvider {
     /**
     * For tests validating combinations of key producer types and bit sizes.
     */
-   public static final String DATA_PROVIDER_JAVA_KEY_PRODUCER_AND_BIT_SIZE = "keyProducerTypeAndBitSize";
+   public static final String DATA_PROVIDER_JAVA_KEY_PRODUCER_AND_BIT_SIZE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#keyProducerTypeAndBitSize";
 
-    @DataProvider
     public static Object[][] keyProducerTypeAndBitSize() {
         return mergeMany(
             keyProducerTypes(),    // e.g., Socket, ZMQ, etc.
@@ -136,9 +130,8 @@ public class CommonDataProvider {
     /**
      * For {@link #bitsToSize()}.
      */
-    public final static String DATA_PROVIDER_BITS_TO_SIZE = "bitsToSize";
+    public final static String DATA_PROVIDER_BITS_TO_SIZE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitsToSize";
 
-    @DataProvider
     public static Object[][] bitsToSize() {
         return new Object[][]{
             {0, 1},
@@ -152,9 +145,8 @@ public class CommonDataProvider {
     /**
      * For {@link #killBits()}.
      */
-    public final static String DATA_PROVIDER_KILL_BITS = "killBits";
+    public final static String DATA_PROVIDER_KILL_BITS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#killBits";
 
-    @DataProvider
     public static Object[][] killBits() {
         return new Object[][]{
             {0, BigInteger.valueOf(0L)},
@@ -168,9 +160,8 @@ public class CommonDataProvider {
     /**
      * For {@link #bytesToMib()}.
      */
-    public final static String DATA_PROVIDER_BYTES_TO_MIB = "bytesToMib";
+    public final static String DATA_PROVIDER_BYTES_TO_MIB = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bytesToMib";
 
-    @DataProvider
     public static Object[][] bytesToMib() {
         return new Object[][]{
             {1L, 0.00000095367431640625d},
@@ -183,9 +174,8 @@ public class CommonDataProvider {
     /**
      * For {@link #mibToBytes()}.
      */
-    public final static String DATA_PROVIDER_MIB_TO_BYTES = "mibToBytes";
+    public final static String DATA_PROVIDER_MIB_TO_BYTES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#mibToBytes";
 
-    @DataProvider
     public static Object[][] mibToBytes() {
         return new Object[][]{
             {1L, 1024L*1024L},
@@ -197,9 +187,8 @@ public class CommonDataProvider {
     /**
      * For {@link #lmdbAmounts()}.
      */
-    public final static String DATA_PROVIDER_LMDB_AMOUNTS = "lmdbAmounts";
+    public final static String DATA_PROVIDER_LMDB_AMOUNTS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#lmdbAmounts";
 
-    @DataProvider
     public static Object[][] lmdbAmounts() {
         long randomAmount = 13371337L;
         return new Object[][]{
@@ -245,9 +234,8 @@ public class CommonDataProvider {
     /**
      * For {@link #lmdbIncreaseSize()}.
      */
-    public final static String DATA_PROVIDER_LMDB_INCREASE_SIZE = "lmdbIncreaseSize";
+    public final static String DATA_PROVIDER_LMDB_INCREASE_SIZE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#lmdbIncreaseSize";
 
-    @DataProvider
     public static Object[][] lmdbIncreaseSize() {
         return new Object[][]{
             {1024L},
@@ -259,9 +247,8 @@ public class CommonDataProvider {
     /**
      * For {@link #bitSizesAtMostMax()}.
      */
-    public final static String DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX = "bitSizesAtMostMax";
+    public final static String DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitSizesAtMostMax";
 
-    @DataProvider
     public static Object[][] bitSizesAtMostMax() {
         final int max = PublicKeyBytes.BIT_COUNT_FOR_MAX_CHUNKS_ARRAY;
 
@@ -276,9 +263,8 @@ public class CommonDataProvider {
     /**
      * For {@link #compressedAndStaticAmount()}.
      */
-    public final static String DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT = "compressedAndStaticAmount";
+    public final static String DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#compressedAndStaticAmount";
 
-    @DataProvider
     public static Object[][] compressedAndStaticAmount() {
         return new Object[][]{
             {true, true},
@@ -291,9 +277,8 @@ public class CommonDataProvider {
     /**
      * For {@link #staticAmount()}.
      */
-    public final static String DATA_PROVIDER_STATIC_AMOUNT = "staticAmount";
+    public final static String DATA_PROVIDER_STATIC_AMOUNT = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticAmount";
 
-    @DataProvider
     public static Object[][] staticAmount() {
         return new Object[][]{
             {true},
@@ -304,9 +289,8 @@ public class CommonDataProvider {
     /**
      * For {@link #compressed()}.
      */
-    public final static String DATA_PROVIDER_COMPRESSED = "compressed";
+    public final static String DATA_PROVIDER_COMPRESSED = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#compressed";
 
-    @DataProvider
     public static Object[][] compressed() {
         return new Object[][]{
             {true},
@@ -317,9 +301,8 @@ public class CommonDataProvider {
     /**
      * For {@link #addressSeperator()}.
      */
-    public final static String DATA_PROVIDER_ADDRESS_SEPARATOR = "addressSeperator";
+    public final static String DATA_PROVIDER_ADDRESS_SEPARATOR = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#addressSeperator";
 
-    @DataProvider
     public static Object[][] addressSeperator() {
             return Arrays.stream(SeparatorFormat.values())
                  .map(format -> new Object[]{format.getSymbol()})
@@ -329,9 +312,8 @@ public class CommonDataProvider {
     /**
      * For {@link #invalidP2WPKHAddressesValidBase58()}.
      */
-    public final static String DATA_PROVIDER_INVALID_P2WPKH_ADDRESSES_VALID_BASE58 = "invalidP2WPKHAddressesValidBase58";
+    public final static String DATA_PROVIDER_INVALID_P2WPKH_ADDRESSES_VALID_BASE58 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#invalidP2WPKHAddressesValidBase58";
 
-    @DataProvider
     public static Object[][] invalidP2WPKHAddressesValidBase58() {
         return new Object[][]{
             {"bc1zqyqsywvzqeeeeeee", "5347dec05b6f03de6cc004c1ec33000000000000"},  // bitcoin
@@ -345,9 +327,8 @@ public class CommonDataProvider {
     /**
      * For {@link #invalidBech32WitnessVersion2()}.
      */
-    public final static String DATA_PROVIDER_INVALID_BECH32_WITNESS_VERSION_2 = "invalidBech32WitnessVersion2";
+    public final static String DATA_PROVIDER_INVALID_BECH32_WITNESS_VERSION_2 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#invalidBech32WitnessVersion2";
 
-    @DataProvider
     public static Object[][] invalidBech32WitnessVersion2() {
         return new Object[][]{
             // Not sure where this address comes from, but it has a witness version of 2 and a witness program length of 2
@@ -358,9 +339,8 @@ public class CommonDataProvider {
     /**
      * For {@link #invalidBase58()}.
      */
-    public final static String DATA_PROVIDER_INVALID_BASE58 = "invalidBase58";
+    public final static String DATA_PROVIDER_INVALID_BASE58 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#invalidBase58";
 
-    @DataProvider
     public static Object[][] invalidBase58() {
         return new Object[][]{
             // P2PKH
@@ -380,9 +360,8 @@ public class CommonDataProvider {
      * For {@link #bitcoinAddressesCorrectBase58()}.
      * A correct base58 format should be parsed anyway.
      */
-    public final static String DATA_PROVIDER_BITCOIN_ADDRESSES_CORRECT_BASE_58 = "bitcoinAddressesCorrectBase58";
+    public final static String DATA_PROVIDER_BITCOIN_ADDRESSES_CORRECT_BASE_58 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitcoinAddressesCorrectBase58";
 
-    @DataProvider
     public static Object[][] bitcoinAddressesCorrectBase58() {
         return new Object[][]{
             {"1WrongAddressFormat","01667b78604490800f88b15c77a5000000000000"},
@@ -395,9 +374,8 @@ public class CommonDataProvider {
      * For {@link #correctBase58()}.
      * A correct base58 format should be parsed anyway.
      */
-    public final static String DATA_PROVIDER_CORRECT_BASE_58 = "correctBase58";
+    public final static String DATA_PROVIDER_CORRECT_BASE_58 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#correctBase58";
 
-    @DataProvider
     public static Object[][] correctBase58() {
         return new Object[][]{
             {"1","0000000000000000000000000000000000000000"},
@@ -411,9 +389,8 @@ public class CommonDataProvider {
     /**
      * For {@link #srcPos()}.
      */
-    public final static String DATA_PROVIDER_SRC_POS = "srcPos";
+    public final static String DATA_PROVIDER_SRC_POS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#srcPos";
 
-    @DataProvider
     public static Object[][] srcPos() {
         return new Object[][]{
             {1},
@@ -444,9 +421,8 @@ public class CommonDataProvider {
      * TODO: I don't know if this is right. It seems like it's a base58 format.
      * I've asked Blockchair and they've answered: "The addresses you listed are for internal purposes.".
      */
-    public final static String DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_CHECKSUM_INVALID = "bitcoinCashAddressesChecksumInvalid";
+    public final static String DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_CHECKSUM_INVALID = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitcoinCashAddressesChecksumInvalid";
 
-    @DataProvider
     public static Object[][] bitcoinCashAddressesChecksumInvalid() {
         return new Object[][]{
             {"dSn3treXZQfJRktvoApJKM","27225957c54a53b10e4f4e00b2562af400000000"},
@@ -467,9 +443,8 @@ public class CommonDataProvider {
      * TODO: I don't know if this is right. It seems like it's a hex format.
      * I've asked Blockchair and they've answered: "The addresses you listed are for internal purposes.".
      */
-    public final static String DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_INTERNAL_PURPOSE = "bitcoinCashAddressesInternalPurpose";
+    public final static String DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_INTERNAL_PURPOSE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitcoinCashAddressesInternalPurpose";
 
-    @DataProvider
     public static Object[][] bitcoinCashAddressesInternalPurpose() {
         return new Object[][]{
             {"d-32551cbc0d16a34c5995b4057c3f027c"},
@@ -483,9 +458,8 @@ public class CommonDataProvider {
     /**
      * For {@link #createSecretBaseLogged()}.
      */
-    public final static String DATA_PROVIDER_CREATE_SECRET_BASE_LOGGED = "createSecretBaseLogged";
+    public final static String DATA_PROVIDER_CREATE_SECRET_BASE_LOGGED = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#createSecretBaseLogged";
 
-    @DataProvider
     public static Object[][] createSecretBaseLogged() {
         return new Object[][]{
             // small key, batchSizeInBits: 2
@@ -505,9 +479,8 @@ public class CommonDataProvider {
     /**
      * For {@link #staticP2PKHAddresses()}.
      */
-    public final static String DATA_PROVIDER_STATIC_P2PKH_ADDRESSES = "staticP2PKHAddresses";
+    public final static String DATA_PROVIDER_STATIC_P2PKH_ADDRESSES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticP2PKHAddresses";
 
-    @DataProvider
     public static Object[][] staticP2PKHAddresses() {
         return transformFlatToObjectArrayArray(P2PKH.values());
     }
@@ -515,9 +488,8 @@ public class CommonDataProvider {
     /**
      * For {@link #staticP2SHAddresses()}.
      */
-    public final static String DATA_PROVIDER_STATIC_P2SH_ADDRESSES = "staticP2SHAddresses";
+    public final static String DATA_PROVIDER_STATIC_P2SH_ADDRESSES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticP2SHAddresses";
 
-    @DataProvider
     public static Object[][] staticP2SHAddresses() {
         return transformFlatToObjectArrayArray(P2SH.values());
     }
@@ -525,9 +497,8 @@ public class CommonDataProvider {
     /**
      * For {@link #staticP2SHAddresses()}.
      */
-    public final static String DATA_PROVIDER_STATIC_P2WPKH_ADDRESSES = "staticP2WPKHAddresses";
+    public final static String DATA_PROVIDER_STATIC_P2WPKH_ADDRESSES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticP2WPKHAddresses";
 
-    @DataProvider
     public static Object[][] staticP2WPKHAddresses() {
         return transformFlatToObjectArrayArray(P2WPKH.values());
     }
@@ -535,9 +506,8 @@ public class CommonDataProvider {
     /**
      * For {@link #staticUnsupportedAddresses()}.
      */
-    public final static String DATA_PROVIDER_STATIC_UNSUPPORTED_ADDRESSES = "staticUnsupportedAddresses";
+    public final static String DATA_PROVIDER_STATIC_UNSUPPORTED_ADDRESSES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticUnsupportedAddresses";
 
-    @DataProvider
     public static Object[][] staticUnsupportedAddresses() {
         return transformFlatToObjectArrayArray(StaticUnsupportedAddress.values());
     }
@@ -554,9 +524,8 @@ public class CommonDataProvider {
      * For {@link ByteBufferUtility}.
      * Use allocate direct.
      */
-    public final static String DATA_PROVIDER_ALLOCATE_DIRECT = "allocateDirect";
+    public final static String DATA_PROVIDER_ALLOCATE_DIRECT = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#allocateDirect";
 
-    @DataProvider
     public static Object[][] allocateDirect() {
         return new Object[][]{
             {true},
@@ -570,9 +539,8 @@ public class CommonDataProvider {
      * Supplies {@code true} (Bloom filter active) and {@code false} (Bloom filter inactive),
      * to verify correctness and performance behavior in both configurations.
      */
-    public final static String DATA_PROVIDER_BLOOM_FILTER_ENABLED = "bloomFilterEnabled";
+    public final static String DATA_PROVIDER_BLOOM_FILTER_ENABLED = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bloomFilterEnabled";
 
-    @DataProvider
     public static Object[][] bloomFilterEnabled() {
         return new Object[][]{
             {true},
@@ -583,9 +551,8 @@ public class CommonDataProvider {
     /**
      * For {@link #largePrivateKeys()}.
      */
-    public final static String DATA_PROVIDER_LARGE_PRIVATE_KEYS = "largePrivateKeys";
+    public final static String DATA_PROVIDER_LARGE_PRIVATE_KEYS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#largePrivateKeys";
 
-    @DataProvider
     public static Object[][] largePrivateKeys() {
         return new Object[][]{
             // ⚠️ Important: Do not include keys that are near or equal to the maximum valid private key (e.g., MAX_PRIVATE_KEY + offset).
@@ -679,9 +646,8 @@ public class CommonDataProvider {
     /**
      * For {@link #privateKeysTooLargeWithChunkSize()}.
      */
-    public final static String DATA_PROVIDER_PRIVATE_KEYS_TOO_LARGE_WITH_CHUNK_SIZE = "privateKeysTooLargeWithChunkSize";
+    public final static String DATA_PROVIDER_PRIVATE_KEYS_TOO_LARGE_WITH_CHUNK_SIZE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#privateKeysTooLargeWithChunkSize";
 
-    @DataProvider
     public static Object[][] privateKeysTooLargeWithChunkSize() {
         return new Object[][]{
             {PublicKeyBytes.MAX_TECHNICALLY_PRIVATE_KEY, PublicKeyBytes.BIT_COUNT_FOR_MAX_CHUNKS_ARRAY},
@@ -692,9 +658,8 @@ public class CommonDataProvider {
     /**
      * For {@link #privateKeys32ByteRequiringStrip()}.
      */
-    public final static String DATA_PROVIDER_PRIVATE_KEYS_32_BYTE_REQUIRING_STRIP = "privateKeys32ByteRequiringStrip";
+    public final static String DATA_PROVIDER_PRIVATE_KEYS_32_BYTE_REQUIRING_STRIP = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#privateKeys32ByteRequiringStrip";
 
-    @DataProvider
     public static Object[][] privateKeys32ByteRequiringStrip() {
         return new Object[][]{
             // Custom crafted BigIntegers with MSB set (highest bit in first byte = 1)
@@ -708,9 +673,8 @@ public class CommonDataProvider {
     /**
      * For {@link #bigIntegerVariants()}.
      */
-    public final static String DATA_PROVIDER_BIG_INTEGER_VARIANTS = "bigIntegerVariants";
-    
-    @DataProvider
+    public final static String DATA_PROVIDER_BIG_INTEGER_VARIANTS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bigIntegerVariants";
+
     public static Object[][] bigIntegerVariants() {
         return new Object[][] {
             { new BigInteger("00", 16), 0, (byte) 0x00 }, // 0-value, empty result

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/CommonDataProvider.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/CommonDataProvider.java
@@ -14,11 +14,14 @@ import net.ladenthin.bitcoinaddressfinder.configuration.CSecretFormat;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.enums.*;
 
 public class CommonDataProvider {
-    
+
+    /** Must remain a string literal — annotation values require compile-time constants. */
+    private static final String CLASS_NAME = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider";
+
     /**
      * For {@link #cSecretFormat()}.
      */
-    public final static String DATA_PROVIDER_LARGE_SECRETS_AS_HEX = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#largeSecretsAsHex";
+    public final static String DATA_PROVIDER_LARGE_SECRETS_AS_HEX = CLASS_NAME + "#largeSecretsAsHex";
 
     /**
     * Provides valid 64-character (32-byte) hex strings representing large unsigned secrets.
@@ -49,7 +52,7 @@ public class CommonDataProvider {
     /**
      * For {@link #cSecretFormat()}.
      */
-    public final static String DATA_PROVIDER_CSECRET_FORMAT = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#cSecretFormat";
+    public final static String DATA_PROVIDER_CSECRET_FORMAT = CLASS_NAME + "#cSecretFormat";
 
     public static Object[][] cSecretFormat() {
         return transformFlatToObjectArrayArray(CSecretFormat.values());
@@ -58,7 +61,7 @@ public class CommonDataProvider {
     /**
      * For {@link EndiannessConverterTest}.
      */
-    public static final String DATA_PROVIDER_ENDIANNESS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#endiannessScenarios";
+    public static final String DATA_PROVIDER_ENDIANNESS = CLASS_NAME + "#endiannessScenarios";
 
     public static Object[][] endiannessScenarios() {
         return new Object[][] {
@@ -81,7 +84,7 @@ public class CommonDataProvider {
     /**
      * For {@link FinderTest}.
      */
-    public static final String DATA_PROVIDER_KEY_PRODUCER_TYPES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#keyProducerTypes";
+    public static final String DATA_PROVIDER_KEY_PRODUCER_TYPES = CLASS_NAME + "#keyProducerTypes";
 
     public static Object[][] keyProducerTypes() {
         return Arrays.stream(KeyProducerTypesLocal.values())
@@ -92,7 +95,7 @@ public class CommonDataProvider {
     /**
     * For tests validating combinations of key producer types and bit sizes.
     */
-   public static final String DATA_PROVIDER_JAVA_KEY_PRODUCER_AND_BIT_SIZE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#keyProducerTypeAndBitSize";
+   public static final String DATA_PROVIDER_JAVA_KEY_PRODUCER_AND_BIT_SIZE = CLASS_NAME + "#keyProducerTypeAndBitSize";
 
     public static Object[][] keyProducerTypeAndBitSize() {
         return mergeMany(
@@ -130,7 +133,7 @@ public class CommonDataProvider {
     /**
      * For {@link #bitsToSize()}.
      */
-    public final static String DATA_PROVIDER_BITS_TO_SIZE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitsToSize";
+    public final static String DATA_PROVIDER_BITS_TO_SIZE = CLASS_NAME + "#bitsToSize";
 
     public static Object[][] bitsToSize() {
         return new Object[][]{
@@ -145,7 +148,7 @@ public class CommonDataProvider {
     /**
      * For {@link #killBits()}.
      */
-    public final static String DATA_PROVIDER_KILL_BITS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#killBits";
+    public final static String DATA_PROVIDER_KILL_BITS = CLASS_NAME + "#killBits";
 
     public static Object[][] killBits() {
         return new Object[][]{
@@ -160,7 +163,7 @@ public class CommonDataProvider {
     /**
      * For {@link #bytesToMib()}.
      */
-    public final static String DATA_PROVIDER_BYTES_TO_MIB = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bytesToMib";
+    public final static String DATA_PROVIDER_BYTES_TO_MIB = CLASS_NAME + "#bytesToMib";
 
     public static Object[][] bytesToMib() {
         return new Object[][]{
@@ -174,7 +177,7 @@ public class CommonDataProvider {
     /**
      * For {@link #mibToBytes()}.
      */
-    public final static String DATA_PROVIDER_MIB_TO_BYTES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#mibToBytes";
+    public final static String DATA_PROVIDER_MIB_TO_BYTES = CLASS_NAME + "#mibToBytes";
 
     public static Object[][] mibToBytes() {
         return new Object[][]{
@@ -187,7 +190,7 @@ public class CommonDataProvider {
     /**
      * For {@link #lmdbAmounts()}.
      */
-    public final static String DATA_PROVIDER_LMDB_AMOUNTS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#lmdbAmounts";
+    public final static String DATA_PROVIDER_LMDB_AMOUNTS = CLASS_NAME + "#lmdbAmounts";
 
     public static Object[][] lmdbAmounts() {
         long randomAmount = 13371337L;
@@ -234,7 +237,7 @@ public class CommonDataProvider {
     /**
      * For {@link #lmdbIncreaseSize()}.
      */
-    public final static String DATA_PROVIDER_LMDB_INCREASE_SIZE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#lmdbIncreaseSize";
+    public final static String DATA_PROVIDER_LMDB_INCREASE_SIZE = CLASS_NAME + "#lmdbIncreaseSize";
 
     public static Object[][] lmdbIncreaseSize() {
         return new Object[][]{
@@ -247,7 +250,7 @@ public class CommonDataProvider {
     /**
      * For {@link #bitSizesAtMostMax()}.
      */
-    public final static String DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitSizesAtMostMax";
+    public final static String DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX = CLASS_NAME + "#bitSizesAtMostMax";
 
     public static Object[][] bitSizesAtMostMax() {
         final int max = PublicKeyBytes.BIT_COUNT_FOR_MAX_CHUNKS_ARRAY;
@@ -263,7 +266,7 @@ public class CommonDataProvider {
     /**
      * For {@link #compressedAndStaticAmount()}.
      */
-    public final static String DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#compressedAndStaticAmount";
+    public final static String DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT = CLASS_NAME + "#compressedAndStaticAmount";
 
     public static Object[][] compressedAndStaticAmount() {
         return new Object[][]{
@@ -277,7 +280,7 @@ public class CommonDataProvider {
     /**
      * For {@link #staticAmount()}.
      */
-    public final static String DATA_PROVIDER_STATIC_AMOUNT = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticAmount";
+    public final static String DATA_PROVIDER_STATIC_AMOUNT = CLASS_NAME + "#staticAmount";
 
     public static Object[][] staticAmount() {
         return new Object[][]{
@@ -289,7 +292,7 @@ public class CommonDataProvider {
     /**
      * For {@link #compressed()}.
      */
-    public final static String DATA_PROVIDER_COMPRESSED = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#compressed";
+    public final static String DATA_PROVIDER_COMPRESSED = CLASS_NAME + "#compressed";
 
     public static Object[][] compressed() {
         return new Object[][]{
@@ -301,7 +304,7 @@ public class CommonDataProvider {
     /**
      * For {@link #addressSeperator()}.
      */
-    public final static String DATA_PROVIDER_ADDRESS_SEPARATOR = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#addressSeperator";
+    public final static String DATA_PROVIDER_ADDRESS_SEPARATOR = CLASS_NAME + "#addressSeperator";
 
     public static Object[][] addressSeperator() {
             return Arrays.stream(SeparatorFormat.values())
@@ -312,7 +315,7 @@ public class CommonDataProvider {
     /**
      * For {@link #invalidP2WPKHAddressesValidBase58()}.
      */
-    public final static String DATA_PROVIDER_INVALID_P2WPKH_ADDRESSES_VALID_BASE58 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#invalidP2WPKHAddressesValidBase58";
+    public final static String DATA_PROVIDER_INVALID_P2WPKH_ADDRESSES_VALID_BASE58 = CLASS_NAME + "#invalidP2WPKHAddressesValidBase58";
 
     public static Object[][] invalidP2WPKHAddressesValidBase58() {
         return new Object[][]{
@@ -327,7 +330,7 @@ public class CommonDataProvider {
     /**
      * For {@link #invalidBech32WitnessVersion2()}.
      */
-    public final static String DATA_PROVIDER_INVALID_BECH32_WITNESS_VERSION_2 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#invalidBech32WitnessVersion2";
+    public final static String DATA_PROVIDER_INVALID_BECH32_WITNESS_VERSION_2 = CLASS_NAME + "#invalidBech32WitnessVersion2";
 
     public static Object[][] invalidBech32WitnessVersion2() {
         return new Object[][]{
@@ -339,7 +342,7 @@ public class CommonDataProvider {
     /**
      * For {@link #invalidBase58()}.
      */
-    public final static String DATA_PROVIDER_INVALID_BASE58 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#invalidBase58";
+    public final static String DATA_PROVIDER_INVALID_BASE58 = CLASS_NAME + "#invalidBase58";
 
     public static Object[][] invalidBase58() {
         return new Object[][]{
@@ -360,7 +363,7 @@ public class CommonDataProvider {
      * For {@link #bitcoinAddressesCorrectBase58()}.
      * A correct base58 format should be parsed anyway.
      */
-    public final static String DATA_PROVIDER_BITCOIN_ADDRESSES_CORRECT_BASE_58 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitcoinAddressesCorrectBase58";
+    public final static String DATA_PROVIDER_BITCOIN_ADDRESSES_CORRECT_BASE_58 = CLASS_NAME + "#bitcoinAddressesCorrectBase58";
 
     public static Object[][] bitcoinAddressesCorrectBase58() {
         return new Object[][]{
@@ -374,7 +377,7 @@ public class CommonDataProvider {
      * For {@link #correctBase58()}.
      * A correct base58 format should be parsed anyway.
      */
-    public final static String DATA_PROVIDER_CORRECT_BASE_58 = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#correctBase58";
+    public final static String DATA_PROVIDER_CORRECT_BASE_58 = CLASS_NAME + "#correctBase58";
 
     public static Object[][] correctBase58() {
         return new Object[][]{
@@ -389,7 +392,7 @@ public class CommonDataProvider {
     /**
      * For {@link #srcPos()}.
      */
-    public final static String DATA_PROVIDER_SRC_POS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#srcPos";
+    public final static String DATA_PROVIDER_SRC_POS = CLASS_NAME + "#srcPos";
 
     public static Object[][] srcPos() {
         return new Object[][]{
@@ -421,7 +424,7 @@ public class CommonDataProvider {
      * TODO: I don't know if this is right. It seems like it's a base58 format.
      * I've asked Blockchair and they've answered: "The addresses you listed are for internal purposes.".
      */
-    public final static String DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_CHECKSUM_INVALID = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitcoinCashAddressesChecksumInvalid";
+    public final static String DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_CHECKSUM_INVALID = CLASS_NAME + "#bitcoinCashAddressesChecksumInvalid";
 
     public static Object[][] bitcoinCashAddressesChecksumInvalid() {
         return new Object[][]{
@@ -443,7 +446,7 @@ public class CommonDataProvider {
      * TODO: I don't know if this is right. It seems like it's a hex format.
      * I've asked Blockchair and they've answered: "The addresses you listed are for internal purposes.".
      */
-    public final static String DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_INTERNAL_PURPOSE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bitcoinCashAddressesInternalPurpose";
+    public final static String DATA_PROVIDER_BITCOIN_CASH_ADDRESSES_INTERNAL_PURPOSE = CLASS_NAME + "#bitcoinCashAddressesInternalPurpose";
 
     public static Object[][] bitcoinCashAddressesInternalPurpose() {
         return new Object[][]{
@@ -458,7 +461,7 @@ public class CommonDataProvider {
     /**
      * For {@link #createSecretBaseLogged()}.
      */
-    public final static String DATA_PROVIDER_CREATE_SECRET_BASE_LOGGED = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#createSecretBaseLogged";
+    public final static String DATA_PROVIDER_CREATE_SECRET_BASE_LOGGED = CLASS_NAME + "#createSecretBaseLogged";
 
     public static Object[][] createSecretBaseLogged() {
         return new Object[][]{
@@ -479,7 +482,7 @@ public class CommonDataProvider {
     /**
      * For {@link #staticP2PKHAddresses()}.
      */
-    public final static String DATA_PROVIDER_STATIC_P2PKH_ADDRESSES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticP2PKHAddresses";
+    public final static String DATA_PROVIDER_STATIC_P2PKH_ADDRESSES = CLASS_NAME + "#staticP2PKHAddresses";
 
     public static Object[][] staticP2PKHAddresses() {
         return transformFlatToObjectArrayArray(P2PKH.values());
@@ -488,7 +491,7 @@ public class CommonDataProvider {
     /**
      * For {@link #staticP2SHAddresses()}.
      */
-    public final static String DATA_PROVIDER_STATIC_P2SH_ADDRESSES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticP2SHAddresses";
+    public final static String DATA_PROVIDER_STATIC_P2SH_ADDRESSES = CLASS_NAME + "#staticP2SHAddresses";
 
     public static Object[][] staticP2SHAddresses() {
         return transformFlatToObjectArrayArray(P2SH.values());
@@ -497,7 +500,7 @@ public class CommonDataProvider {
     /**
      * For {@link #staticP2SHAddresses()}.
      */
-    public final static String DATA_PROVIDER_STATIC_P2WPKH_ADDRESSES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticP2WPKHAddresses";
+    public final static String DATA_PROVIDER_STATIC_P2WPKH_ADDRESSES = CLASS_NAME + "#staticP2WPKHAddresses";
 
     public static Object[][] staticP2WPKHAddresses() {
         return transformFlatToObjectArrayArray(P2WPKH.values());
@@ -506,7 +509,7 @@ public class CommonDataProvider {
     /**
      * For {@link #staticUnsupportedAddresses()}.
      */
-    public final static String DATA_PROVIDER_STATIC_UNSUPPORTED_ADDRESSES = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#staticUnsupportedAddresses";
+    public final static String DATA_PROVIDER_STATIC_UNSUPPORTED_ADDRESSES = CLASS_NAME + "#staticUnsupportedAddresses";
 
     public static Object[][] staticUnsupportedAddresses() {
         return transformFlatToObjectArrayArray(StaticUnsupportedAddress.values());
@@ -524,7 +527,7 @@ public class CommonDataProvider {
      * For {@link ByteBufferUtility}.
      * Use allocate direct.
      */
-    public final static String DATA_PROVIDER_ALLOCATE_DIRECT = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#allocateDirect";
+    public final static String DATA_PROVIDER_ALLOCATE_DIRECT = CLASS_NAME + "#allocateDirect";
 
     public static Object[][] allocateDirect() {
         return new Object[][]{
@@ -539,7 +542,7 @@ public class CommonDataProvider {
      * Supplies {@code true} (Bloom filter active) and {@code false} (Bloom filter inactive),
      * to verify correctness and performance behavior in both configurations.
      */
-    public final static String DATA_PROVIDER_BLOOM_FILTER_ENABLED = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bloomFilterEnabled";
+    public final static String DATA_PROVIDER_BLOOM_FILTER_ENABLED = CLASS_NAME + "#bloomFilterEnabled";
 
     public static Object[][] bloomFilterEnabled() {
         return new Object[][]{
@@ -551,7 +554,7 @@ public class CommonDataProvider {
     /**
      * For {@link #largePrivateKeys()}.
      */
-    public final static String DATA_PROVIDER_LARGE_PRIVATE_KEYS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#largePrivateKeys";
+    public final static String DATA_PROVIDER_LARGE_PRIVATE_KEYS = CLASS_NAME + "#largePrivateKeys";
 
     public static Object[][] largePrivateKeys() {
         return new Object[][]{
@@ -646,7 +649,7 @@ public class CommonDataProvider {
     /**
      * For {@link #privateKeysTooLargeWithChunkSize()}.
      */
-    public final static String DATA_PROVIDER_PRIVATE_KEYS_TOO_LARGE_WITH_CHUNK_SIZE = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#privateKeysTooLargeWithChunkSize";
+    public final static String DATA_PROVIDER_PRIVATE_KEYS_TOO_LARGE_WITH_CHUNK_SIZE = CLASS_NAME + "#privateKeysTooLargeWithChunkSize";
 
     public static Object[][] privateKeysTooLargeWithChunkSize() {
         return new Object[][]{
@@ -658,7 +661,7 @@ public class CommonDataProvider {
     /**
      * For {@link #privateKeys32ByteRequiringStrip()}.
      */
-    public final static String DATA_PROVIDER_PRIVATE_KEYS_32_BYTE_REQUIRING_STRIP = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#privateKeys32ByteRequiringStrip";
+    public final static String DATA_PROVIDER_PRIVATE_KEYS_32_BYTE_REQUIRING_STRIP = CLASS_NAME + "#privateKeys32ByteRequiringStrip";
 
     public static Object[][] privateKeys32ByteRequiringStrip() {
         return new Object[][]{
@@ -673,7 +676,7 @@ public class CommonDataProvider {
     /**
      * For {@link #bigIntegerVariants()}.
      */
-    public final static String DATA_PROVIDER_BIG_INTEGER_VARIANTS = "net.ladenthin.bitcoinaddressfinder.CommonDataProvider#bigIntegerVariants";
+    public final static String DATA_PROVIDER_BIG_INTEGER_VARIANTS = CLASS_NAME + "#bigIntegerVariants";
 
     public static Object[][] bigIntegerVariants() {
         return new Object[][] {

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ConsumerJavaTest.java
@@ -233,6 +233,7 @@ public class ConsumerJavaTest {
         // assert
         Persistence persistence = Objects.requireNonNull(consumerJava.persistence);
         assertThat(persistence.isClosed(), is(equalTo(Boolean.FALSE)));
+        consumerJava.interrupt();
     }
     
     @Test
@@ -315,6 +316,7 @@ public class ConsumerJavaTest {
         
         String hitMessageFull = ConsumerJava.HIT_PREFIX + keyUtility.createKeyDetails(key);
         assertThat(arguments.get(5), is(equalTo(hitMessageFull)));
+        consumerJava.interrupt();
     }
 
     @ParameterizedTest
@@ -377,6 +379,7 @@ public class ConsumerJavaTest {
         // assert for expected miss messages
         assertThat(argumentsTrace.get(7), is(equalTo(missMessageUncompressed)));
         assertThat(argumentsTrace.get(8), is(equalTo(missMessageCompressed)));
+        consumerJava.interrupt();
     }
 
     @Test
@@ -400,8 +403,9 @@ public class ConsumerJavaTest {
         PublicKeyBytes[] publicKeyBytesArray = new PublicKeyBytes[]{invalidPublicKeyBytes};
         consumerJava.consumeKeys(publicKeyBytesArray);
         consumerJava.consumeKeys(createHash160ByteBuffer());
+        consumerJava.interrupt();
     }
-    
+
     @ParameterizedTest
     @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED)
     public void consumeKeys_withRuntimeKeyCalculationEnabled_logsError_whenPublicKeyHashIsInvalid(boolean compressed) throws IOException, InterruptedException, DecoderException, MnemonicException.MnemonicLengthException {
@@ -454,8 +458,9 @@ public class ConsumerJavaTest {
             assertThat(arguments.get(4), is(equalTo("hash160Uncompressed: 1a69285cb42032d77801a15a30357d510b247100")));
             assertThat(arguments.get(5), is(equalTo("hash160UncompressedFromEcKey: e02e1cae178d3a2f84a5d897ee8b7ed6c0e2bbc4")));
         }
+        consumerJava.interrupt();
     }
-    
+
     @ParameterizedTest
     @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED)
     public void consumeKeys_testVanityPattern_patternMatches(boolean compressed) throws IOException, InterruptedException, DecoderException, MnemonicException.MnemonicLengthException {
@@ -546,6 +551,7 @@ public class ConsumerJavaTest {
         
         String expectedMessage = "vanity pattern match: privateKeyBigInteger: [73] privateKeyBytes: ["+privateKeyBytes+"] privateKeyHex: ["+privateKeyHex+"] WiF: [" + wif +"] publicKeyAsHex: ["+publicKeyAsHex+"] publicKeyHash160Hex: ["+publicKeyHash160Hex+"] publicKeyHash160Base58: ["+publicKeyHash160Base58+"] Compressed: ["+compressed+"] "+ mnemonics;
         assertThat(arguments.get(5), is(equalTo(expectedMessage)));
+        consumerJava.interrupt();
     }
 
 
@@ -563,13 +569,18 @@ public class ConsumerJavaTest {
         consumerJava.initLMDB();
 
         // Mock the persistence to throw an exception on close
+        Persistence realPersistence = Objects.requireNonNull(consumerJava.persistence);
         Persistence mockPersistence = mock(Persistence.class);
         when(mockPersistence.isClosed()).thenReturn(false);
         doThrow(new RuntimeException("Simulated close failure")).when(mockPersistence).close();
         consumerJava.persistence = mockPersistence;
 
         // act - should throw RuntimeException
-        assertThrows(RuntimeException.class, () -> consumerJava.interrupt());
+        try {
+            assertThrows(RuntimeException.class, () -> consumerJava.interrupt());
+        } finally {
+            realPersistence.close();
+        }
     }
 
     private ByteBuffer createHash160ByteBuffer() {

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ConsumerJavaTest.java
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.File;
+import java.nio.file.Files;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -32,18 +31,18 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.mockito.Mockito.*;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 
-@RunWith(DataProviderRunner.class)
 public class ConsumerJavaTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
     
     private final Network network = new NetworkParameterFactory().getNetwork();
     private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
@@ -60,11 +59,11 @@ public class ConsumerJavaTest {
         return publicKeyBytesArray;
     }
 
-    @Test(expected = org.lmdbjava.LmdbNativeException.class)
+    @Test
     public void initLMDB_lmdbNotExisting_noExceptionThrown() throws IOException {
         CConsumerJava cConsumerJava = new CConsumerJava();
         cConsumerJava.lmdbConfigurationReadOnly = new CLMDBConfigurationReadOnly();
-        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = folder.newFolder().getAbsolutePath();
+        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = Files.createTempDirectory(folder, "junit").toFile().getAbsolutePath();
 
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
         consumerJava.initLMDB();
@@ -77,7 +76,7 @@ public class ConsumerJavaTest {
     public void toString_whenCalled_containsClassNameAndIdentityHash() throws IOException {
         CConsumerJava cConsumerJava = new CConsumerJava();
         cConsumerJava.lmdbConfigurationReadOnly = new CLMDBConfigurationReadOnly();
-        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = folder.newFolder().getAbsolutePath();
+        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = Files.createTempDirectory(folder, "junit").toFile().getAbsolutePath();
 
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
 
@@ -121,7 +120,7 @@ public class ConsumerJavaTest {
         assertThat(arguments.get(0), is(equalTo("Statistics: [Checked 0 M keys in 0 minutes] [0 k keys/second] [0 M keys/minute] [Times an empty consumer: 0] [Average contains time: 0 ms] [keys queue size: 0] [Hits: 0]")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void startStatisticsTimer_invalidparameter_throwsException() throws IOException {
         CConsumerJava cConsumerJava = new CConsumerJava();
         cConsumerJava.printStatisticsEveryNSeconds = 0;
@@ -259,8 +258,8 @@ public class ConsumerJavaTest {
         assertThat(persistence.isClosed(), is(equalTo(Boolean.TRUE)));
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT)
     public void runProber_testAddressGiven_hitExpected(boolean compressed, boolean useStaticAmount) throws Exception {
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(compressed);
@@ -317,8 +316,8 @@ public class ConsumerJavaTest {
         assertThat(arguments.get(5), is(equalTo(hitMessageFull)));
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT)
     public void runProber_unknownAddressGiven_missExpectedAndLogMessagesInDebugAndTrace(boolean compressed, boolean useStaticAmount) throws Exception {
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(compressed);
@@ -402,8 +401,8 @@ public class ConsumerJavaTest {
         consumerJava.consumeKeys(createHash160ByteBuffer());
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_COMPRESSED, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED)
     public void consumeKeys_withRuntimeKeyCalculationEnabled_logsError_whenPublicKeyHashIsInvalid(boolean compressed) throws IOException, InterruptedException, DecoderException, MnemonicException.MnemonicLengthException {
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(false);
@@ -456,8 +455,8 @@ public class ConsumerJavaTest {
         }
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_COMPRESSED, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED)
     public void consumeKeys_testVanityPattern_patternMatches(boolean compressed) throws IOException, InterruptedException, DecoderException, MnemonicException.MnemonicLengthException {
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(false);
@@ -549,7 +548,7 @@ public class ConsumerJavaTest {
     }
 
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void interrupt_persistenceCloseThrowsException_runtimeExceptionThrown() throws Exception {
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(false);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ConsumerJavaTest.java
@@ -27,6 +27,7 @@ import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.crypto.MnemonicException;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.mockito.Mockito.*;
@@ -66,10 +67,10 @@ public class ConsumerJavaTest {
         cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = Files.createTempDirectory(folder, "junit").toFile().getAbsolutePath();
 
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
-        consumerJava.initLMDB();
+        assertThrows(org.lmdbjava.LmdbNativeException.class, () -> consumerJava.initLMDB());
     }
-    
-    
+
+
     // <editor-fold defaultstate="collapsed" desc="toString">
     @ToStringTest
     @Test
@@ -126,9 +127,9 @@ public class ConsumerJavaTest {
         cConsumerJava.printStatisticsEveryNSeconds = 0;
 
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
-        consumerJava.startStatisticsTimer();
+        assertThrows(IllegalArgumentException.class, () -> consumerJava.startStatisticsTimer());
     }
-    
+
     @AwaitTimeTest
     @Test
     public void interrupt_keysQueueNotEmpty_consumerNotRunningWaitedInternallyForTheDuration() throws IOException, InterruptedException, MnemonicException.MnemonicLengthException {
@@ -568,7 +569,7 @@ public class ConsumerJavaTest {
         consumerJava.persistence = mockPersistence;
 
         // act - should throw RuntimeException
-        consumerJava.interrupt();
+        assertThrows(RuntimeException.class, () -> consumerJava.interrupt());
     }
 
     private ByteBuffer createHash160ByteBuffer() {

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/EndiannessConverterTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/EndiannessConverterTest.java
@@ -3,25 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import static org.mockito.Mockito.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.nio.ByteOrder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(DataProviderRunner.class)
 public class EndiannessConverterTest {
 
     private final ByteBufferUtility byteBufferUtility = mock(ByteBufferUtility.class);
 
     // <editor-fold defaultstate="collapsed" desc="mustConvert">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ENDIANNESS, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ENDIANNESS)
     public void mustConvertTest(ByteOrder sourceOrder, ByteOrder targetOrder, boolean expectedMustConvert) {
         // arrange
         EndiannessConverter converter = new EndiannessConverter(sourceOrder, targetOrder, byteBufferUtility);
@@ -35,8 +33,8 @@ public class EndiannessConverterTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="convertEndian">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ENDIANNESS, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ENDIANNESS)
     public void convertEndianTest(ByteOrder sourceOrder, ByteOrder targetOrder, boolean mustConvert) {
         // arrange
         EndiannessConverter converter = new EndiannessConverter(sourceOrder, targetOrder, byteBufferUtility);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/EqualHashCodeToStringTestHelper.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/EqualHashCodeToStringTestHelper.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -69,12 +69,12 @@ public class EqualHashCodeToStringTestHelper {
     }
 
     private void assertDifferenceReference() {
-        Assert.assertNotSame(instanceA, instanceADifferentReference);
-        Assert.assertNotSame(instanceA, instanceB);
-        Assert.assertNotSame(instanceA, instanceBDifferentReference);
+        Assertions.assertNotSame(instanceA, instanceADifferentReference);
+        Assertions.assertNotSame(instanceA, instanceB);
+        Assertions.assertNotSame(instanceA, instanceBDifferentReference);
 
-        Assert.assertNotSame(instanceB, instanceBDifferentReference);
-        Assert.assertNotSame(instanceB, instanceA);
-        Assert.assertNotSame(instanceB, instanceADifferentReference);
+        Assertions.assertNotSame(instanceB, instanceBDifferentReference);
+        Assertions.assertNotSame(instanceB, instanceA);
+        Assertions.assertNotSame(instanceB, instanceADifferentReference);
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/FileHelperTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/FileHelperTest.java
@@ -14,15 +14,16 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import java.nio.file.Files;
 
 public class FileHelperTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
 
     private final FileHelper fileHelper = new FileHelper();
 
@@ -77,7 +78,7 @@ public class FileHelperTest {
     @Test
     public void assertFilesExists_existingFile_noExceptionThrown() throws IOException {
         // arrange
-        File tempFile = folder.newFile("filehelper_test.tmp");
+        File tempFile = Files.createFile(folder.resolve("filehelper_test.tmp")).toFile();
 
         // act
         fileHelper.assertFilesExists(Collections.singletonList(tempFile));
@@ -88,8 +89,8 @@ public class FileHelperTest {
     @Test
     public void assertFilesExists_multipleExistingFiles_noExceptionThrown() throws IOException {
         // arrange
-        File tempFile1 = folder.newFile("filehelper_test_a.tmp");
-        File tempFile2 = folder.newFile("filehelper_test_b.tmp");
+        File tempFile1 = Files.createFile(folder.resolve("filehelper_test_a.tmp")).toFile();
+        File tempFile2 = Files.createFile(folder.resolve("filehelper_test_b.tmp")).toFile();
 
         // act
         fileHelper.assertFilesExists(Arrays.asList(tempFile1, tempFile2));
@@ -97,7 +98,7 @@ public class FileHelperTest {
         // assert
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertFilesExists_missingFile_throwsIllegalArgumentException() {
         // arrange
         File nonExistentFile = new File("/this/path/does/not/exist/file.txt");

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/FileHelperTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/FileHelperTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -104,7 +105,7 @@ public class FileHelperTest {
         File nonExistentFile = new File("/this/path/does/not/exist/file.txt");
 
         // act
-        fileHelper.assertFilesExists(Collections.singletonList(nonExistentFile));
+        assertThrows(IllegalArgumentException.class, () -> fileHelper.assertFilesExists(Collections.singletonList(nonExistentFile)));
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/FinderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/FinderTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -197,9 +198,9 @@ public class FinderTest {
         configureConsumerJava(cFinder);
         Finder finder = new Finder(cFinder);
         // act
-        finder.startKeyProducer();
+        assertThrows(KeyProducerIdNullException.class, () -> finder.startKeyProducer());
     }
-    
+
     @Test
     public void startKeyProducer_keyProducerIdIsNotUnique_ExceptionThrown() throws IOException, InterruptedException {
         // arrange
@@ -207,11 +208,11 @@ public class FinderTest {
         String sameIdTwice = "123";
         configureKeyProducerJavaRandom(sameIdTwice, cFinder);
         configureKeyProducerJavaRandom(sameIdTwice, cFinder);
-        
+
         configureConsumerJava(cFinder);
         Finder finder = new Finder(cFinder);
         // act
-        finder.startKeyProducer();
+        assertThrows(KeyProducerIdIsNotUniqueException.class, () -> finder.startKeyProducer());
     }
     // </editor-fold>
 
@@ -232,9 +233,9 @@ public class FinderTest {
 
         finder.startConsumer();
         finder.startKeyProducer();
-        
+
         // act
-        finder.configureProducer();
+        assertThrows(KeyProducerIdUnknownException.class, () -> finder.configureProducer());
     }
     // </editor-fold>
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/FinderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/FinderTest.java
@@ -3,14 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.File;
+import java.nio.file.Files;
 
 import org.jspecify.annotations.Nullable;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -38,14 +39,12 @@ import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaSocketTest;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaZmqTest;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesFiles;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesLMDB;
-import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 
-@RunWith(DataProviderRunner.class)
 public class FinderTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
 
     // <editor-fold defaultstate="collapsed" desc="interrupt">
     @Test
@@ -189,7 +188,7 @@ public class FinderTest {
     // </editor-fold>
     
     // <editor-fold defaultstate="collapsed" desc="startKeyProducer">
-    @Test(expected = KeyProducerIdNullException.class)
+    @Test
     public void startKeyProducer_keyProducerIdIsNull_ExceptionThrown() throws IOException, InterruptedException {
         // arrange
         CFinder cFinder = new CFinder();
@@ -201,7 +200,7 @@ public class FinderTest {
         finder.startKeyProducer();
     }
     
-    @Test(expected = KeyProducerIdIsNotUniqueException.class)
+    @Test
     public void startKeyProducer_keyProducerIdIsNotUnique_ExceptionThrown() throws IOException, InterruptedException {
         // arrange
         CFinder cFinder = new CFinder();
@@ -217,7 +216,7 @@ public class FinderTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="configureProducer">
-    @Test(expected = KeyProducerIdUnknownException.class)
+    @Test
     public void configureProducer_keyProducerIdIsUnknown_ExceptionThrown() throws IOException, InterruptedException {
         // arrange
         CFinder cFinder = new CFinder();
@@ -240,8 +239,8 @@ public class FinderTest {
     // </editor-fold>
     
     // <editor-fold defaultstate="collapsed" desc="testFullCycle">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_KEY_PRODUCER_TYPES, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_KEY_PRODUCER_TYPES)
     public void testFullCycle_keyProducerJavaSetAndInitialized_statesCorrect(CommonDataProvider.KeyProducerTypesLocal keyProducerType) throws IOException, InterruptedException {
         // arrange
         CFinder cFinder = new CFinder();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/FinderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/FinderTest.java
@@ -70,9 +70,10 @@ public class FinderTest {
         finder.configureProducer();
         // act
         finder.interrupt();
+        finder.shutdownAndAwaitTermination();
         // assert
     }
-    
+
     @Test
     public void interrupt_consumerStarted_consumerNotStopped() throws IOException {
         // arrange
@@ -86,6 +87,7 @@ public class FinderTest {
         finder.startConsumer();
         // act
         finder.interrupt();
+        finder.shutdownAndAwaitTermination();
         // assert
     }
     // </editor-fold>
@@ -185,6 +187,8 @@ public class FinderTest {
         List<Producer> allProducers = finder.getAllProducers();
         // assert
         assertThat(allProducers, hasSize(3));
+        finder.interrupt();
+        finder.shutdownAndAwaitTermination();
     }
     // </editor-fold>
     
@@ -236,6 +240,7 @@ public class FinderTest {
 
         // act
         assertThrows(KeyProducerIdUnknownException.class, () -> finder.configureProducer());
+        finder.shutdownAndAwaitTermination();
     }
     // </editor-fold>
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/HexEncodeTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/HexEncodeTest.java
@@ -6,7 +6,7 @@ package net.ladenthin.bitcoinaddressfinder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HexEncodeTest {
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/KeyUtilityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/KeyUtilityTest.java
@@ -8,21 +8,19 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.NoMoreSecretsAvailableException;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.StaticKey;
 import org.bitcoinj.base.LegacyAddress;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.crypto.MnemonicException;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-@RunWith(DataProviderRunner.class)
 public class KeyUtilityTest {
 
     private final StaticKey staticKey = new StaticKey();
@@ -224,15 +222,15 @@ public class KeyUtilityTest {
         assertThat(ecKey.getPrivKey(), is(equalTo(randomValidKey)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ecKey_fromPrivate_minPrivateKey_throwsException() {
         // act
         ECKey.fromPrivate(PublicKeyBytes.MIN_PRIVATE_KEY, false);
     }
 
-    @Ignore("bitcoinj.ECKey.fromPrivate(...) accepts values > MAX_PRIVATE_KEY without throwing an exception. " +
+    @Disabled("bitcoinj.ECKey.fromPrivate(...) accepts values > MAX_PRIVATE_KEY without throwing an exception. " +
        "Test ignored because the library does not enforce the upper bound.")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ecKey_fromPrivate_maxPrivateKeyPlusOne_throwsException() {
         // act
         ECKey.fromPrivate(PublicKeyBytes.MAX_PRIVATE_KEY.add(BigInteger.ONE), false);
@@ -555,7 +553,7 @@ public class KeyUtilityTest {
         assertThat(Arrays.asList(secrets), everyItem(is(notNullValue())));
     }
 
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_zeroLength_throwsException() throws NoMoreSecretsAvailableException {
         // arrange
         KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
@@ -576,8 +574,8 @@ public class KeyUtilityTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="bigIntegerToFixedLengthHex">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_LARGE_SECRETS_AS_HEX, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_LARGE_SECRETS_AS_HEX)
     public void bigIntegerToFixedLengthHex_knownBigInteger_correctHex(String largeSecretsAsHex) {
         // arrange
         BigInteger input = new BigInteger(largeSecretsAsHex, 16);
@@ -608,7 +606,7 @@ public class KeyUtilityTest {
         assertThat(result, is(equalTo(expected)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void bigIntegerFromUnsignedByteArray_wrongLength_throwsException() {
         // arrange
         KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/KeyUtilityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/KeyUtilityTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.*;
 
 public class KeyUtilityTest {
@@ -225,7 +226,7 @@ public class KeyUtilityTest {
     @Test
     public void ecKey_fromPrivate_minPrivateKey_throwsException() {
         // act
-        ECKey.fromPrivate(PublicKeyBytes.MIN_PRIVATE_KEY, false);
+        assertThrows(IllegalArgumentException.class, () -> ECKey.fromPrivate(PublicKeyBytes.MIN_PRIVATE_KEY, false));
     }
 
     @Disabled("bitcoinj.ECKey.fromPrivate(...) accepts values > MAX_PRIVATE_KEY without throwing an exception. " +
@@ -569,7 +570,7 @@ public class KeyUtilityTest {
         boolean returnStartSecretOnly = false;
 
         // act
-        keyUtility.createSecrets(overallWorkSize, returnStartSecretOnly, privateKeyMaxNumBits, randomSupplier);
+        assertThrows(NoMoreSecretsAvailableException.class, () -> keyUtility.createSecrets(overallWorkSize, returnStartSecretOnly, privateKeyMaxNumBits, randomSupplier));
     }
     // </editor-fold>
 
@@ -613,7 +614,7 @@ public class KeyUtilityTest {
         byte[] invalid = new byte[31];
 
         // act
-        keyUtility.bigIntegerFromUnsignedByteArray(invalid);
+        assertThrows(IllegalArgumentException.class, () -> keyUtility.bigIntegerFromUnsignedByteArray(invalid));
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBBase.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBBase.java
@@ -5,6 +5,7 @@ package net.ladenthin.bitcoinaddressfinder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import net.ladenthin.bitcoinaddressfinder.configuration.CLMDBConfigurationReadOnly;
 import net.ladenthin.bitcoinaddressfinder.persistence.Persistence;
 import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
@@ -12,13 +13,12 @@ import net.ladenthin.bitcoinaddressfinder.persistence.lmdb.LMDBPersistence;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.AddressesFiles;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesLMDB;
 import org.bitcoinj.base.Network;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LMDBBase {
-    
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+
+    @TempDir
+    public Path folder;
     
     protected final Network network = new NetworkParameterFactory().getNetwork();
     protected final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(true));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPersistencePerformanceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPersistencePerformanceTest.java
@@ -4,8 +4,6 @@
 package net.ladenthin.bitcoinaddressfinder;
 
 import ch.qos.logback.classic.Level;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -18,20 +16,20 @@ import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesFiles;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesLMDB;
 import org.bitcoinj.base.Network;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-@RunWith(DataProviderRunner.class)
 public class LMDBPersistencePerformanceTest {
     
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
     
     private final Network network = new NetworkParameterFactory().getNetwork();
     private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
@@ -45,8 +43,8 @@ public class LMDBPersistencePerformanceTest {
     private final static int KEYS_QUEUE_SIZE = CONSUMER_THREADS*2;
     private final static int PRODUCER_THREADS = KEYS_QUEUE_SIZE;
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BLOOM_FILTER_ENABLED, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BLOOM_FILTER_ENABLED)
     public void runProber_performanceTest(boolean useBloomFilter) throws IOException, InterruptedException, IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
         new LMDBPlatformAssume().assumeLMDBExecution();
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPersistenceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPersistenceTest.java
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.File;
+import java.nio.file.Files;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -16,19 +15,19 @@ import net.ladenthin.bitcoinaddressfinder.persistence.lmdb.LMDBPersistence;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.crypto.ECKey;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
 
-@RunWith(DataProviderRunner.class)
 public class LMDBPersistenceTest {
     
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
     
     private final Random random = new Random(1337);
     
@@ -49,11 +48,11 @@ public class LMDBPersistenceTest {
     
     
     // <editor-fold defaultstate="collapsed" desc="use static amount">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_LMDB_AMOUNTS, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_LMDB_AMOUNTS)
     public void putNewAmount_putNewAmount_correctAmountStored(boolean useStaticAmount, long staticAmount, long amount, long expectedAmount) throws IOException {
         // arrange
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
         
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
@@ -83,7 +82,7 @@ public class LMDBPersistenceTest {
     @Test
     public void getDatabaseSize_initialLMDBSetTo1MiB_returnInitialDatabaseSize() throws IOException {
         // arrange
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
         
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
@@ -103,7 +102,7 @@ public class LMDBPersistenceTest {
     public void getDatabaseSize_valuesAdded_returnInitialDatabaseSize() throws IOException {
         // arrange
         int keysToAdd = 1024*16;
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
         
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
@@ -123,11 +122,11 @@ public class LMDBPersistenceTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="getDatabaseSize increaseDatabaseSize and filled">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_LMDB_INCREASE_SIZE, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_LMDB_INCREASE_SIZE)
     public void getDatabaseSize_initialLMDBSetTo1MiB_increaseDatabaseSize_returnResizedDatabaseSize(long increaseSize) throws IOException {
         // arrange
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
         
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
@@ -144,12 +143,12 @@ public class LMDBPersistenceTest {
         assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L)+increaseSize)));
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_LMDB_INCREASE_SIZE, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_LMDB_INCREASE_SIZE)
     public void getDatabaseSize_valuesAdded_increaseDatabaseSize_returnResizedDatabaseSize(long increaseSize) throws IOException {
         // arrange
         int keysToAdd = 1024*16;
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
         
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
@@ -170,10 +169,10 @@ public class LMDBPersistenceTest {
     // </editor-fold>
     
     // <editor-fold defaultstate="collapsed" desc="increaseDatabaseSize">
-    @Test(expected = org.lmdbjava.Env.MapFullException.class)
+    @Test
     public void putNewAmount_initialLMDBSetTo1MiB_fillWithTooMuchValues_exceptionThrown() throws IOException {
         // arrange
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
         
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
@@ -196,7 +195,7 @@ public class LMDBPersistenceTest {
     @Test
     public void putNewAmount_initialLMDBSetTo1MiB_fillWithTooMuchValues_increaseDatabaseSizeAndNoExceptionThrown() throws IOException {
         // arrange
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
 
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPersistenceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPersistenceTest.java
@@ -54,28 +54,29 @@ public class LMDBPersistenceTest {
     public void putNewAmount_putNewAmount_correctAmountStored(boolean useStaticAmount, long staticAmount, long amount, long expectedAmount) throws IOException {
         // arrange
         File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
-        
+
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
         cLMDBConfigurationWrite.lmdbDirectory = lmdbFolder.getAbsolutePath();
         cLMDBConfigurationWrite.useStaticAmount = useStaticAmount;
         cLMDBConfigurationWrite.staticAmount = staticAmount;
-        
-        LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils);
-        lmdbPersistence.init();
-        
-        // create key
-        BigInteger secret = keyUtility.createSecret(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS, random);
-        ECKey ecKey = keyUtility.createECKey(secret, true);
-        byte[] hash160 = ecKey.getPubKeyHash();
-        ByteBuffer hash160ByteBuffer = byteBufferUtility.byteArrayToByteBuffer(hash160);
-        
-        // act
-        lmdbPersistence.putNewAmount(hash160ByteBuffer, Coin.valueOf(amount));
-        
-        // assert
-        Coin amountInLmdb = lmdbPersistence.getAmount(hash160ByteBuffer);
-        assertThat(amountInLmdb.getValue(), is(equalTo(expectedAmount)));
+
+        try (LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils)) {
+            lmdbPersistence.init();
+
+            // create key
+            BigInteger secret = keyUtility.createSecret(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS, random);
+            ECKey ecKey = keyUtility.createECKey(secret, true);
+            byte[] hash160 = ecKey.getPubKeyHash();
+            ByteBuffer hash160ByteBuffer = byteBufferUtility.byteArrayToByteBuffer(hash160);
+
+            // act
+            lmdbPersistence.putNewAmount(hash160ByteBuffer, Coin.valueOf(amount));
+
+            // assert
+            Coin amountInLmdb = lmdbPersistence.getAmount(hash160ByteBuffer);
+            assertThat(amountInLmdb.getValue(), is(equalTo(expectedAmount)));
+        }
     }
     // </editor-fold>
 
@@ -84,19 +85,20 @@ public class LMDBPersistenceTest {
     public void getDatabaseSize_initialLMDBSetTo1MiB_returnInitialDatabaseSize() throws IOException {
         // arrange
         File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
-        
+
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
         cLMDBConfigurationWrite.lmdbDirectory = lmdbFolder.getAbsolutePath();
-        
-        LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils);
-        lmdbPersistence.init();
-        
-        // act
-        long databaseSize = lmdbPersistence.getDatabaseSize();
-        
-        // assert
-        assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L))));
+
+        try (LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils)) {
+            lmdbPersistence.init();
+
+            // act
+            long databaseSize = lmdbPersistence.getDatabaseSize();
+
+            // assert
+            assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L))));
+        }
     }
     
     @Test
@@ -104,21 +106,22 @@ public class LMDBPersistenceTest {
         // arrange
         int keysToAdd = 1024*16;
         File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
-        
+
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
         cLMDBConfigurationWrite.lmdbDirectory = lmdbFolder.getAbsolutePath();
-        
-        LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils);
-        lmdbPersistence.init();
-        
-        fillWithRandomKeys(keysToAdd, lmdbPersistence);
-        
-        // act
-        long databaseSize = lmdbPersistence.getDatabaseSize();
-        
-        // assert
-        assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L))));
+
+        try (LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils)) {
+            lmdbPersistence.init();
+
+            fillWithRandomKeys(keysToAdd, lmdbPersistence);
+
+            // act
+            long databaseSize = lmdbPersistence.getDatabaseSize();
+
+            // assert
+            assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L))));
+        }
     }
     // </editor-fold>
 
@@ -128,20 +131,21 @@ public class LMDBPersistenceTest {
     public void getDatabaseSize_initialLMDBSetTo1MiB_increaseDatabaseSize_returnResizedDatabaseSize(long increaseSize) throws IOException {
         // arrange
         File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
-        
+
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
         cLMDBConfigurationWrite.lmdbDirectory = lmdbFolder.getAbsolutePath();
-        
-        LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils);
-        lmdbPersistence.init();
-        
-        // act
-        lmdbPersistence.increaseDatabaseSize(increaseSize);
-        
-        // assert
-        long databaseSize = lmdbPersistence.getDatabaseSize();
-        assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L)+increaseSize)));
+
+        try (LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils)) {
+            lmdbPersistence.init();
+
+            // act
+            lmdbPersistence.increaseDatabaseSize(increaseSize);
+
+            // assert
+            long databaseSize = lmdbPersistence.getDatabaseSize();
+            assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L)+increaseSize)));
+        }
     }
     
     @ParameterizedTest
@@ -150,22 +154,23 @@ public class LMDBPersistenceTest {
         // arrange
         int keysToAdd = 1024*16;
         File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
-        
+
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
         cLMDBConfigurationWrite.lmdbDirectory = lmdbFolder.getAbsolutePath();
-        
-        LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils);
-        lmdbPersistence.init();
-        
-        fillWithRandomKeys(keysToAdd, lmdbPersistence);
-        
-        // act
-        lmdbPersistence.increaseDatabaseSize(increaseSize);
-        
-        // assert
-        long databaseSize = lmdbPersistence.getDatabaseSize();
-        assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L)+increaseSize)));
+
+        try (LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils)) {
+            lmdbPersistence.init();
+
+            fillWithRandomKeys(keysToAdd, lmdbPersistence);
+
+            // act
+            lmdbPersistence.increaseDatabaseSize(increaseSize);
+
+            // assert
+            long databaseSize = lmdbPersistence.getDatabaseSize();
+            assertThat(databaseSize, is(equalTo(new ByteConversion().mibToBytes(1L)+increaseSize)));
+        }
     }
     // </editor-fold>
     
@@ -174,23 +179,24 @@ public class LMDBPersistenceTest {
     public void putNewAmount_initialLMDBSetTo1MiB_fillWithTooMuchValues_exceptionThrown() throws IOException {
         // arrange
         File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
-        
+
         CLMDBConfigurationWrite cLMDBConfigurationWrite = new CLMDBConfigurationWrite();
         cLMDBConfigurationWrite.initialMapSizeInMiB = 1;
         cLMDBConfigurationWrite.lmdbDirectory = lmdbFolder.getAbsolutePath();
         cLMDBConfigurationWrite.increaseMapAutomatically = false;
         cLMDBConfigurationWrite.increaseSizeInMiB = 1;
-        
-        LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils);
-        lmdbPersistence.init();
-        
-        // pre assert
-        assertThat(lmdbPersistence.getDatabaseSize(), is(equalTo(new ByteConversion().mibToBytes(1L))));
-        assertThat(lmdbPersistence.getIncreasedCounter(), is(equalTo(new ByteConversion().mibToBytes(0L))));
-        assertThat(lmdbPersistence.getIncreasedSum(), is(equalTo(new ByteConversion().mibToBytes(0L))));
-        
-        // act, assert
-        assertThrows(org.lmdbjava.Env.MapFullException.class, () -> fillWithRandomKeys(TOO_MUCH_KEYS_FOR_1MiB, lmdbPersistence));
+
+        try (LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils)) {
+            lmdbPersistence.init();
+
+            // pre assert
+            assertThat(lmdbPersistence.getDatabaseSize(), is(equalTo(new ByteConversion().mibToBytes(1L))));
+            assertThat(lmdbPersistence.getIncreasedCounter(), is(equalTo(new ByteConversion().mibToBytes(0L))));
+            assertThat(lmdbPersistence.getIncreasedSum(), is(equalTo(new ByteConversion().mibToBytes(0L))));
+
+            // act, assert
+            assertThrows(org.lmdbjava.Env.MapFullException.class, () -> fillWithRandomKeys(TOO_MUCH_KEYS_FOR_1MiB, lmdbPersistence));
+        }
     }
 
     @Test
@@ -204,21 +210,22 @@ public class LMDBPersistenceTest {
         cLMDBConfigurationWrite.increaseMapAutomatically = true;
         cLMDBConfigurationWrite.increaseSizeInMiB = 1;
 
-        LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils);
-        lmdbPersistence.init();
+        try (LMDBPersistence lmdbPersistence = new LMDBPersistence(cLMDBConfigurationWrite, persistenceUtils)) {
+            lmdbPersistence.init();
 
-        // pre assert
-        assertThat(lmdbPersistence.getDatabaseSize(), is(equalTo(new ByteConversion().mibToBytes(1L))));
-        assertThat(lmdbPersistence.getIncreasedCounter(), is(equalTo(new ByteConversion().mibToBytes(0L))));
-        assertThat(lmdbPersistence.getIncreasedSum(), is(equalTo(new ByteConversion().mibToBytes(0L))));
+            // pre assert
+            assertThat(lmdbPersistence.getDatabaseSize(), is(equalTo(new ByteConversion().mibToBytes(1L))));
+            assertThat(lmdbPersistence.getIncreasedCounter(), is(equalTo(new ByteConversion().mibToBytes(0L))));
+            assertThat(lmdbPersistence.getIncreasedSum(), is(equalTo(new ByteConversion().mibToBytes(0L))));
 
-        // act
-        fillWithRandomKeys(TOO_MUCH_KEYS_FOR_1MiB, lmdbPersistence);
+            // act
+            fillWithRandomKeys(TOO_MUCH_KEYS_FOR_1MiB, lmdbPersistence);
 
-        // post assert
-        assertThat(lmdbPersistence.getDatabaseSize(), is(equalTo(new ByteConversion().mibToBytes(1L) + (new ByteConversion().mibToBytes(cLMDBConfigurationWrite.increaseSizeInMiB)) * TOO_MUCH_KEYS_EXPECTED_1MiB_INCREASES)));
-        assertThat(lmdbPersistence.getIncreasedCounter(), is(equalTo((long) TOO_MUCH_KEYS_EXPECTED_1MiB_INCREASES)));
-        assertThat(lmdbPersistence.getIncreasedSum(), is(equalTo(new ByteConversion().mibToBytes(cLMDBConfigurationWrite.increaseSizeInMiB * TOO_MUCH_KEYS_EXPECTED_1MiB_INCREASES))));
+            // post assert
+            assertThat(lmdbPersistence.getDatabaseSize(), is(equalTo(new ByteConversion().mibToBytes(1L) + (new ByteConversion().mibToBytes(cLMDBConfigurationWrite.increaseSizeInMiB)) * TOO_MUCH_KEYS_EXPECTED_1MiB_INCREASES)));
+            assertThat(lmdbPersistence.getIncreasedCounter(), is(equalTo((long) TOO_MUCH_KEYS_EXPECTED_1MiB_INCREASES)));
+            assertThat(lmdbPersistence.getIncreasedSum(), is(equalTo(new ByteConversion().mibToBytes(cLMDBConfigurationWrite.increaseSizeInMiB * TOO_MUCH_KEYS_EXPECTED_1MiB_INCREASES))));
+        }
     }
     // </editor-fold>
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPersistenceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPersistenceTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
 
@@ -189,7 +190,7 @@ public class LMDBPersistenceTest {
         assertThat(lmdbPersistence.getIncreasedSum(), is(equalTo(new ByteConversion().mibToBytes(0L))));
         
         // act, assert
-        fillWithRandomKeys(TOO_MUCH_KEYS_FOR_1MiB, lmdbPersistence);
+        assertThrows(org.lmdbjava.Env.MapFullException.class, () -> fillWithRandomKeys(TOO_MUCH_KEYS_FOR_1MiB, lmdbPersistence));
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPlatformAssume.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBPlatformAssume.java
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import static java.lang.Boolean.FALSE;
-import static org.hamcrest.Matchers.is;
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 
 /**
  * Platform assumption for conditionally running LMDB tests.
@@ -16,6 +14,6 @@ public class LMDBPlatformAssume implements PlatformAssume {
     public void assumeLMDBExecution() {
         // If the system property is set, disable LMDB tests
         boolean disableLMDB = Boolean.getBoolean("net.ladenthin.bitcoinaddressfinder.disableLMDBTest");
-        Assume.assumeThat("LMDB tests are disabled via -DdisableLMDBTest", disableLMDB, is(FALSE));
+        Assumptions.assumeFalse(disableLMDB, "LMDB tests are disabled via -DdisableLMDBTest");
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBToAddressFileTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBToAddressFileTest.java
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -19,26 +17,27 @@ import org.apache.commons.io.FileUtils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.nio.file.Files;
 
-@RunWith(DataProviderRunner.class)
 public class LMDBToAddressFileTest extends LMDBBase {
 
-    @Before
+    @BeforeEach
     public void init() throws IOException {
     }
 
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT)
     public void writeAllAmountsToAddressFileAsDynamicWidthBase58BitcoinAddressWithAmount(boolean compressed, boolean useStaticAmount) throws Exception {
         // arrange
         AtomicBoolean shouldRun = new AtomicBoolean(true);
         TestAddressesFiles testAddressesFiles = new TestAddressesFiles(compressed);
         try (Persistence persistence = createAndFillAndOpenLMDB(useStaticAmount, testAddressesFiles, false, false)) {
             // act
-            File file = folder.newFile();
+            File file = Files.createTempFile(folder, "junit", "").toFile();
             persistence.writeAllAmountsToAddressFile(file, CAddressFileOutputFormat.DynamicWidthBase58BitcoinAddressWithAmount, shouldRun);
 
             // assert
@@ -63,8 +62,8 @@ public class LMDBToAddressFileTest extends LMDBBase {
         }
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT)
     public void writeAllAmountsToAddressFileAsFixedWidthBase58BitcoinAddress(boolean compressed, boolean useStaticAmount) throws Exception {
         // arrange
         AtomicBoolean shouldRun = new AtomicBoolean(true);
@@ -72,7 +71,7 @@ public class LMDBToAddressFileTest extends LMDBBase {
         try (Persistence persistence = createAndFillAndOpenLMDB(useStaticAmount, testAddressesFiles, false, false)) {
 
             // act
-            File file = folder.newFile();
+            File file = Files.createTempFile(folder, "junit", "").toFile();
             persistence.writeAllAmountsToAddressFile(file, CAddressFileOutputFormat.FixedWidthBase58BitcoinAddress, shouldRun);
 
             // assert
@@ -96,15 +95,15 @@ public class LMDBToAddressFileTest extends LMDBBase {
         }
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_COMPRESSED_AND_STATIC_AMOUNT)
     public void writeAllAmountsToAddressFileAsHexHash(boolean compressed, boolean useStaticAmount) throws Exception {
         // arrange
         AtomicBoolean shouldRun = new AtomicBoolean(true);
         TestAddressesFiles testAddressesFiles = new TestAddressesFiles(compressed);
         try (Persistence persistence = createAndFillAndOpenLMDB(useStaticAmount, testAddressesFiles, false, false)) {
             // act
-            File file = folder.newFile();
+            File file = Files.createTempFile(folder, "junit", "").toFile();
             persistence.writeAllAmountsToAddressFile(file, CAddressFileOutputFormat.HexHash, shouldRun);
 
             // assert

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/MainTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/MainTest.java
@@ -19,6 +19,7 @@ import net.ladenthin.bitcoinaddressfinder.configuration.CConfiguration;
 
 import static net.ladenthin.bitcoinaddressfinder.cli.Main.printAllStackTracesWithDelay;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -212,7 +213,7 @@ public class MainTest {
         Files.writeString(tempFile.toPath(), OPEN_CL_INFO_JSON_STRING, StandardCharsets.UTF_8);
 
         // act
-        Main.main(new String[]{tempFile.getAbsolutePath()});
+        assertThrows(IllegalArgumentException.class, () -> Main.main(new String[]{tempFile.getAbsolutePath()}));
     }
     // </editor-fold>
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/MainTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/MainTest.java
@@ -22,9 +22,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -34,8 +34,8 @@ import org.slf4j.Logger;
 
 public class MainTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
     
     private final Path resourceDirectory = Path.of("src","test","resources");
     private final Path testRoundtripDirectory = resourceDirectory.resolve("testRoundtrip");
@@ -205,10 +205,10 @@ public class MainTest {
         Main.main(new String[]{config_OpenCLInfo_yml.toAbsolutePath().toString()});
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void main_unknownExtensionPath_throwsIllegalArgumentException() throws IOException {
         // arrange
-        File tempFile = folder.newFile("config.txt");
+        File tempFile = Files.createFile(folder.resolve("config.txt")).toFile();
         Files.writeString(tempFile.toPath(), OPEN_CL_INFO_JSON_STRING, StandardCharsets.UTF_8);
 
         // act

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/MockKeyProducerTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/MockKeyProducerTest.java
@@ -4,8 +4,6 @@
 package net.ladenthin.bitcoinaddressfinder;
 
 import net.ladenthin.bitcoinaddressfinder.keyproducer.NoMoreSecretsAvailableException;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Random;
@@ -13,10 +11,10 @@ import org.bitcoinj.base.Network;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(DataProviderRunner.class)
 public class MockKeyProducerTest {
     
     private final Network network = new NetworkParameterFactory().getNetwork();
@@ -132,8 +130,8 @@ public class MockKeyProducerTest {
     // </editor-fold>
     
     // <editor-fold defaultstate="collapsed" desc="createStatisticsMessage">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX)
     public void createSecrets_parameterBatchSizeInBitsFromDataProviderAndReturnStartSecretOnlyTrue_returnExpectedSecrets(int maximumBitLength) throws NoMoreSecretsAvailableException {
         // arrange
         int batchSizeInBits = 2;
@@ -147,8 +145,8 @@ public class MockKeyProducerTest {
         assertThat(createSecrets.length, is(equalTo(1)));
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX)
     public void createSecrets_parameterBatchSizeInBitsFromDataProviderAndReturnStartSecretOnlyFalse_returnExpectedSecrets(int maximumBitLength) throws NoMoreSecretsAvailableException {
         // arrange
         int batchSizeInBits = 2;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/NetworkParameterFactoryTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/NetworkParameterFactoryTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link NetworkParameterFactory}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLBuilderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLBuilderTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OpenCLBuilderTest {
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
@@ -5,7 +5,7 @@ package net.ladenthin.bitcoinaddressfinder;
 
 import java.io.IOException;
 import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLDeviceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLDeviceTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jocl.CL;
 import org.jocl.cl_device_id;
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLGridResultTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLGridResultTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link OpenCLGridResult}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformAssume.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformAssume.java
@@ -3,21 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import static java.lang.Boolean.TRUE;
 import java.util.List;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLBuilder;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
-import org.junit.Assume;
-import static org.hamcrest.Matchers.is;
+import org.junit.jupiter.api.Assumptions;
 
 public class OpenCLPlatformAssume implements PlatformAssume {
-    
+
     public void assumeOpenCLLibraryLoadable() {
-        Assume.assumeThat("OpenCL library loadable", OpenCLBuilder.isOpenCLnativeLibraryLoadable(), is(TRUE));
+        Assumptions.assumeTrue(OpenCLBuilder.isOpenCLnativeLibraryLoadable(), "OpenCL library loadable");
     }
-    
+
     public void assumeOneOpenCL2_0OrGreaterDeviceAvailable(List<OpenCLPlatform> openCLPlatforms) {
-        Assume.assumeThat("One OpenCL 2.0 or greater device available", OpenCLBuilder.isOneOpenCL2_0OrGreaterDeviceAvailable(openCLPlatforms), is(TRUE));
+        Assumptions.assumeTrue(OpenCLBuilder.isOneOpenCL2_0OrGreaterDeviceAvailable(openCLPlatforms), "One OpenCL 2.0 or greater device available");
     }
     
     public void assumeOpenCLLibraryLoadableAndOneOpenCL2_0OrGreaterDeviceAvailable() {

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformSelectorTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformSelectorTest.java
@@ -12,11 +12,12 @@ import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatformSelector;
 import org.jocl.cl_context_properties;
 import org.jocl.cl_device_id;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OpenCLPlatformSelectorTest {
 
@@ -75,36 +76,36 @@ public class OpenCLPlatformSelectorTest {
         assertThat(result.device(), is(equalTo(secondDevice)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void select_negativePlatformIndex_throwsIllegalArgumentException() {
         // arrange
         OpenCLPlatform platform = createTestPlatform("Platform0", createTestDevice(DEVICE_TYPE_GPU));
         List<OpenCLPlatform> platforms = List.of(platform);
 
         // act
-        platformSelector.select(platforms, -1, DEVICE_TYPE_GPU, 0);
+        assertThrows(IllegalArgumentException.class, () -> platformSelector.select(platforms, -1, DEVICE_TYPE_GPU, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void select_platformIndexTooLarge_throwsIllegalArgumentException() {
         // arrange
         OpenCLPlatform platform = createTestPlatform("Platform0", createTestDevice(DEVICE_TYPE_GPU));
         List<OpenCLPlatform> platforms = List.of(platform);
 
         // act
-        platformSelector.select(platforms, 1, DEVICE_TYPE_GPU, 0);
+        assertThrows(IllegalArgumentException.class, () -> platformSelector.select(platforms, 1, DEVICE_TYPE_GPU, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void select_emptyPlatformList_throwsIllegalArgumentException() {
         // arrange
         List<OpenCLPlatform> platforms = Collections.emptyList();
 
         // act
-        platformSelector.select(platforms, 0, DEVICE_TYPE_GPU, 0);
+        assertThrows(IllegalArgumentException.class, () -> platformSelector.select(platforms, 0, DEVICE_TYPE_GPU, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void select_negativeDeviceIndex_throwsIllegalArgumentException() {
         // arrange
         OpenCLDevice gpuDevice = createTestDevice(DEVICE_TYPE_GPU);
@@ -112,10 +113,10 @@ public class OpenCLPlatformSelectorTest {
         List<OpenCLPlatform> platforms = List.of(platform);
 
         // act
-        platformSelector.select(platforms, 0, DEVICE_TYPE_GPU, -1);
+        assertThrows(IllegalArgumentException.class, () -> platformSelector.select(platforms, 0, DEVICE_TYPE_GPU, -1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void select_deviceIndexTooLarge_throwsIllegalArgumentException() {
         // arrange
         OpenCLDevice gpuDevice = createTestDevice(DEVICE_TYPE_GPU);
@@ -123,10 +124,10 @@ public class OpenCLPlatformSelectorTest {
         List<OpenCLPlatform> platforms = List.of(platform);
 
         // act
-        platformSelector.select(platforms, 0, DEVICE_TYPE_GPU, 1);
+        assertThrows(IllegalArgumentException.class, () -> platformSelector.select(platforms, 0, DEVICE_TYPE_GPU, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void select_noDeviceMatchingType_throwsIllegalArgumentException() {
         // arrange
         OpenCLDevice cpuDevice = createTestDevice(DEVICE_TYPE_CPU);
@@ -134,7 +135,7 @@ public class OpenCLPlatformSelectorTest {
         List<OpenCLPlatform> platforms = List.of(platform);
 
         // act
-        platformSelector.select(platforms, 0, DEVICE_TYPE_GPU, 0);
+        assertThrows(IllegalArgumentException.class, () -> platformSelector.select(platforms, 0, DEVICE_TYPE_GPU, 0));
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformTest.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ImmutableList;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDevice;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
 import org.jspecify.annotations.NonNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/PlatformAssume.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/PlatformAssume.java
@@ -11,7 +11,7 @@ package net.ladenthin.bitcoinaddressfinder;
  * (e.g., required native libraries or hardware support).
  * </p>
  *
- * @see org.junit.Assume
+ * @see org.junit.jupiter.api.Assumptions
  */
 public interface PlatformAssume {
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/PrivateKeyTooLargeExceptionTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/PrivateKeyTooLargeExceptionTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link PrivateKeyTooLargeException}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/PrivateKeyValidatorTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/PrivateKeyValidatorTest.java
@@ -4,14 +4,12 @@
 package net.ladenthin.bitcoinaddressfinder;
 
 import java.math.BigInteger;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-@RunWith(DataProviderRunner.class)
 public class PrivateKeyValidatorTest {
 
     private final PrivateKeyValidator validator = new PrivateKeyValidator();
@@ -55,19 +53,19 @@ public class PrivateKeyValidatorTest {
         assertThat(result, is(equalTo(expected)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getMaxPrivateKeyForBatchSize_bitSizeNegative_throwsException() {
         // act
         validator.getMaxPrivateKeyForBatchSize(-1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getMaxPrivateKeyForBatchSize_bitSizeTooLarge_throwsException() {
         // act
         validator.getMaxPrivateKeyForBatchSize(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS + 1);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void getMaxPrivateKeyForBatchSize_tooLarge_throwsException() {
         // arrange
         int batchSizeInBits = PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS;
@@ -78,8 +76,8 @@ public class PrivateKeyValidatorTest {
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="isInvalidWithBatchSize">
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_PRIVATE_KEYS_TOO_LARGE_WITH_CHUNK_SIZE, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_PRIVATE_KEYS_TOO_LARGE_WITH_CHUNK_SIZE)
     public void isInvalidWithBatchSize_keyTooLarge_returnsTrue(BigInteger privateKey, int batchSizeInBits) {
         // arrange
         BigInteger maxAllowed = validator.getMaxPrivateKeyForBatchSize(batchSizeInBits);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/PrivateKeyValidatorTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/PrivateKeyValidatorTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.*;
 
 public class PrivateKeyValidatorTest {
@@ -56,13 +57,13 @@ public class PrivateKeyValidatorTest {
     @Test
     public void getMaxPrivateKeyForBatchSize_bitSizeNegative_throwsException() {
         // act
-        validator.getMaxPrivateKeyForBatchSize(-1);
+        assertThrows(IllegalArgumentException.class, () -> validator.getMaxPrivateKeyForBatchSize(-1));
     }
 
     @Test
     public void getMaxPrivateKeyForBatchSize_bitSizeTooLarge_throwsException() {
         // act
-        validator.getMaxPrivateKeyForBatchSize(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS + 1);
+        assertThrows(IllegalArgumentException.class, () -> validator.getMaxPrivateKeyForBatchSize(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS + 1));
     }
 
     @Test
@@ -71,7 +72,7 @@ public class PrivateKeyValidatorTest {
         int batchSizeInBits = PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS;
 
         // act
-        validator.getMaxPrivateKeyForBatchSize(batchSizeInBits);
+        assertThrows(IllegalStateException.class, () -> validator.getMaxPrivateKeyForBatchSize(batchSizeInBits));
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
@@ -4,9 +4,8 @@
 package net.ladenthin.bitcoinaddressfinder;
 
 import com.google.common.io.Resources;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.File;
+import java.nio.file.Files;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URL;
@@ -14,10 +13,12 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.jocl.CL.*;
 
@@ -38,11 +39,9 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.mockito.Mockito.mock;
 
 import org.jocl.*;
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
 import org.slf4j.Logger;
 
-@RunWith(DataProviderRunner.class)
 public class ProbeAddressesOpenCLTest {
 
     public static final String ADDRESSES_CSV = "addresses.csv";
@@ -62,10 +61,10 @@ public class ProbeAddressesOpenCLTest {
     
     private final BitHelper bitHelper = new BitHelper();
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+    @TempDir
+    public Path tempFolder;
 
-    @Before
+    @BeforeEach
     public void init() throws IOException {
         createTemporaryAddressesFile();
     }
@@ -75,7 +74,7 @@ public class ProbeAddressesOpenCLTest {
     }
 
     public void createTemporaryAddressesFile() throws IOException {
-        File tempAddressesFile = tempFolder.newFile(ADDRESSES_CSV);
+        File tempAddressesFile = Files.createFile(tempFolder.resolve(ADDRESSES_CSV)).toFile();
         fillAddressesFiles(tempAddressesFile);
     }
 
@@ -227,7 +226,7 @@ public class ProbeAddressesOpenCLTest {
     public static int ACCESS_STRIDE = (ACCESS_BUNDLE/BN_NWORDS);
     
     @Test
-    @Ignore
+    @Disabled
     public void reverseEngineering_startPoints() {
         int GLOBAL_SIZE = 1024;
         for (int j = 0; j < 1024; j++) {
@@ -264,7 +263,7 @@ public class ProbeAddressesOpenCLTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void calcAddrsFixZeroCl_loadWithoutErrors() throws IOException {
         // ATTENTION: BLDEBUG
         
@@ -383,9 +382,9 @@ public class ProbeAddressesOpenCLTest {
                 global_work_size, null, 0, null, null);
     }
 
-    @Test
+    @ParameterizedTest
     @OpenCLTest
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX, location = CommonDataProvider.class)
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX)
     public void createKeys_bitsLowerThan25_use32BitNevertheless(int bitSize) throws IOException {
         new OpenCLPlatformAssume().assumeOpenCLLibraryLoadableAndOneOpenCL2_0OrGreaterDeviceAvailable();
 
@@ -459,8 +458,8 @@ public class ProbeAddressesOpenCLTest {
    }
    
     @OpenCLTest
-    @Test(expected = PrivateKeyTooLargeException.class)
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_PRIVATE_KEYS_TOO_LARGE_WITH_CHUNK_SIZE, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_PRIVATE_KEYS_TOO_LARGE_WITH_CHUNK_SIZE)
     public void setSrcPrivateKeyChunk_privateKeyTooLarge_throwsException(BigInteger privateKey, int chunkSize) throws IOException {
         new OpenCLPlatformAssume().assumeOpenCLLibraryLoadableAndOneOpenCL2_0OrGreaterDeviceAvailable();
         
@@ -475,9 +474,9 @@ public class ProbeAddressesOpenCLTest {
        }
     }
 
-    @Test
+    @ParameterizedTest
     @OpenCLTest
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_PRIVATE_KEYS_32_BYTE_REQUIRING_STRIP, location = CommonDataProvider.class)
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_PRIVATE_KEYS_32_BYTE_REQUIRING_STRIP)
     public void setSrcPrivateKeyChunk_handlesLeadingZero_correctlySerializesTo32Bytes(BigInteger privateKey) throws IOException {
         new OpenCLPlatformAssume().assumeOpenCLLibraryLoadableAndOneOpenCL2_0OrGreaterDeviceAvailable();
 
@@ -520,9 +519,9 @@ public class ProbeAddressesOpenCLTest {
        }
     }
     
-    @Test
+    @ParameterizedTest
     @OpenCLTest
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_LARGE_PRIVATE_KEYS, location = CommonDataProvider.class)
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_LARGE_PRIVATE_KEYS)
     public void createKeys_fromLargePrivateKey_generatesValidPublicKeys(BigInteger privateKey) throws IOException {
         new OpenCLPlatformAssume().assumeOpenCLLibraryLoadableAndOneOpenCL2_0OrGreaterDeviceAvailable();
         

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerJavaSecretsFilesTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerJavaSecretsFilesTest.java
@@ -4,8 +4,6 @@
 package net.ladenthin.bitcoinaddressfinder;
 
 import com.google.common.hash.Hashing;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -28,16 +26,17 @@ import org.bitcoinj.crypto.ECKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(DataProviderRunner.class)
 public class ProducerJavaSecretsFilesTest {
     
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
     
     private static final Network network = new NetworkParameterFactory().getNetwork();
     private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
@@ -122,8 +121,8 @@ public class ProducerJavaSecretsFilesTest {
         assertThat(mockConsumer.publicKeyBytesArrayList.size(), is(equalTo(0)));
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_CSECRET_FORMAT, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_CSECRET_FORMAT)
     public void produceKeys_filesConfigured_keysCreated(CSecretFormat cSecretFormat) throws IOException, InterruptedException {
         CProducerJavaSecretsFiles cProducerJavaSecretsFiles = new CProducerJavaSecretsFiles();
         List<File> secretsFiles = createSecretsFiles(cSecretFormat);
@@ -162,7 +161,7 @@ public class ProducerJavaSecretsFilesTest {
     private List<File> createSecretsFiles(CSecretFormat secretFormat) throws IOException {
         List<File> fileList = new ArrayList<>();
         {
-            File secretsFile = folder.newFile("secretsFile0.txt");
+            File secretsFile = Files.createFile(folder.resolve("secretsFile0.txt")).toFile();
             fileList.add(secretsFile);
             PrivateKey[] secretsAsArray = new PrivateKey[] {
                 PrivateKey.TEST,
@@ -173,7 +172,7 @@ public class ProducerJavaSecretsFilesTest {
             fillSecretsFile(secretsFile, secretsAsList, secretFormat);
         }
         {
-            File secretsFile = folder.newFile("secretsFile1.txt");
+            File secretsFile = Files.createFile(folder.resolve("secretsFile1.txt")).toFile();
             fileList.add(secretsFile);
             PrivateKey[] secretsAsArray = new PrivateKey[] {
                 PrivateKey.NUMBER_73,

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerJavaTest.java
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Random;
@@ -14,16 +13,14 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
 
-@RunWith(DataProviderRunner.class)
 public class ProducerJavaTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
 
     private final Network network = new NetworkParameterFactory().getNetwork();
     private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerOpenCLTest.java
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -21,8 +21,8 @@ import static org.hamcrest.Matchers.is;
 
 public class ProducerOpenCLTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
 
     private final Network network = new NetworkParameterFactory().getNetwork();
     private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
@@ -232,7 +232,7 @@ public class ProducerOpenCLTest {
     // </editor-fold>
     
     // <editor-fold defaultstate="collapsed" desc="produceKeys">
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void produceKeys_notInitialized_illegalStateExceptionThrown() throws Exception {
         CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerOpenCLTest.java
@@ -15,6 +15,7 @@ import org.bitcoinj.base.Network;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -242,8 +243,8 @@ public class ProducerOpenCLTest {
         ProducerOpenCL producerOpenCL = new ProducerOpenCL(cProducerOpenCL, mockConsumer, keyUtility, mockKeyProducer, bitHelper);
         
         // act
-        producerOpenCL.produceKeys();
-        
+        assertThrows(IllegalStateException.class, () -> producerOpenCL.produceKeys());
+
         // assert
     }
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerStateTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProducerStateTest.java
@@ -6,7 +6,8 @@ package net.ladenthin.bitcoinaddressfinder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 public class ProducerStateTest {
 
@@ -96,10 +97,10 @@ public class ProducerStateTest {
         assertThat(ProducerState.valueOf("NOT_RUNNING"), is(equalTo(ProducerState.NOT_RUNNING)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void valueOf_unknownString_throwsIllegalArgumentException() {
         // arrange, act, assert
-        ProducerState.valueOf("UNKNOWN_STATE");
+        assertThrows(IllegalArgumentException.class, () -> ProducerState.valueOf("UNKNOWN_STATE"));
     }
     // </editor-fold>
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytesTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytesTest.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.math.BigInteger;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/RandomSecretSupplierTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/RandomSecretSupplierTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RandomSecretSupplierTest {
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ReadStatisticTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ReadStatisticTest.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/SecretsFileTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/SecretsFileTest.java
@@ -17,9 +17,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.StaticKey;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import java.nio.file.Files;
 
 /**
  * Unit tests for {@link SecretsFile}.
@@ -29,14 +30,14 @@ public class SecretsFileTest {
     private final Network network = new NetworkParameterFactory().getNetwork();
     private final StaticKey staticKey = new StaticKey();
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder;
 
     // <editor-fold defaultstate="collapsed" desc="processLine">
     @Test
     public void processLine_bigIntegerFormat_consumerReceivesExpectedSecret() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
         SecretsFile secretsFile = new SecretsFile(network, file, CSecretFormat.BIG_INTEGER, readStatistic, captured::add);
@@ -52,7 +53,7 @@ public class SecretsFileTest {
     @Test
     public void processLine_sha256Format_consumerReceivesExpectedSecret() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
         SecretsFile secretsFile = new SecretsFile(network, file, CSecretFormat.SHA256, readStatistic, captured::add);
@@ -68,7 +69,7 @@ public class SecretsFileTest {
     @Test
     public void processLine_sha256Format_singleByteValue_consumerReceivesExpected() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
         SecretsFile secretsFile = new SecretsFile(network, file, CSecretFormat.SHA256, readStatistic, captured::add);
@@ -84,7 +85,7 @@ public class SecretsFileTest {
     @Test
     public void processLine_stringDoSha256Format_consumerReceivesHashOfInput() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
         SecretsFile secretsFile = new SecretsFile(network, file, CSecretFormat.STRING_DO_SHA256, readStatistic, captured::add);
@@ -102,7 +103,7 @@ public class SecretsFileTest {
     @Test
     public void processLine_dumpedPrivateKeyFormat_consumerReceivesNonNullPositiveSecret() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
         SecretsFile secretsFile = new SecretsFile(network, file, CSecretFormat.DUMPED_RIVATE_KEY, readStatistic, captured::add);
@@ -119,7 +120,7 @@ public class SecretsFileTest {
     @Test
     public void processLine_dumpedPrivateKeyFormat_consumerReceivesExpectedPrivateKey() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
         SecretsFile secretsFile = new SecretsFile(network, file, CSecretFormat.DUMPED_RIVATE_KEY, readStatistic, captured::add);
@@ -134,7 +135,7 @@ public class SecretsFileTest {
     @Test
     public void processLine_bigIntegerFormat_calledTwice_consumerCalledTwice() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
         SecretsFile secretsFile = new SecretsFile(network, file, CSecretFormat.BIG_INTEGER, readStatistic, captured::add);
@@ -154,7 +155,7 @@ public class SecretsFileTest {
     @Test
     public void readFile_fileWithTwoLines_consumerCalledTwice() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         FileUtils.writeStringToFile(file, "1\n2\n", StandardCharsets.UTF_8.name());
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
@@ -172,7 +173,7 @@ public class SecretsFileTest {
     @Test
     public void readFile_emptyFile_consumerNeverCalled() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();
         SecretsFile secretsFile = new SecretsFile(network, file, CSecretFormat.BIG_INTEGER, readStatistic, captured::add);
@@ -189,7 +190,7 @@ public class SecretsFileTest {
     @Test
     public void interrupt_calledBeforeReadFile_noLinesProcessed() throws Exception {
         // arrange
-        File file = folder.newFile("secrets.txt");
+        File file = Files.createFile(folder.resolve("secrets.txt")).toFile();
         FileUtils.writeStringToFile(file, "1\n2\n3\n", StandardCharsets.UTF_8.name());
         ReadStatistic readStatistic = new ReadStatistic();
         List<BigInteger[]> captured = new ArrayList<>();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/SeparatorFormatTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/SeparatorFormatTest.java
@@ -3,29 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
-import org.junit.runner.RunWith;
 
 /**
  * Unit tests for {@link SeparatorFormat}.
  */
-@RunWith(DataProviderRunner.class)
 public class SeparatorFormatTest {
 
     /**
      * Tests that the input is correctly split into two parts using a valid
      * separator between them.
      */
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR)
     public void split_separatorBetweenTwoParts_returnsSplitParts(String addressSeparator) {
         // arrange
         String expectedLeft = "leftPart";
@@ -45,8 +43,8 @@ public class SeparatorFormatTest {
      * Tests that an input string consisting only of a separator returns two
      * empty strings after splitting.
      */
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR)
     public void split_inputEqualsSeparator_returnsEmptyStrings(String separator) {
         // arrange
         String input = separator;
@@ -119,8 +117,8 @@ public class SeparatorFormatTest {
      * Tests that if the input starts and ends with a separator, the result
      * contains empty prefix and suffix parts.
      */
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR)
     public void split_inputStartsAndEndsWithSeparator_returnsEmptyAndMiddleAndEmpty(String separator) {
         // arrange
         String input = separator + "middle" + separator;
@@ -155,8 +153,8 @@ public class SeparatorFormatTest {
      * Tests that when the separator appears at the end of the input, the last
      * part is returned as an empty string.
      */
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR)
     public void split_trailingSeparator_returnsEmptyLastPart(String separator) {
         // arrange
         String input = "value" + separator;
@@ -174,8 +172,8 @@ public class SeparatorFormatTest {
      * Tests that when the separator appears at the beginning of the input, the
      * first part is returned as an empty string.
      */
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_ADDRESS_SEPARATOR)
     public void split_leadingSeparator_returnsEmptyFirstPart(String separator) {
         // arrange
         String input = separator + "value";

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/StatisticsTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/StatisticsTest.java
@@ -6,7 +6,7 @@ package net.ladenthin.bitcoinaddressfinder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatisticsTest {
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CKeyProducerJavaIncrementalTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CKeyProducerJavaIncrementalTest.java
@@ -4,7 +4,7 @@
 package net.ladenthin.bitcoinaddressfinder.configuration;
 
 import java.math.BigInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import net.ladenthin.bitcoinaddressfinder.BitHelper;
 import net.ladenthin.bitcoinaddressfinder.PublicKeyBytes;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerTest.java
@@ -5,14 +5,14 @@ package net.ladenthin.bitcoinaddressfinder.configuration;
 
 import java.io.IOException;
 import net.ladenthin.bitcoinaddressfinder.BitHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CProducerTest {
     
     private final BitHelper bitHelper = new BitHelper();
     
-    @Before
+    @BeforeEach
     public void init() throws IOException {
     }
     

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/UnknownSecretFormatExceptionTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/UnknownSecretFormatExceptionTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link UnknownSecretFormatException}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/eckey/Secp256k1Test.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/eckey/Secp256k1Test.java
@@ -4,7 +4,7 @@
 
 package net.ladenthin.bitcoinaddressfinder.eckey;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.security.KeyFactory;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/AbstractKeyProducerQueueBufferedTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/AbstractKeyProducerQueueBufferedTest.java
@@ -4,8 +4,8 @@
 package net.ladenthin.bitcoinaddressfinder.keyproducer;
 
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import net.ladenthin.bitcoinaddressfinder.ByteBufferUtility;
@@ -15,8 +15,9 @@ import org.bitcoinj.base.Network;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -27,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import net.ladenthin.bitcoinaddressfinder.BitHelper;
 import net.ladenthin.bitcoinaddressfinder.KeyUtility;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaReceiver;
 import static org.mockito.Mockito.mock;
@@ -43,13 +44,13 @@ public class AbstractKeyProducerQueueBufferedTest {
     private Logger mockLogger;
     private ExecutorService executorService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         mockLogger = mock(Logger.class);
         executorService = Executors.newCachedThreadPool();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         executorService.shutdownNow();
     }
@@ -117,7 +118,7 @@ public class AbstractKeyProducerQueueBufferedTest {
         }
     }
     
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_throwsException_onInvalidLength() throws Exception {
         CKeyProducerJavaReceiver config = new CKeyProducerJavaReceiver();
         TestKeyProducer producer = createTestKeyProducer(config);
@@ -125,25 +126,25 @@ public class AbstractKeyProducerQueueBufferedTest {
         byte[] invalidSecret = new KeyProducerTestUtility().createInvalidSecret();
         producer.addSecret(invalidSecret);
 
-        producer.createSecrets(1, true); // should throw
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(1, true)); // should throw
     }
     
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_throwsException_onTimeout() throws Exception {
         CKeyProducerJavaReceiver config = new CKeyProducerJavaReceiver();
         TestKeyProducer producer = createTestKeyProducer(config);
 
         // Do not add anything to queue
-        producer.createSecrets(1, true); // should timeout
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(1, true)); // should timeout
     }
     
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_throwsException_whenShouldStopSet() throws Exception {
         CKeyProducerJavaReceiver config = new CKeyProducerJavaReceiver();
         TestKeyProducer producer = createTestKeyProducer(config);
 
         producer.shouldStop = true;
-        producer.createSecrets(1, true); // should throw immediately
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(1, true)); // should throw immediately
     }
     
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/ConnectionUtilsTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/ConnectionUtilsTest.java
@@ -3,26 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.keyproducer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.ServerSocket;
 import java.util.concurrent.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConnectionUtilsTest {
 
     private ExecutorService executorService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         executorService = Executors.newCachedThreadPool();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         executorService.shutdownNow();
     }
@@ -71,11 +72,11 @@ public class ConnectionUtilsTest {
         assertThat(duration, lessThan(2500L)); // with some margin
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void waitUntilTcpPortOpen_whenPortNeverOpens_throwsException() throws Exception {
         int unusedPort = findFreePort();
         // Do not bind anything to this port
 
-        ConnectionUtils.waitUntilTcpPortOpen("localhost", unusedPort, 1000);
+        assertThrows(IllegalStateException.class, () -> ConnectionUtils.waitUntilTcpPortOpen("localhost", unusedPort, 1000));
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerIdIsNotUniqueExceptionTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerIdIsNotUniqueExceptionTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link KeyProducerIdIsNotUniqueException}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerIdNullExceptionTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerIdNullExceptionTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link KeyProducerIdNullException}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerIdUnknownExceptionTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerIdUnknownExceptionTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link KeyProducerIdUnknownException}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaBip39Test.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaBip39Test.java
@@ -14,8 +14,8 @@ import org.bitcoinj.base.Network;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.slf4j.Logger;
 
@@ -28,7 +28,7 @@ public class KeyProducerJavaBip39Test {
     
     String keyProducerId = "exampleId";
     
-    @Before
+    @BeforeEach
     public void setUp() {
         mockLogger = mock(Logger.class);
     }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaIncrementalTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaIncrementalTest.java
@@ -12,11 +12,12 @@ import java.math.BigInteger;
 import net.ladenthin.bitcoinaddressfinder.*;
 
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaIncremental;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.bitcoinj.base.Network;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.slf4j.Logger;
 
@@ -132,7 +133,7 @@ public class KeyProducerJavaIncrementalTest {
     
     private Logger mockLogger;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         keyUtility = new KeyUtility(network, byteBufferUtility);
         bitHelper = new BitHelper();
@@ -183,26 +184,26 @@ public class KeyProducerJavaIncrementalTest {
      * the method immediately throws NoMoreSecretsAvailableException.
      * This prevents invalid key ranges.
      */
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_startExceedsEnd_throwsException() throws Exception {
         KeyProducerJavaIncremental producer = createKeyProducerJavaIncremental(
                 "0000000000000000000000000000000000000000000000000000000000000010",
                 "0000000000000000000000000000000000000000000000000000000000000005"
         );
-        producer.createSecrets(1, true);
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(1, true));
     }
 
     /**
      * Tests that requesting a batch larger than the available keys before the end address
      * causes a NoMoreSecretsAvailableException to be thrown.
      */
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_batchExceedsEnd_throwsException() throws Exception {
         KeyProducerJavaIncremental producer = createKeyProducerJavaIncremental(
                 startHex,
                 "0000000000000000000000000000000000000000000000000000000000000003"
         );
-        producer.createSecrets(5, false);
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(5, false));
     }
 
     /**
@@ -260,7 +261,7 @@ public class KeyProducerJavaIncrementalTest {
      * Tests that if a batch would partially exceed the end address, an exception is thrown.
      * This test confirms partial batches are not allowed when returnStartSecretOnly is false.
      */
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_threeBatches_twoElementsEach_thirdThrowsException() throws Exception {
         // Setup: start = 1, end = 5 (allowed keys: 1, 2, 3, 4, 5)
         KeyProducerJavaIncremental producer = createKeyProducerJavaIncremental(
@@ -273,7 +274,7 @@ public class KeyProducerJavaIncrementalTest {
 
         // 3rd batch: should throw NoMoreSecretsAvailableException because
         // the next values would be 5 and 6, but 6 exceeds the end address
-        producer.createSecrets(batchSize, false);
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(batchSize, false));
     }
     
     /**
@@ -281,7 +282,7 @@ public class KeyProducerJavaIncrementalTest {
      * Demonstrates that partial batches beyond the end are disallowed and cause an exception,
      * even if the end address itself is technically within the allowed range.
      */
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_endAddressInclusive_butPartialBatchNotAllowed_throwsException() throws Exception {
         // Setup: start=1, end=5 (allowed keys: 1, 2, 3, 4, 5)
         KeyProducerJavaIncremental producer = createKeyProducerJavaIncremental(
@@ -293,7 +294,7 @@ public class KeyProducerJavaIncrementalTest {
         assertTwoBatchedOk(producer, batchSize);
 
         // 3rd batch: tries [5, 6], but 6 > end (5), so exception thrown
-        producer.createSecrets(batchSize, false);
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(batchSize, false));
     }
     
     /**

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaRandomTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaRandomTest.java
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.keyproducer;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.math.BigInteger;
 import net.ladenthin.bitcoinaddressfinder.BitHelper;
 import net.ladenthin.bitcoinaddressfinder.ByteBufferUtility;
@@ -20,13 +18,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import org.jspecify.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.mockito.Mockito.mock;
 import org.slf4j.Logger;
 
-@RunWith(DataProviderRunner.class)
 public class KeyProducerJavaRandomTest {
     
     private final Network network = new NetworkParameterFactory().getNetwork();
@@ -36,7 +34,7 @@ public class KeyProducerJavaRandomTest {
     
     String keyProducerId = "exampleId";
     
-    @Before
+    @BeforeEach
     public void setUp() {
         mockLogger = mock(Logger.class);
     }
@@ -66,8 +64,8 @@ public class KeyProducerJavaRandomTest {
         assertThat(result.length, is(equalTo(1)));
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX)
     public void createSecrets_parameterBatchSizeInBitsFromDataProviderAndReturnStartSecretOnlyTrue_returnExpectedSecrets(int batchSizeInBits) throws NoMoreSecretsAvailableException {
         // arrange
         CKeyProducerJavaRandom cKeyProducerJavaRandom = new CKeyProducerJavaRandom();
@@ -87,8 +85,8 @@ public class KeyProducerJavaRandomTest {
         assertThat(result.length, is(equalTo(1)));
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_BIT_SIZES_AT_MOST_MAX)
     public void createSecrets_parameterBatchSizeInBitsFromDataProviderAndReturnStartSecretOnlyFalse_returnExpectedSecrets(int batchSizeInBits) throws NoMoreSecretsAvailableException {
         // arrange
         CKeyProducerJavaRandom cKeyProducerJavaRandom = new CKeyProducerJavaRandom();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaSocketTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaSocketTest.java
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.keyproducer;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import java.io.DataInputStream;
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaSocket;
 import org.jspecify.annotations.Nullable;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import java.util.concurrent.TimeUnit;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -28,15 +29,14 @@ import org.bitcoinj.base.Network;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import org.junit.runner.RunWith;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.*;
 import org.slf4j.Logger;
 
-@RunWith(DataProviderRunner.class)
 public class KeyProducerJavaSocketTest {
     
     private final Network network = new NetworkParameterFactory().getNetwork();
@@ -54,13 +54,13 @@ public class KeyProducerJavaSocketTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         executorService = Executors.newCachedThreadPool();
         mockLogger = mock(Logger.class);
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         executorService.shutdownNow();
     }
@@ -220,7 +220,7 @@ public class KeyProducerJavaSocketTest {
         cleanup(client, serverFuture, serverSocket);
     }
 
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_prematureStreamClose_throwsException() throws Exception {
         int port = findFreePort();
 
@@ -240,12 +240,12 @@ public class KeyProducerJavaSocketTest {
         KeyProducerJavaSocket client = new KeyProducerJavaSocket(clientConfig, keyUtility, bitHelper, mockLogger);
 
         try {
-            client.createSecrets(1, true);
+            assertThrows(NoMoreSecretsAvailableException.class, () -> client.createSecrets(1, true));
         } finally {
             cleanup(client, serverFuture, serverSocket);
         }
     }
-    
+
     @Test
     public void interrupt_closesConnectionAndNoExceptionThrown() throws Exception {
         int port = findFreePort();
@@ -460,7 +460,7 @@ public class KeyProducerJavaSocketTest {
         cleanup(client, serverFuture, null, 3, TimeUnit.SECONDS);
     }
 
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_socketClosedMidRead_throwsException() throws Exception {
         int port = findFreePort();
 
@@ -480,13 +480,13 @@ public class KeyProducerJavaSocketTest {
         KeyProducerJavaSocket client = new KeyProducerJavaSocket(clientConfig, keyUtility, bitHelper, mockLogger);
 
         try {
-            client.createSecrets(1, true);
+            assertThrows(NoMoreSecretsAvailableException.class, () -> client.createSecrets(1, true));
         } finally {
             cleanup(client, serverFuture, serverSocket);
         }
     }
     
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_serverDisconnectsMidTransfer_throwsException() throws Exception {
         int port = findFreePort();
 
@@ -505,7 +505,7 @@ public class KeyProducerJavaSocketTest {
         KeyProducerJavaSocket client = new KeyProducerJavaSocket(clientConfig, keyUtility, bitHelper, mockLogger);
 
         try {
-            client.createSecrets(1, true);
+            assertThrows(NoMoreSecretsAvailableException.class, () -> client.createSecrets(1, true));
         } finally {
             cleanup(client, serverFuture, serverSocket);
         }
@@ -538,7 +538,7 @@ public class KeyProducerJavaSocketTest {
         cleanup(client, serverFuture, serverSocket);
     }
 
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_malformedSecretStream_throwsException() throws Exception {
         int port = findFreePort();
 
@@ -557,7 +557,7 @@ public class KeyProducerJavaSocketTest {
         KeyProducerJavaSocket client = new KeyProducerJavaSocket(clientConfig, keyUtility, bitHelper, mockLogger);
 
         try {
-            client.createSecrets(2, false);
+            assertThrows(NoMoreSecretsAvailableException.class, () -> client.createSecrets(2, false));
         } finally {
             cleanup(client, serverFuture, serverSocket);
         }
@@ -624,7 +624,8 @@ public class KeyProducerJavaSocketTest {
         return serverSocket;
     }
     
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testInterruptCausesShutdownDuringConnectionAttemptOnly() throws Exception {
         final int STATE_UNEXPECTED_SUCCESS = -1;
         final int STATE_UNKNOWN = 0;
@@ -668,11 +669,12 @@ public class KeyProducerJavaSocketTest {
         future.get(3, TimeUnit.SECONDS);
         executor.shutdownNow();
         
-        assertNotEquals("Thread exited without triggering interrupt", STATE_UNEXPECTED_SUCCESS, state.get());
-        assertEquals("Expected interrupt to cause shutdown", STATE_INTERRUPTED_EXIT, state.get());
+        assertNotEquals(STATE_UNEXPECTED_SUCCESS, state.get(), "Thread exited without triggering interrupt");
+        assertEquals(STATE_INTERRUPTED_EXIT, state.get(), "Expected interrupt to cause shutdown");
     }
     
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void serverAcceptTimesOut_whenNoClientConnects() throws Exception {
         int port = findFreePort();
 
@@ -691,7 +693,7 @@ public class KeyProducerJavaSocketTest {
         } catch (NoMoreSecretsAvailableException e) {
             long duration = System.currentTimeMillis() - start;
             // Timeout must be honored within reasonable margin (±200ms)
-            assertTrue("Timeout did not occur as expected", duration >= TestTimeProvider.SOCKET_ACCEPT_TIMEOUT && duration <= TestTimeProvider.SOCKET_ACCEPT_TIMEOUT + 200);
+            assertTrue(duration >= TestTimeProvider.SOCKET_ACCEPT_TIMEOUT && duration <= TestTimeProvider.SOCKET_ACCEPT_TIMEOUT + 200, "Timeout did not occur as expected");
             assertThat(e.getMessage(), containsString("Timeout while waiting for secret"));
         } finally {
             server.interrupt();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaTest.java
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.keyproducer;
 
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.IOException;
 
 import net.ladenthin.bitcoinaddressfinder.*;
@@ -17,16 +15,16 @@ import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaRandomIn
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaSocket;
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaWebSocket;
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaZmq;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.bitcoinj.base.Network;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.mockito.Mockito.mock;
 import org.slf4j.Logger;
 
-@RunWith(DataProviderRunner.class)
 public class KeyProducerJavaTest {
     
     /**
@@ -41,15 +39,15 @@ public class KeyProducerJavaTest {
 
     private final Network network = new NetworkParameterFactory().getNetwork();
     
-    @Before
+    @BeforeEach
     public void setUp() {
         keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
         bitHelper = new BitHelper();
         mockLogger = mock(Logger.class);
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_JAVA_KEY_PRODUCER_AND_BIT_SIZE, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_JAVA_KEY_PRODUCER_AND_BIT_SIZE)
     public void createSecrets_throwsException_whenWorkSizeExceedsMax(CommonDataProvider.KeyProducerTypesLocal keyProducerType, int bits) throws IOException, InterruptedException {
         // arrange
         final int maxWorkSize = 1 << bits; // 2^bits
@@ -59,8 +57,8 @@ public class KeyProducerJavaTest {
         assertWorkSizeTooLargeThrows(keyProducer, maxWorkSize + 1);
     }
     
-    @Test
-    @UseDataProvider(value = CommonDataProvider.DATA_PROVIDER_KEY_PRODUCER_TYPES, location = CommonDataProvider.class)
+    @ParameterizedTest
+    @MethodSource(CommonDataProvider.DATA_PROVIDER_KEY_PRODUCER_TYPES)
     public void createSecrets_throwsException_whenWorkSizeTooLess(CommonDataProvider.KeyProducerTypesLocal keyProducerType) throws IOException, InterruptedException {
         // arrange
         KeyProducerJava keyProducer = createKeyProducer(keyProducerType, 1);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaWebSocketTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaWebSocketTest.java
@@ -11,9 +11,9 @@ import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaWebSocke
 import org.bitcoinj.base.Network;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 import java.math.BigInteger;
@@ -23,6 +23,7 @@ import net.ladenthin.bitcoinaddressfinder.PublicKeyBytes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 public class KeyProducerJavaWebSocketTest {
@@ -33,7 +34,7 @@ public class KeyProducerJavaWebSocketTest {
 
     private ExecutorService executorService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Network network = new NetworkParameterFactory().getNetwork();
         keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
@@ -42,7 +43,7 @@ public class KeyProducerJavaWebSocketTest {
         executorService = Executors.newCachedThreadPool();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         executorService.shutdownNow();
     }
@@ -89,13 +90,13 @@ public class KeyProducerJavaWebSocketTest {
         client.close();
     }
 
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_timeoutWithoutMessage_throwsException() throws Exception {
         CKeyProducerJavaWebSocket config = createConfig();
         config.timeout = TestTimeProvider.DEFAULT_TIMEOUT;
         KeyProducerJavaWebSocket producer = new KeyProducerJavaWebSocket(config, keyUtility, bitHelper, mockLogger);
 
-        producer.createSecrets(1, true);
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(1, true));
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaZmqTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaZmqTest.java
@@ -14,9 +14,9 @@ import net.ladenthin.bitcoinaddressfinder.KeyUtility;
 import net.ladenthin.bitcoinaddressfinder.NetworkParameterFactory;
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaZmq;
 import org.bitcoinj.base.Network;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.zeromq.SocketType;
 import org.zeromq.ZContext;
@@ -25,6 +25,7 @@ import org.zeromq.ZMQException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -37,13 +38,13 @@ public class KeyProducerJavaZmqTest {
     private ExecutorService executorService;
     private Logger mockLogger;
 
-    @Before
+    @BeforeEach
     public void setup() {
         executorService = Executors.newCachedThreadPool();
         mockLogger = mock(Logger.class);
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         executorService.shutdownNow();
     }
@@ -145,7 +146,7 @@ public class KeyProducerJavaZmqTest {
         producer.interrupt();
     }
 
-    @Test(expected = NoMoreSecretsAvailableException.class)
+    @Test
     public void createSecrets_timeout_throwsException() throws Exception {
         // arrange
         String address = findFreeZmqAddress();
@@ -156,7 +157,7 @@ public class KeyProducerJavaZmqTest {
         KeyProducerJavaZmq producer = createKeyProducerJavaZmq(config);
 
         // act
-        producer.createSecrets(1, true);
+        assertThrows(NoMoreSecretsAvailableException.class, () -> producer.createSecrets(1, true));
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/NoMoreSecretsAvailableExceptionTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/NoMoreSecretsAvailableExceptionTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link NoMoreSecretsAvailableException}.

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/PersistenceUtilsTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/PersistenceUtilsTest.java
@@ -6,7 +6,7 @@ package net.ladenthin.bitcoinaddressfinder.persistence;
 import java.nio.ByteBuffer;
 import net.ladenthin.bitcoinaddressfinder.NetworkParameterFactory;
 import org.bitcoinj.base.Network;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/AddressesFileSpecialUsecases.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/AddressesFileSpecialUsecases.java
@@ -6,9 +6,9 @@ package net.ladenthin.bitcoinaddressfinder.staticaddresses;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.rules.TemporaryFolder;
 
 import static net.ladenthin.bitcoinaddressfinder.SeparatorFormat.COMMA;
 import static net.ladenthin.bitcoinaddressfinder.SeparatorFormat.SEMICOLON;
@@ -27,8 +27,8 @@ public class AddressesFileSpecialUsecases implements AddressesFiles {
     }
     
     @Override
-    public List<String> createAddressesFiles(TemporaryFolder folder, boolean addInvalidAddresses) throws IOException {
-        File one = folder.newFile(ADDRESS_FILE_ONE);
+    public List<String> createAddressesFiles(Path folder, boolean addInvalidAddresses) throws IOException {
+        File one = Files.createFile(folder.resolve(ADDRESS_FILE_ONE)).toFile();
 
         Files.write(one.toPath(), getAllAddresses());
         List<String> addresses = new ArrayList<>();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/AddressesFiles.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/AddressesFiles.java
@@ -4,12 +4,12 @@
 package net.ladenthin.bitcoinaddressfinder.staticaddresses;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
-import org.junit.rules.TemporaryFolder;
 
 public interface AddressesFiles {
 
-    List<String> createAddressesFiles(TemporaryFolder folder, boolean addInvalidAddresses) throws IOException;
+    List<String> createAddressesFiles(Path folder, boolean addInvalidAddresses) throws IOException;
 
     TestAddresses getTestAddresses();
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/StaticAddressesFiles.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/StaticAddressesFiles.java
@@ -10,8 +10,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.nio.file.Path;
 import org.bitcoinj.base.Coin;
-import org.junit.rules.TemporaryFolder;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.enums.*;
 
 public class StaticAddressesFiles implements AddressesFiles {
@@ -24,8 +24,8 @@ public class StaticAddressesFiles implements AddressesFiles {
     }
 
     @Override
-    public List<String> createAddressesFiles(TemporaryFolder folder, boolean addInvalidAddresses) throws IOException {
-        File one = folder.newFile(ADDRESS_FILE_ONE);
+    public List<String> createAddressesFiles(Path folder, boolean addInvalidAddresses) throws IOException {
+        File one = Files.createFile(folder.resolve(ADDRESS_FILE_ONE)).toFile();
 
         Files.write(one.toPath(), getAllAddresses());
         List<String> addresses = new ArrayList<>();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/TestAddressesFiles.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/TestAddressesFiles.java
@@ -15,8 +15,8 @@ import static net.ladenthin.bitcoinaddressfinder.SeparatorFormat.COMMA;
 import static net.ladenthin.bitcoinaddressfinder.SeparatorFormat.SEMICOLON;
 import static net.ladenthin.bitcoinaddressfinder.SeparatorFormat.TAB_SPLIT;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.enums.P2WPKH;
+import java.nio.file.Path;
 import org.bitcoinj.base.Coin;
-import org.junit.rules.TemporaryFolder;
 
 public class TestAddressesFiles implements AddressesFiles {
 
@@ -202,10 +202,10 @@ public class TestAddressesFiles implements AddressesFiles {
     }
 
     @Override
-    public List<String> createAddressesFiles(TemporaryFolder folder, boolean addInvalidAddresses) throws IOException {
-        File one = folder.newFile(ADDRESS_FILE_ONE);
-        File two = folder.newFile(ADDRESS_FILE_TWO);
-        File three = folder.newFile(ADDRESS_FILE_THREE);
+    public List<String> createAddressesFiles(Path folder, boolean addInvalidAddresses) throws IOException {
+        File one = Files.createFile(folder.resolve(ADDRESS_FILE_ONE)).toFile();
+        File two = Files.createFile(folder.resolve(ADDRESS_FILE_TWO)).toFile();
+        File three = Files.createFile(folder.resolve(ADDRESS_FILE_THREE)).toFile();
 
         Files.write(one.toPath(), Arrays.asList(
                 testAddresses.getIndexAsBase58String(0) + COMMA.getSymbol() + amountFirstAddress,

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/TestAddressesLMDB.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/staticaddresses/TestAddressesLMDB.java
@@ -5,24 +5,25 @@ package net.ladenthin.bitcoinaddressfinder.staticaddresses;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import net.ladenthin.bitcoinaddressfinder.AddressFilesToLMDB;
 import net.ladenthin.bitcoinaddressfinder.configuration.CAddressFilesToLMDB;
 import net.ladenthin.bitcoinaddressfinder.configuration.CLMDBConfigurationWrite;
-import org.junit.rules.TemporaryFolder;
 
 public class TestAddressesLMDB {
-    
-    
-    public File createTestLMDB(TemporaryFolder folder, AddressesFiles addressesFiles, boolean useStaticAmount, boolean addInvalidAddresses) throws IOException {
+
+
+    public File createTestLMDB(Path folder, AddressesFiles addressesFiles, boolean useStaticAmount, boolean addInvalidAddresses) throws IOException {
         CAddressFilesToLMDB addressFilesToLMDBConfigurationWrite = new CAddressFilesToLMDB();
-        
+
         List<String> files = addressesFiles.createAddressesFiles(folder, addInvalidAddresses);
         addressFilesToLMDBConfigurationWrite.addressesFiles.addAll(files);
         addressFilesToLMDBConfigurationWrite.lmdbConfigurationWrite = new CLMDBConfigurationWrite();
         addressFilesToLMDBConfigurationWrite.lmdbConfigurationWrite.useStaticAmount = useStaticAmount;
         addressFilesToLMDBConfigurationWrite.lmdbConfigurationWrite.staticAmount = 0L;
-        File lmdbFolder = folder.newFolder("lmdb");
+        File lmdbFolder = Files.createDirectory(folder.resolve("lmdb")).toFile();
         String lmdbFolderPath = lmdbFolder.getAbsolutePath();
         addressFilesToLMDBConfigurationWrite.lmdbConfigurationWrite.lmdbDirectory = lmdbFolderPath;
         AddressFilesToLMDB addressFilesToLMDB = new AddressFilesToLMDB(addressFilesToLMDBConfigurationWrite);


### PR DESCRIPTION
## Summary

- Migrate entire test suite from JUnit 4 with `junit-dataprovider` to JUnit 5 (Jupiter) with native `@ParameterizedTest` and `@MethodSource`
- Remove `@RunWith(DataProviderRunner.class)` and `@DataProvider` annotations; replace with JUnit 5 equivalents
- Update all test lifecycle annotations (`@Before`/`@After` → `@BeforeEach`/`@AfterEach`, `@Ignore` → `@Disabled`)
- Replace `@Rule TemporaryFolder` with JUnit 5's `@TempDir` and `java.nio.file.Path`
- Update data provider method references to fully qualified names (e.g., `"net.ladenthin.bitcoinaddressfinder.CommonDataProvider#largeSecretsAsHex"`)
- Remove JUnit 4 and vintage engine dependencies from `pom.xml`; keep JUnit 5 Jupiter as the sole test framework

## Test plan

- [x] Affected unit / integration tests pass locally
- [x] CI is green on this branch
- [x] All parameterized tests execute with correct data sources
- [x] Temporary folder and resource cleanup work correctly with `@TempDir`

## Related issues / PRs

Modernizes test infrastructure to use current JUnit 5 best practices.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01Lw41gXYk2hGaKo4z9DRiVM