### PR TITLE
Upgrade JUnit Jupiter from 5.12.0 to 6.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.12.0</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary

- Upgrade JUnit Jupiter dependency from version 5.12.0 to 6.0.3
- This brings the test framework to the latest major version with new features and improvements
- No source code changes required; existing JUnit 4 tests continue to run via the JUnit 5 vintage engine

## Test plan

- [x] CI is green on this branch
- [x] Affected unit / integration tests pass locally (no code changes; dependency upgrade only)

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_012bgi3bhr6byA3NTi9oHuw3