### PR TITLE
Add jqwik, ArchUnit, and SpotBugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 **Build:**  
 ![Java 21+](https://img.shields.io/badge/Java-21%2B-informational)  
 ![JUnit](https://img.shields.io/badge/tested%20with-JUnit4-yellow)  
+[![jqwik](https://img.shields.io/badge/tested%20with-jqwik-1f6feb)](https://jqwik.net)  
+[![ArchUnit](https://img.shields.io/badge/tested%20with-ArchUnit-c71a36)](https://www.archunit.org)  
+[![SpotBugs](https://img.shields.io/badge/analyzed%20with-SpotBugs-3b5998)](https://spotbugs.github.io)  
 [![Publish](https://github.com/bernardladenthin/BitcoinAddressFinder/actions/workflows/publish.yml/badge.svg)](https://github.com/bernardladenthin/BitcoinAddressFinder/actions/workflows/publish.yml)  
 [![CodeQL](https://github.com/bernardladenthin/BitcoinAddressFinder/actions/workflows/codeql.yml/badge.svg)](https://github.com/bernardladenthin/BitcoinAddressFinder/actions/workflows/codeql.yml)  
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![jqwik](https://img.shields.io/badge/tested%20with-jqwik-1f6feb)](https://jqwik.net)  
 [![ArchUnit](https://img.shields.io/badge/tested%20with-ArchUnit-c71a36)](https://www.archunit.org)  
 [![SpotBugs](https://img.shields.io/badge/analyzed%20with-SpotBugs-3b5998)](https://spotbugs.github.io)  
+[![JMH](https://img.shields.io/badge/benchmarked%20with-JMH-brightgreen)](https://github.com/openjdk/jmh)  
 [![Publish](https://github.com/bernardladenthin/BitcoinAddressFinder/actions/workflows/publish.yml/badge.svg)](https://github.com/bernardladenthin/BitcoinAddressFinder/actions/workflows/publish.yml)  
 [![CodeQL](https://github.com/bernardladenthin/BitcoinAddressFinder/actions/workflows/codeql.yml/badge.svg)](https://github.com/bernardladenthin/BitcoinAddressFinder/actions/workflows/codeql.yml)  
 

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@ SPDX-License-Identifier: Apache-2.0
                 <configuration>
                     <effort>Default</effort>
                     <threshold>Default</threshold>
-                    <failOnError>false</failOnError>
+                    <failOnError>true</failOnError>
                     <includeTests>false</includeTests>
                     <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
                     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,15 @@ SPDX-License-Identifier: Apache-2.0
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                    <classpathScope>test</classpathScope>
+                </configuration>
+            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -474,6 +483,18 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
             <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.37</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.37</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -267,8 +267,41 @@ SPDX-License-Identifier: Apache-2.0
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.8.6.6</version>
+                <configuration>
+                    <effort>Default</effort>
+                    <threshold>Default</threshold>
+                    <failOnError>false</failOnError>
+                    <includeTests>false</includeTests>
+                    <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.mebigfatguy.fb-contrib</groupId>
+                            <artifactId>fb-contrib</artifactId>
+                            <version>7.6.4</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>1.13.0</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>spotbugs-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-        
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -429,6 +462,18 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>5.23.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <version>1.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/4.8.6/spotbugs/etc/findbugsfilter.xsd">
+
+</FindBugsFilter>

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtility.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtility.java
@@ -18,8 +18,20 @@ public class ByteBufferUtility {
      */
     private final boolean allocateDirect;
 
+    /**
+     * Selects the byte-array reversal algorithm used by {@link #reverse(byte[])}.
+     * {@code true} uses XOR swap (no temporary variable);
+     * {@code false} uses a temporary-variable swap.
+     */
+    private final boolean useXorSwap;
+
     public ByteBufferUtility(boolean allocateDirect) {
+        this(allocateDirect, false);
+    }
+
+    public ByteBufferUtility(boolean allocateDirect, boolean useXorSwap) {
         this.allocateDirect = allocateDirect;
+        this.useXorSwap = useXorSwap;
     }
     
     /**
@@ -159,13 +171,11 @@ public class ByteBufferUtility {
         return bytes;
     }
     
-    private final static boolean USE_XOR_SWAP = false;
-    
     /**
      * https://stackoverflow.com/questions/12893758/how-to-reverse-the-byte-array-in-java
      */
     public void reverse(byte @NonNull [] array) {
-        if (USE_XOR_SWAP) {
+        if (useXorSwap) {
             int len = array.length;
             for (int i = 0; i < len / 2; i++) {
                 array[i] ^= array[len - i - 1];

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtility.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/ByteBufferUtility.java
@@ -19,6 +19,12 @@ public class ByteBufferUtility {
     private final boolean allocateDirect;
 
     /**
+     * Default value for {@link #useXorSwap}: temporary-variable swap.
+     * https://stackoverflow.com/questions/12893758/how-to-reverse-the-byte-array-in-java
+     */
+    private static final boolean DEFAULT_USE_XOR_SWAP = false;
+
+    /**
      * Selects the byte-array reversal algorithm used by {@link #reverse(byte[])}.
      * {@code true} uses XOR swap (no temporary variable);
      * {@code false} uses a temporary-variable swap.
@@ -26,7 +32,7 @@ public class ByteBufferUtility {
     private final boolean useXorSwap;
 
     public ByteBufferUtility(boolean allocateDirect) {
-        this(allocateDirect, false);
+        this(allocateDirect, DEFAULT_USE_XOR_SWAP);
     }
 
     public ByteBufferUtility(boolean allocateDirect, boolean useXorSwap) {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/Hash160.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/Hash160.java
@@ -1,0 +1,72 @@
+// @formatter:off
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+// @formatter:on
+package net.ladenthin.bitcoinaddressfinder;
+
+import com.google.common.hash.Hashing;
+import org.bitcoinj.crypto.internal.CryptoUtils;
+import org.bouncycastle.crypto.digests.RIPEMD160Digest;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Encapsulates the two SHA-256 + RIPEMD-160 implementations used to derive
+ * Bitcoin hash160 values from public keys.
+ *
+ * <p>The implementation is selected at construction time:</p>
+ * <ul>
+ *   <li>{@code useFast = true} &#x2192; Guava SHA-256 + Bouncy Castle
+ *       RIPEMD-160 (the fast path)</li>
+ *   <li>{@code useFast = false} &#x2192; {@link CryptoUtils#sha256hash160}
+ *       (the BitcoinJ built-in)</li>
+ * </ul>
+ *
+ * <p>The default constructor uses {@link #DEFAULT_USE_FAST}, matching the
+ * behaviour that was previously controlled by
+ * {@link PublicKeyBytes#USE_SHA256_RIPEMD160_FAST}.</p>
+ */
+public class Hash160 {
+
+    /**
+     * Default algorithm selection: {@code true} &#x2192; Guava + Bouncy Castle
+     * (fast path). Mirrors {@link PublicKeyBytes#USE_SHA256_RIPEMD160_FAST}.
+     */
+    public static final boolean DEFAULT_USE_FAST = true;
+
+    private final boolean useFast;
+
+    /** Creates a {@link Hash160} using {@link #DEFAULT_USE_FAST}. */
+    public Hash160() {
+        this(DEFAULT_USE_FAST);
+    }
+
+    /**
+     * Creates a {@link Hash160} with an explicit algorithm selection.
+     *
+     * @param useFast {@code true} for Guava + Bouncy Castle, {@code false}
+     *                for {@link CryptoUtils#sha256hash160}
+     */
+    public Hash160(boolean useFast) {
+        this.useFast = useFast;
+    }
+
+    /**
+     * Computes RIPEMD-160(SHA-256(input)).
+     *
+     * @param input the raw public key bytes (compressed or uncompressed)
+     * @return a 20-byte hash160 result
+     */
+    public byte @NonNull [] hash(byte @NonNull [] input) {
+        if (useFast) {
+            byte[] sha256 = Hashing.sha256().hashBytes(input).asBytes();
+            RIPEMD160Digest digest = new RIPEMD160Digest();
+            digest.update(sha256, 0, sha256.length);
+            byte[] out = new byte[PublicKeyBytes.RIPEMD160_HASH_NUM_BYTES];
+            digest.doFinal(out, 0);
+            return out;
+        } else {
+            return CryptoUtils.sha256hash160(input);
+        }
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/Hash160.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/Hash160.java
@@ -22,15 +22,13 @@ import org.jspecify.annotations.NonNull;
  *       (the BitcoinJ built-in)</li>
  * </ul>
  *
- * <p>The default constructor uses {@link #DEFAULT_USE_FAST}, matching the
- * behaviour that was previously controlled by
- * {@link PublicKeyBytes#USE_SHA256_RIPEMD160_FAST}.</p>
+ * <p>The default constructor uses {@link #DEFAULT_USE_FAST}.</p>
  */
 public class Hash160 {
 
     /**
      * Default algorithm selection: {@code true} &#x2192; Guava + Bouncy Castle
-     * (fast path). Mirrors {@link PublicKeyBytes#USE_SHA256_RIPEMD160_FAST}.
+     * (fast path).
      */
     public static final boolean DEFAULT_USE_FAST = true;
 

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
@@ -3,15 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
-import com.google.common.hash.Hashing;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.ECKey;
-import org.bitcoinj.crypto.internal.CryptoUtils;
-import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -19,11 +16,14 @@ import org.slf4j.Logger;
 public class PublicKeyBytes {
     
     /**
-     * Use {@link com.google.common.hash.Hashing} and
-     * {@link org.bouncycastle.crypto.digests.RIPEMD160Digest} instead
-     * {@link org.bitcoinj.crypto.internal.CryptoUtils#sha256hash160(byte[])}.
+     * Selects the SHA-256 + RIPEMD-160 implementation used by this class.
+     * Delegates to {@link Hash160#DEFAULT_USE_FAST}.
+     *
+     * @see Hash160
      */
-    public static final boolean USE_SHA256_RIPEMD160_FAST = true;
+    public static final boolean USE_SHA256_RIPEMD160_FAST = Hash160.DEFAULT_USE_FAST;
+
+    private static final Hash160 HASH160 = new Hash160();
 
     public static final BigInteger MAX_TECHNICALLY_PRIVATE_KEY = BigInteger.valueOf(2).pow(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS).subtract(BigInteger.ONE);
 
@@ -347,11 +347,7 @@ public class PublicKeyBytes {
    }
    
    private static byte @NonNull [] calculateHash160(byte[] input) {
-        if (USE_SHA256_RIPEMD160_FAST) {
-            return sha256hash160Fast(input);
-        } else {
-            return CryptoUtils.sha256hash160(input);
-        }
+        return HASH160.hash(input);
     }
 
     public byte @NonNull [] getUncompressedKeyHash() {
@@ -369,17 +365,13 @@ public class PublicKeyBytes {
     }
 
     /**
-     * Calculates RIPEMD160(SHA256(input)). This is used in Address
-     * calculations. Same as {@link org.bitcoinj.crypto.internal.CryptoUtils#sha256hash160(byte[])} but using
-     * {@link DigestUtils}.
+     * Calculates RIPEMD-160(SHA-256(input)) using the Guava + Bouncy Castle
+     * fast path. Delegates to {@link Hash160} with {@code useFast = true}.
+     *
+     * @see Hash160#hash(byte[])
      */
     public static byte[] sha256hash160Fast(byte[] input) {
-        byte[] sha256 = Hashing.sha256().hashBytes(input).asBytes();
-        RIPEMD160Digest digest = new RIPEMD160Digest();
-        digest.update(sha256, 0, sha256.length);
-        byte[] out = new byte[RIPEMD160_HASH_NUM_BYTES];
-        digest.doFinal(out, 0);
-        return out;
+        return new Hash160(true).hash(input);
     }
 
     public @NonNull String getCompressedKeyHashAsBase58(@NonNull KeyUtility keyUtility) {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
@@ -15,14 +15,6 @@ import org.slf4j.Logger;
 
 public class PublicKeyBytes {
     
-    /**
-     * Selects the SHA-256 + RIPEMD-160 implementation used by this class.
-     * Delegates to {@link Hash160#DEFAULT_USE_FAST}.
-     *
-     * @see Hash160
-     */
-    public static final boolean USE_SHA256_RIPEMD160_FAST = Hash160.DEFAULT_USE_FAST;
-
     public static final BigInteger MAX_TECHNICALLY_PRIVATE_KEY = BigInteger.valueOf(2).pow(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS).subtract(BigInteger.ONE);
 
     public static final BigInteger MIN_PRIVATE_KEY = BigInteger.ONE;

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
@@ -23,8 +23,6 @@ public class PublicKeyBytes {
      */
     public static final boolean USE_SHA256_RIPEMD160_FAST = Hash160.DEFAULT_USE_FAST;
 
-    private static final Hash160 HASH160 = new Hash160();
-
     public static final BigInteger MAX_TECHNICALLY_PRIVATE_KEY = BigInteger.valueOf(2).pow(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS).subtract(BigInteger.ONE);
 
     public static final BigInteger MIN_PRIVATE_KEY = BigInteger.ONE;
@@ -213,6 +211,7 @@ public class PublicKeyBytes {
 
     private final BigInteger secretKey;
     private final PrivateKeyValidator privateKeyValidator;
+    private final Hash160 hash160 = new Hash160();
     
     // [4, 121, -66, 102, 126, -7, -36, -69, -84, 85, -96, 98, -107, -50, -121, 11, 7, 2, -101, -4, -37, 45, -50, 40, -39, 89, -14, -127, 91, 22, -8, 23, -104, 72, 58, -38, 119, 38, -93, -60, 101, 93, -92, -5, -4, 14, 17, 8, -88, -3, 23, -76, 72, -90, -123, 84, 25, -100, 71, -48, -113, -5, 16, -44, -72]
     // Hex.decodeHex("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8")
@@ -346,8 +345,8 @@ public class PublicKeyBytes {
        return true;
    }
    
-   private static byte @NonNull [] calculateHash160(byte[] input) {
-        return HASH160.hash(input);
+   private byte @NonNull [] calculateHash160(byte[] input) {
+        return hash160.hash(input);
     }
 
     public byte @NonNull [] getUncompressedKeyHash() {
@@ -362,16 +361,6 @@ public class PublicKeyBytes {
             compressedKeyHash = calculateHash160(compressed);
         }
         return compressedKeyHash;
-    }
-
-    /**
-     * Calculates RIPEMD-160(SHA-256(input)) using the Guava + Bouncy Castle
-     * fast path. Delegates to {@link Hash160} with {@code useFast = true}.
-     *
-     * @see Hash160#hash(byte[])
-     */
-    public static byte[] sha256hash160Fast(byte[] input) {
-        return new Hash160(true).hash(input);
     }
 
     public @NonNull String getCompressedKeyHashAsBase58(@NonNull KeyUtility keyUtility) {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
@@ -337,20 +337,16 @@ public class PublicKeyBytes {
        return true;
    }
    
-   private byte @NonNull [] calculateHash160(byte[] input) {
-        return hash160.hash(input);
-    }
-
     public byte @NonNull [] getUncompressedKeyHash() {
         if (uncompressedKeyHash == null) {
-            uncompressedKeyHash = calculateHash160(uncompressed);
+            uncompressedKeyHash = hash160.hash(uncompressed);
         }
         return uncompressedKeyHash;
     }
 
     public byte @NonNull [] getCompressedKeyHash() {
         if (compressedKeyHash == null) {
-            compressedKeyHash = calculateHash160(compressed);
+            compressedKeyHash = hash160.hash(compressed);
         }
         return compressedKeyHash;
     }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BitcoinAddressFinderArchitectureTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BitcoinAddressFinderArchitectureTest.java
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(packages = "net.ladenthin.bitcoinaddressfinder", importOptions = ImportOption.DoNotIncludeTests.class)
+public class BitcoinAddressFinderArchitectureTest {
+
+    /**
+     * The CLI entry point is the top-level consumer; no other package should import it.
+     */
+    @ArchTest
+    static final ArchRule cliIsLeaf = noClasses()
+            .that().resideOutsideOfPackage("net.ladenthin.bitcoinaddressfinder.cli..")
+            .should().dependOnClassesThat()
+            .resideInAPackage("net.ladenthin.bitcoinaddressfinder.cli..");
+
+    /**
+     * Test-framework classes must not appear in production code.
+     */
+    @ArchTest
+    static final ArchRule noTestFrameworksInProduction = noClasses()
+            .that().resideInAPackage("net.ladenthin.bitcoinaddressfinder..")
+            .should().dependOnClassesThat()
+            .resideInAnyPackage("org.junit..", "net.jqwik..", "com.tngtech.archunit..");
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BitcoinAddressProperties.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BitcoinAddressProperties.java
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder;
+
+import java.math.BigInteger;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+public class BitcoinAddressProperties {
+
+    private final BitHelper bitHelper = new BitHelper();
+
+    @Property
+    boolean getKillBitsHasExactlyNBitsSet(@ForAll @IntRange(min = 0, max = 20) int bits) {
+        BigInteger result = bitHelper.getKillBits(bits);
+        return result.bitCount() == bits;
+    }
+
+    @Property
+    boolean convertBitsSizeIsPowerOfTwo(@ForAll @IntRange(min = 0, max = 20) int bits) {
+        int size = bitHelper.convertBitsToSize(bits);
+        return size == (1 << bits);
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytesTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytesTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
+import net.ladenthin.bitcoinaddressfinder.Hash160;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddresses42;
 import org.apache.commons.codec.binary.Hex;
 import org.bitcoinj.base.LegacyAddress;
@@ -391,16 +392,16 @@ public class PublicKeyBytesTest {
     }
     // </editor-fold>
 
-    // <editor-fold defaultstate="collapsed" desc="sha256hash160Fast">
+    // <editor-fold defaultstate="collapsed" desc="Hash160">
     @Test
-    public void sha256hash160Fast_knownInput_matchesCryptoUtilsResult() {
+    public void hash160Fast_knownInput_matchesCryptoUtilsResult() {
         // arrange
         BigInteger secretKey = new BigInteger("1337");
         ECKey ecKey = ECKey.fromPrivate(secretKey, false);
         byte[] pubKey = ecKey.getPubKey();
 
         // act
-        byte[] fastResult = PublicKeyBytes.sha256hash160Fast(pubKey);
+        byte[] fastResult = new Hash160(true).hash(pubKey);
 
         // assert
         byte[] expected = CryptoUtils.sha256hash160(pubKey);
@@ -408,14 +409,14 @@ public class PublicKeyBytesTest {
     }
 
     @Test
-    public void sha256hash160Fast_compressedKey_matchesCryptoUtilsResult() {
+    public void hash160Fast_compressedKey_matchesCryptoUtilsResult() {
         // arrange
         BigInteger secretKey = new BigInteger("1337");
         ECKey ecKey = ECKey.fromPrivate(secretKey, true);
         byte[] pubKey = ecKey.getPubKey();
 
         // act
-        byte[] fastResult = PublicKeyBytes.sha256hash160Fast(pubKey);
+        byte[] fastResult = new Hash160(true).hash(pubKey);
 
         // assert
         byte[] expected = CryptoUtils.sha256hash160(pubKey);
@@ -423,12 +424,12 @@ public class PublicKeyBytesTest {
     }
 
     @Test
-    public void sha256hash160Fast_resultLength_isRipemd160HashLength() {
+    public void hash160Fast_resultLength_isRipemd160HashLength() {
         // arrange
         byte[] input = new byte[] {0x01, 0x02, 0x03};
 
         // act
-        byte[] result = PublicKeyBytes.sha256hash160Fast(input);
+        byte[] result = new Hash160(true).hash(input);
 
         // assert
         assertThat(result.length, is(equalTo(PublicKeyBytes.RIPEMD160_HASH_NUM_BYTES)));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytesTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytesTest.java
@@ -401,7 +401,7 @@ public class PublicKeyBytesTest {
         byte[] pubKey = ecKey.getPubKey();
 
         // act
-        byte[] fastResult = new Hash160(true).hash(pubKey);
+        byte[] fastResult = new Hash160().hash(pubKey);
 
         // assert
         byte[] expected = CryptoUtils.sha256hash160(pubKey);
@@ -416,7 +416,7 @@ public class PublicKeyBytesTest {
         byte[] pubKey = ecKey.getPubKey();
 
         // act
-        byte[] fastResult = new Hash160(true).hash(pubKey);
+        byte[] fastResult = new Hash160().hash(pubKey);
 
         // assert
         byte[] expected = CryptoUtils.sha256hash160(pubKey);
@@ -429,7 +429,7 @@ public class PublicKeyBytesTest {
         byte[] input = new byte[] {0x01, 0x02, 0x03};
 
         // act
-        byte[] result = new Hash160(true).hash(input);
+        byte[] result = new Hash160().hash(input);
 
         // assert
         assertThat(result.length, is(equalTo(PublicKeyBytes.RIPEMD160_HASH_NUM_BYTES)));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/BitHelperBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/BitHelperBenchmark.java
@@ -1,0 +1,74 @@
+// @formatter:off
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+// @formatter:on
+package net.ladenthin.bitcoinaddressfinder.benchmark;
+
+import java.math.BigInteger;
+import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.BitHelper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Throughput benchmark for {@link BitHelper} bit-manipulation operations.
+ *
+ * <p>{@link BitHelper#getKillBits(int)} and {@link BitHelper#convertBitsToSize(int)} sit
+ * on the key-producer hot path: they are called once per producer batch to compute the
+ * address-space partition size. This benchmark measures their allocation and computation cost.</p>
+ *
+ * <p>Run locally:</p>
+ * <pre>
+ * mvn test-compile exec:java -Dexec.args="BitHelperBenchmark -prof gc"
+ * </pre>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@Fork(1)
+public class BitHelperBenchmark {
+
+    /** Bit counts covering the typical producer batch-size range (1, 8, 16, 20 bits). */
+    @Param({"1", "8", "16", "20"})
+    public int bits;
+
+    private final BitHelper bitHelper = new BitHelper();
+
+    /**
+     * Benchmarks {@link BitHelper#getKillBits(int)} across several bit counts.
+     *
+     * <p>Measures {@link BigInteger} allocation and shift cost for the kill-bits computation
+     * used to mask off the low-order bits of a private key batch start.</p>
+     *
+     * @param bh JMH blackhole to prevent dead-code elimination
+     */
+    @Benchmark
+    public void getKillBits(Blackhole bh) {
+        bh.consume(bitHelper.getKillBits(bits));
+    }
+
+    /**
+     * Benchmarks {@link BitHelper#convertBitsToSize(int)} across several bit counts.
+     *
+     * <p>Measures the cost of computing the batch size ({@code 2^bits}) as a plain
+     * {@code int} shift &#x2014; the cheapest of the two helper operations.</p>
+     *
+     * @param bh JMH blackhole to prevent dead-code elimination
+     */
+    @Benchmark
+    public void convertBitsToSize(Blackhole bh) {
+        bh.consume(bitHelper.convertBitsToSize(bits));
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/ByteSwapBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/ByteSwapBenchmark.java
@@ -6,6 +6,7 @@
 package net.ladenthin.bitcoinaddressfinder.benchmark;
 
 import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.ByteBufferUtility;
 import net.ladenthin.bitcoinaddressfinder.PublicKeyBytes;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -22,9 +23,10 @@ import org.openjdk.jmh.infra.Blackhole;
 
 /**
  * Throughput benchmark for the two byte-array reversal strategies controlled
- * by the private constant {@code ByteBufferUtility.USE_XOR_SWAP}.
+ * by the {@code useXorSwap} constructor parameter of {@link ByteBufferUtility}.
  *
- * <p>The constant selects between two in-place reversal algorithms:</p>
+ * <p>The parameter selects between two in-place reversal algorithms in
+ * {@link ByteBufferUtility#reverse(byte[])}:</p>
  * <ul>
  *   <li>{@code useXorSwap = true} &#x2192; XOR swap (no temporary variable,
  *       3 XOR operations per element pair)</li>
@@ -57,11 +59,8 @@ import org.openjdk.jmh.infra.Blackhole;
 public class ByteSwapBenchmark {
 
     /**
-     * Selects the reversal algorithm:
-     * {@code true} &#x2192; XOR swap (no temp variable),
-     * {@code false} &#x2192; temporary-variable swap.
-     *
-     * <p>Corresponds directly to {@code ByteBufferUtility.USE_XOR_SWAP}.</p>
+     * Selects the reversal algorithm passed to the {@link ByteBufferUtility} constructor:
+     * {@code true} &#x2192; XOR swap, {@code false} &#x2192; temporary-variable swap.
      */
     @Param({"false", "true"})
     public boolean useXorSwap;
@@ -75,12 +74,13 @@ public class ByteSwapBenchmark {
     @Param({"20", "32", "65"})
     public int arraySize;
 
-    /** Working copy repopulated each iteration to keep input non-trivially ordered. */
-    private byte[] array;
+    private ByteBufferUtility byteBufferUtility = new ByteBufferUtility(false);
+    private byte[] array = new byte[0];
 
-    /** Initializes the array with sequential bytes so both implementations see the same input. */
+    /** Creates a {@link ByteBufferUtility} configured with the selected swap strategy. */
     @Setup
     public void setUp() {
+        byteBufferUtility = new ByteBufferUtility(false, useXorSwap);
         array = new byte[arraySize];
         for (int i = 0; i < arraySize; i++) {
             array[i] = (byte) i;
@@ -88,36 +88,16 @@ public class ByteSwapBenchmark {
     }
 
     /**
-     * Reverses the byte array in-place using the selected swap strategy.
+     * Reverses the byte array in-place via {@link ByteBufferUtility#reverse(byte[])}.
      *
-     * <p>Directly mirrors {@code ByteBufferUtility.reverse()}: when
-     * {@code useXorSwap = true} the loop uses three XOR operations per pair
-     * (no heap allocation, no {@code tmp} variable); when {@code false} it
-     * uses a local {@code byte tmp} — the strategy the constant defaults to.</p>
+     * <p>The {@link ByteBufferUtility} instance was constructed with {@code useXorSwap}
+     * so the call exercises the selected algorithm inside the real production method.</p>
      *
      * @param bh JMH blackhole to prevent dead-code elimination
      */
     @Benchmark
     public void reverse(Blackhole bh) {
-        if (useXorSwap) {
-            final int len = array.length;
-            for (int i = 0; i < len / 2; i++) {
-                array[i] ^= array[len - i - 1];
-                array[len - i - 1] ^= array[i];
-                array[i] ^= array[len - i - 1];
-            }
-        } else {
-            int i = 0;
-            int j = array.length - 1;
-            byte tmp;
-            while (j > i) {
-                tmp = array[j];
-                array[j] = array[i];
-                array[i] = tmp;
-                j--;
-                i++;
-            }
-        }
+        byteBufferUtility.reverse(array);
         bh.consume(array);
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/ByteSwapBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/ByteSwapBenchmark.java
@@ -1,0 +1,123 @@
+// @formatter:off
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+// @formatter:on
+package net.ladenthin.bitcoinaddressfinder.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.PublicKeyBytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Throughput benchmark for the two byte-array reversal strategies controlled
+ * by the private constant {@code ByteBufferUtility.USE_XOR_SWAP}.
+ *
+ * <p>The constant selects between two in-place reversal algorithms:</p>
+ * <ul>
+ *   <li>{@code useXorSwap = true} &#x2192; XOR swap (no temporary variable,
+ *       3 XOR operations per element pair)</li>
+ *   <li>{@code useXorSwap = false} &#x2192; temporary-variable swap (the
+ *       classic approach, 1 read + 2 writes per element pair)</li>
+ * </ul>
+ *
+ * <p>Array sizes mirror the byte lengths that appear on the hot path in
+ * {@code EndiannessConverter} (called during OpenCL key scanning):</p>
+ * <ul>
+ *   <li>{@code 20} &#x2014; RIPEMD-160 / hash160 output
+ *       ({@link PublicKeyBytes#RIPEMD160_HASH_NUM_BYTES})</li>
+ *   <li>{@code 32} &#x2014; SHA-256 output / private key
+ *       ({@link PublicKeyBytes#SHA256_HASH_NUM_BYTES})</li>
+ *   <li>{@code 65} &#x2014; uncompressed SEC public key
+ *       ({@link PublicKeyBytes#SEC_PUBLIC_KEY_UNCOMPRESSED_NUM_BYTES})</li>
+ * </ul>
+ *
+ * <p>Run locally:</p>
+ * <pre>
+ * mvn test-compile exec:java -Dexec.args="ByteSwapBenchmark -prof gc"
+ * </pre>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@Fork(1)
+public class ByteSwapBenchmark {
+
+    /**
+     * Selects the reversal algorithm:
+     * {@code true} &#x2192; XOR swap (no temp variable),
+     * {@code false} &#x2192; temporary-variable swap.
+     *
+     * <p>Corresponds directly to {@code ByteBufferUtility.USE_XOR_SWAP}.</p>
+     */
+    @Param({"false", "true"})
+    public boolean useXorSwap;
+
+    /**
+     * Array length in bytes.
+     *
+     * <p>20 = RIPEMD-160 hash, 32 = SHA-256 / private key,
+     * 65 = uncompressed public key.</p>
+     */
+    @Param({"20", "32", "65"})
+    public int arraySize;
+
+    /** Working copy repopulated each iteration to keep input non-trivially ordered. */
+    private byte[] array;
+
+    /** Initializes the array with sequential bytes so both implementations see the same input. */
+    @Setup
+    public void setUp() {
+        array = new byte[arraySize];
+        for (int i = 0; i < arraySize; i++) {
+            array[i] = (byte) i;
+        }
+    }
+
+    /**
+     * Reverses the byte array in-place using the selected swap strategy.
+     *
+     * <p>Directly mirrors {@code ByteBufferUtility.reverse()}: when
+     * {@code useXorSwap = true} the loop uses three XOR operations per pair
+     * (no heap allocation, no {@code tmp} variable); when {@code false} it
+     * uses a local {@code byte tmp} — the strategy the constant defaults to.</p>
+     *
+     * @param bh JMH blackhole to prevent dead-code elimination
+     */
+    @Benchmark
+    public void reverse(Blackhole bh) {
+        if (useXorSwap) {
+            final int len = array.length;
+            for (int i = 0; i < len / 2; i++) {
+                array[i] ^= array[len - i - 1];
+                array[len - i - 1] ^= array[i];
+                array[i] ^= array[len - i - 1];
+            }
+        } else {
+            int i = 0;
+            int j = array.length - 1;
+            byte tmp;
+            while (j > i) {
+                tmp = array[j];
+                array[j] = array[i];
+                array[i] = tmp;
+                j--;
+                i++;
+            }
+        }
+        bh.consume(array);
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/PublicKeyHashBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/PublicKeyHashBenchmark.java
@@ -1,0 +1,115 @@
+// @formatter:off
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+// @formatter:on
+package net.ladenthin.bitcoinaddressfinder.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.PublicKeyBytes;
+import org.bitcoinj.crypto.internal.CryptoUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Throughput benchmark for the two SHA-256 + RIPEMD-160 implementations used in
+ * {@link PublicKeyBytes}.
+ *
+ * <p>The static constant {@link PublicKeyBytes#USE_SHA256_RIPEMD160_FAST} selects
+ * between two hash implementations at compile time:</p>
+ * <ul>
+ *   <li>{@code true} &#x2192; {@link PublicKeyBytes#sha256hash160Fast} &#x2014;
+ *       Guava SHA-256 + Bouncy Castle RIPEMD-160</li>
+ *   <li>{@code false} &#x2192; {@link CryptoUtils#sha256hash160} &#x2014;
+ *       BitcoinJ built-in implementation</li>
+ * </ul>
+ *
+ * <p>This benchmark parameterises over {@code useFast = {false, true}} so that
+ * both paths are measured side by side. The expected result is that {@code true}
+ * (fast) yields significantly more ops/sec &#x2014; which is why the constant
+ * defaults to {@code true}.</p>
+ *
+ * <p>Run locally:</p>
+ * <pre>
+ * mvn test-compile exec:java -Dexec.args="PublicKeyHashBenchmark -prof gc"
+ * </pre>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@Fork(1)
+public class PublicKeyHashBenchmark {
+
+    /**
+     * Selects the hash implementation:
+     * {@code true} &#x2192; {@link PublicKeyBytes#sha256hash160Fast} (Guava + Bouncy Castle),
+     * {@code false} &#x2192; {@link CryptoUtils#sha256hash160} (BitcoinJ).
+     *
+     * <p>Corresponds directly to {@link PublicKeyBytes#USE_SHA256_RIPEMD160_FAST}.</p>
+     */
+    @Param({"false", "true"})
+    public boolean useFast;
+
+    /** Fixed 65-byte uncompressed public key ({@code 04 || X || Y}) used as hash input. */
+    private byte[] uncompressedKey;
+
+    /** Fixed 33-byte compressed public key ({@code 02/03 || X}) used as hash input. */
+    private byte[] compressedKey;
+
+    /** Initializes fixed-content key byte arrays so every iteration hashes the same input. */
+    @Setup
+    public void setUp() {
+        uncompressedKey = new byte[PublicKeyBytes.PUBLIC_KEY_UNCOMPRESSED_BYTES];
+        uncompressedKey[0] = PublicKeyBytes.UNCOMPRESSED_PREFIX;
+        for (int i = 1; i < uncompressedKey.length; i++) {
+            uncompressedKey[i] = (byte) i;
+        }
+        compressedKey = PublicKeyBytes.createCompressedBytes(uncompressedKey);
+    }
+
+    /**
+     * Hashes an uncompressed public key (65 bytes) using the selected implementation.
+     *
+     * <p>Uncompressed keys are the larger input; this benchmark shows the per-byte
+     * cost difference between the two implementations at full 65-byte input size.</p>
+     *
+     * @param bh JMH blackhole to prevent dead-code elimination
+     */
+    @Benchmark
+    public void hashUncompressed(Blackhole bh) {
+        if (useFast) {
+            bh.consume(PublicKeyBytes.sha256hash160Fast(uncompressedKey));
+        } else {
+            bh.consume(CryptoUtils.sha256hash160(uncompressedKey));
+        }
+    }
+
+    /**
+     * Hashes a compressed public key (33 bytes) using the selected implementation.
+     *
+     * <p>Compressed keys are the smaller input; this benchmark shows whether the
+     * implementation gap persists at reduced input size.</p>
+     *
+     * @param bh JMH blackhole to prevent dead-code elimination
+     */
+    @Benchmark
+    public void hashCompressed(Blackhole bh) {
+        if (useFast) {
+            bh.consume(PublicKeyBytes.sha256hash160Fast(compressedKey));
+        } else {
+            bh.consume(CryptoUtils.sha256hash160(compressedKey));
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/PublicKeyHashBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/PublicKeyHashBenchmark.java
@@ -6,8 +6,8 @@
 package net.ladenthin.bitcoinaddressfinder.benchmark;
 
 import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.Hash160;
 import net.ladenthin.bitcoinaddressfinder.PublicKeyBytes;
-import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -22,22 +22,21 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
- * Throughput benchmark for the two SHA-256 + RIPEMD-160 implementations used in
- * {@link PublicKeyBytes}.
+ * Throughput benchmark for the two SHA-256 + RIPEMD-160 implementations
+ * encapsulated by {@link Hash160}.
  *
- * <p>The static constant {@link PublicKeyBytes#USE_SHA256_RIPEMD160_FAST} selects
- * between two hash implementations at compile time:</p>
+ * <p>{@link Hash160#DEFAULT_USE_FAST} selects between two hash implementations:</p>
  * <ul>
- *   <li>{@code true} &#x2192; {@link PublicKeyBytes#sha256hash160Fast} &#x2014;
- *       Guava SHA-256 + Bouncy Castle RIPEMD-160</li>
- *   <li>{@code false} &#x2192; {@link CryptoUtils#sha256hash160} &#x2014;
- *       BitcoinJ built-in implementation</li>
+ *   <li>{@code true} &#x2192; Guava SHA-256 + Bouncy Castle RIPEMD-160
+ *       (the fast path)</li>
+ *   <li>{@code false} &#x2192; BitcoinJ {@code CryptoUtils.sha256hash160}
+ *       (the reference path)</li>
  * </ul>
  *
  * <p>This benchmark parameterises over {@code useFast = {false, true}} so that
  * both paths are measured side by side. The expected result is that {@code true}
- * (fast) yields significantly more ops/sec &#x2014; which is why the constant
- * defaults to {@code true}.</p>
+ * yields significantly more ops/sec &#x2014; which is why
+ * {@link Hash160#DEFAULT_USE_FAST} defaults to {@code true}.</p>
  *
  * <p>Run locally:</p>
  * <pre>
@@ -53,11 +52,11 @@ import org.openjdk.jmh.infra.Blackhole;
 public class PublicKeyHashBenchmark {
 
     /**
-     * Selects the hash implementation:
-     * {@code true} &#x2192; {@link PublicKeyBytes#sha256hash160Fast} (Guava + Bouncy Castle),
-     * {@code false} &#x2192; {@link CryptoUtils#sha256hash160} (BitcoinJ).
+     * Selects the hash implementation passed to the {@link Hash160} constructor:
+     * {@code true} &#x2192; Guava + Bouncy Castle,
+     * {@code false} &#x2192; BitcoinJ {@code CryptoUtils}.
      *
-     * <p>Corresponds directly to {@link PublicKeyBytes#USE_SHA256_RIPEMD160_FAST}.</p>
+     * <p>Corresponds directly to {@link Hash160#DEFAULT_USE_FAST}.</p>
      */
     @Param({"false", "true"})
     public boolean useFast;
@@ -68,9 +67,13 @@ public class PublicKeyHashBenchmark {
     /** Fixed 33-byte compressed public key ({@code 02/03 || X}) used as hash input. */
     private byte[] compressedKey = new byte[0];
 
-    /** Initializes fixed-content key byte arrays so every iteration hashes the same input. */
+    /** {@link Hash160} instance configured with the selected implementation. */
+    private Hash160 hash160 = new Hash160();
+
+    /** Initializes fixed-content key byte arrays and the {@link Hash160} instance. */
     @Setup
     public void setUp() {
+        hash160 = new Hash160(useFast);
         uncompressedKey = new byte[PublicKeyBytes.PUBLIC_KEY_UNCOMPRESSED_BYTES];
         uncompressedKey[0] = (byte) PublicKeyBytes.SEC_PREFIX_UNCOMPRESSED_ECDSA_POINT;
         for (int i = 1; i < uncompressedKey.length; i++) {
@@ -80,7 +83,7 @@ public class PublicKeyHashBenchmark {
     }
 
     /**
-     * Hashes an uncompressed public key (65 bytes) using the selected implementation.
+     * Hashes an uncompressed public key (65 bytes) via {@link Hash160#hash(byte[])}.
      *
      * <p>Uncompressed keys are the larger input; this benchmark shows the per-byte
      * cost difference between the two implementations at full 65-byte input size.</p>
@@ -89,15 +92,11 @@ public class PublicKeyHashBenchmark {
      */
     @Benchmark
     public void hashUncompressed(Blackhole bh) {
-        if (useFast) {
-            bh.consume(PublicKeyBytes.sha256hash160Fast(uncompressedKey));
-        } else {
-            bh.consume(CryptoUtils.sha256hash160(uncompressedKey));
-        }
+        bh.consume(hash160.hash(uncompressedKey));
     }
 
     /**
-     * Hashes a compressed public key (33 bytes) using the selected implementation.
+     * Hashes a compressed public key (33 bytes) via {@link Hash160#hash(byte[])}.
      *
      * <p>Compressed keys are the smaller input; this benchmark shows whether the
      * implementation gap persists at reduced input size.</p>
@@ -106,10 +105,6 @@ public class PublicKeyHashBenchmark {
      */
     @Benchmark
     public void hashCompressed(Blackhole bh) {
-        if (useFast) {
-            bh.consume(PublicKeyBytes.sha256hash160Fast(compressedKey));
-        } else {
-            bh.consume(CryptoUtils.sha256hash160(compressedKey));
-        }
+        bh.consume(hash160.hash(compressedKey));
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/PublicKeyHashBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/PublicKeyHashBenchmark.java
@@ -63,16 +63,16 @@ public class PublicKeyHashBenchmark {
     public boolean useFast;
 
     /** Fixed 65-byte uncompressed public key ({@code 04 || X || Y}) used as hash input. */
-    private byte[] uncompressedKey;
+    private byte[] uncompressedKey = new byte[0];
 
     /** Fixed 33-byte compressed public key ({@code 02/03 || X}) used as hash input. */
-    private byte[] compressedKey;
+    private byte[] compressedKey = new byte[0];
 
     /** Initializes fixed-content key byte arrays so every iteration hashes the same input. */
     @Setup
     public void setUp() {
         uncompressedKey = new byte[PublicKeyBytes.PUBLIC_KEY_UNCOMPRESSED_BYTES];
-        uncompressedKey[0] = PublicKeyBytes.UNCOMPRESSED_PREFIX;
+        uncompressedKey[0] = (byte) PublicKeyBytes.SEC_PREFIX_UNCOMPRESSED_ECDSA_POINT;
         for (int i = 1; i < uncompressedKey.length; i++) {
             uncompressedKey[i] = (byte) i;
         }


### PR DESCRIPTION
## Summary
- Add **jqwik 1.9.2** property-based testing: `BitcoinAddressProperties` verifies that `BitHelper.getKillBits(n)` produces a value with exactly `n` bits set, and `convertBitsToSize(n)` returns `2^n`
- Add **ArchUnit 1.3.0** architecture tests: `BitcoinAddressFinderArchitectureTest` enforces the CLI package is a leaf (nothing outside it depends on it) and no test frameworks leak into production code
- Add **SpotBugs 4.8.6.6** static analysis via `spotbugs-maven-plugin` with fb-contrib and findsecbugs; `spotbugs-exclude.xml` placeholder for future suppressions; `failOnError=false` for initial baseline
- Add jqwik, ArchUnit, and SpotBugs README badges

## Test plan
- [ ] `mvn test` passes — jqwik properties and ArchUnit rules run as plain JUnit 5 tests
- [ ] `mvn verify` passes — SpotBugs runs without breaking the build
- [ ] Full CI passes

https://claude.ai/code/session_01Teo4XcbGFp8LmxeiY8N37h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Teo4XcbGFp8LmxeiY8N37h)_