### PR TITLE
docs: downgrade jqwik to 1.9.3 and plan QuickTheories replacement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -529,9 +529,11 @@ interim measure until that work lands.
 
 ## Open TODOs
 
-- **[URGENT] Replace jqwik.** Upstream is openly hostile to the AI-assisted workflow this project uses (jqwik 1.10.0 added a deliberate prompt-injection string to test stdout; jqwik 1.10.1 release notes added: *"This project is not meant to be used by any 'AI' coding agents at all."*). See the "jqwik prompt-injection in test output" section above for context and links. Replace the one jqwik test class in this repo (`BitcoinAddressProperties`) with one of:
-  - **junit-quickcheck** (`com.pholser:junit-quickcheck-core` + `-generators`) — closest API match; uses JUnit Vintage runner, well-maintained, no anti-AI behaviour.
-  - A minimal hand-rolled `@ParameterizedTest` + `@MethodSource`/`@ArgumentsSource` approach using JUnit Jupiter that is already on the classpath. Lower dependency count; some shrinking / generator features lost.
+- **[URGENT] Replace jqwik with QuickTheories.** Upstream is openly hostile to the AI-assisted workflow this project uses (jqwik 1.10.0 added a deliberate prompt-injection string to test stdout; jqwik 1.10.1 release notes added: *"This project is not meant to be used by any 'AI' coding agents at all."*). See the "jqwik prompt-injection in test output" section above for context and links. Replace the one jqwik test class in this repo (`BitcoinAddressProperties`) with one of (in order of preference):
+  - **QuickTheories** (`org.quicktheories:quicktheories`, MIT) — preferred. Native JUnit Jupiter (5/6); plain `@Test` methods with `qt().forAll(...).check(...)` bodies. No `@RunWith`, no JUnit Vintage engine. Property-based generation with shrinking preserved; the fluent DSL (`integers().between(...)`, `lists().of(...).ofSizeBetween(...)`, `strings().basicLatinAlphabet().ofLengthBetween(...)`) covers every constraint the current jqwik tests use.
+  - **junit-quickcheck** (`com.pholser:junit-quickcheck-core` + `-generators`) — closest annotation match to jqwik but requires the JUnit Vintage engine alongside Jupiter; only use if the QuickTheories DSL turns out to be a poor fit.
+  - A minimal hand-rolled `@ParameterizedTest` + `@MethodSource`/`@ArgumentsSource` approach using JUnit Jupiter that is already on the classpath. Lower dependency count; loses shrinking and built-in generators.
+
   Remove the jqwik dependency from `pom.xml` (and the `jqwik.version` property), drop the jqwik bullet from any test-frameworks documentation, and verify CI is green with the replacement. Until this lands, the doc-only warning section above is the interim mitigation.
 
 - **`@VisibleForTesting` audit.** 18 existing usages — review each for accuracy (still needed? still test-only?), and walk the production tree for any package-private/protected members that exist purely for tests but are *not* annotated; either add the annotation or move into the test tree.

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@ SPDX-License-Identifier: Apache-2.0
         <jcstress.version>0.16</jcstress.version>
         <lincheck.version>2.39</lincheck.version>
         <vmlens.version>1.2.28</vmlens.version>
+        <!-- DO NOT UPGRADE: jqwik >= 1.10.0 ships an anti-AI prompt-injection string in test stdout; see CLAUDE.md. Replacement (QuickTheories) tracked as an URGENT TODO. -->
         <jqwik.version>1.9.3</jqwik.version>
         <archunit.version>1.4.2</archunit.version>
         <spotbugs.version>4.9.8.3</spotbugs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
         <jcstress.version>0.16</jcstress.version>
         <lincheck.version>2.39</lincheck.version>
         <vmlens.version>1.2.28</vmlens.version>
-        <jqwik.version>1.10.0</jqwik.version>
+        <jqwik.version>1.9.3</jqwik.version>
         <archunit.version>1.4.2</archunit.version>
         <spotbugs.version>4.9.8.3</spotbugs.version>
         <fb-contrib.version>7.6.4</fb-contrib.version>


### PR DESCRIPTION
## Summary

- Downgrade jqwik from 1.10.0 to 1.9.3 in `pom.xml` to avoid the anti-AI prompt-injection string added in 1.10.0+
- Add explanatory comment in `pom.xml` documenting the issue and linking to CLAUDE.md
- Update the URGENT TODO in CLAUDE.md to clarify that **QuickTheories is the preferred replacement** (with junit-quickcheck and hand-rolled `@ParameterizedTest` as fallbacks)
- Provide detailed rationale for QuickTheories: native JUnit Jupiter support, no JUnit Vintage engine required, fluent DSL covering all current jqwik test constraints, and shrinking preservation

## Test plan

- [x] CI is green on this branch (no code changes; configuration and documentation only)
- [x] Docs updated with clear migration path and rationale

## Related issues / PRs

Addresses the URGENT TODO documented in CLAUDE.md regarding jqwik's hostile stance toward AI-assisted workflows.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01XigFKHMf8r7HLsLHts1J1K