### PR TITLE
Upgrade to JUnit 6 (Jupiter) and remove legacy test dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ BitcoinAddressFinder/
 │   │       └── simplelogger.properties
 │   └── test/
 │       └── java/net/ladenthin/bitcoinaddressfinder/
-│           └── *.java                # JUnit 4 tests (run via JUnit 5 vintage engine)
+│           └── *.java                # JUnit 6 (Jupiter) tests
 ├── examples/                         # Sample JSON configs and run scripts
 │   ├── config_*.json
 │   ├── run_*.bat
@@ -217,11 +217,9 @@ See `examples/config_*.json` for all configuration variants.
 
 ### Frameworks
 
-- **JUnit 4** (4.13.2) — existing tests (run unchanged via JUnit 5 vintage engine)
-- **JUnit 5** (5.12.0) — `junit-vintage-engine` runs all JUnit 4 tests on the JUnit Platform; `junit-jupiter` available for new tests
+- **JUnit 6** (6.0.3) — `junit-jupiter` (JUnit Jupiter) for all tests
 - **Hamcrest** (3.0) — matchers
-- **Mockito** (5.22.0) — mocking
-- **junit4-dataprovider** (2.12) — data-driven tests
+- **Mockito** (5.23.0) — mocking
 
 ### Conventions
 
@@ -337,12 +335,9 @@ GPU code is bound through JOCL (`jocl` 2.0.6). `OpenCLBuilder` constructs the pl
 | `logback-classic` | 1.5.32 | SLF4J implementation |
 
 Test-only:
-| `junit` | 4.13.2 | Existing JUnit 4 tests (compile + run via vintage engine) |
-| `junit-vintage-engine` | 5.12.0 | Runs JUnit 4 tests on JUnit Platform |
-| `junit-jupiter` | 5.12.0 | JUnit 5 support for new tests |
+| `junit-jupiter` | 6.0.3 | JUnit 6 (Jupiter) test framework |
 | `hamcrest` | 3.0 | Assertion matchers |
 | `mockito-core` | 5.23.0 | Mocking |
-| `junit4-dataprovider` | 2.12 | Data-driven tests |
 
 ---
 


### PR DESCRIPTION
## Summary

- Upgrade test framework from JUnit 4 + JUnit 5 vintage engine to JUnit 6 (Jupiter)
- Remove `junit-vintage-engine` and `junit4-dataprovider` dependencies
- Update Mockito from 5.22.0 to 5.23.0
- Update documentation to reflect JUnit 6 as the sole test framework

## Test plan

- [x] Existing unit tests pass with JUnit 6 (Jupiter)
- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01SgRXpvs9zEZAyYWP36PqJE