### PR TITLE
Add package description to opencl package-info.java

### DIFF
--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/package-info.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/package-info.java
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
+ * Package for OpenCL-related classes and utilities used in Bitcoin address
+ * generation and finding.
+ * <p>
  * JSpecify {@code @NullMarked}: see {@link net.ladenthin.bitcoinaddressfinder}
  * for the convention.
  */


### PR DESCRIPTION
## Problem

The `opencl` package's `package-info.java` file currently only mentions JSpecify conventions without describing the package's purpose. This lack of documentation may reduce code readability for developers unfamiliar with the project.

## Solution

Added a concise description to the package documentation, explaining that the package contains OpenCL-related classes and utilities for Bitcoin address generation and finding. This includes using an HTML `<p>` tag to separate the new description from existing content, improving documentation structure.

## Verification

- Review the updated `package-info.java` file to ensure the description is clear and accurate.
- Verify that the code compiles without errors and existing tests pass, as this is a documentation-only change.
- Consider checking if the documentation appears correctly in generated Javadoc to confirm formatting.