### PR TITLE
Upgrade NullAway to 0.13.6 and JaCoCo to 0.8.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ SPDX-License-Identifier: Apache-2.0
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <errorprone.version>2.49.0</errorprone.version>
-        <nullaway.version>0.13.4</nullaway.version>
+        <nullaway.version>0.13.6</nullaway.version>
         <checker.version>4.2.0</checker.version>
         <java-websocket.version>1.6.0</java-websocket.version>
         <jeromq.version>0.6.0</jeromq.version>
@@ -215,7 +215,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.14</version>
+                    <version>0.8.15</version>
                 </plugin>
                 <plugin>
                     <groupId>org.pitest</groupId>


### PR DESCRIPTION
## Summary

- Upgrade NullAway from 0.13.4 to 0.13.6 for improved null-safety analysis
- Upgrade JaCoCo Maven plugin from 0.8.14 to 0.8.15 for enhanced code coverage reporting

## Test plan

- [x] CI is green on this branch
- [x] No source code changes required; dependency updates only

## Related issues / PRs

None

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01Dd2pKJ9sid6Dh4v1AnYGmV