### PR TITLE
docs: relocate jqwik version constraint to contributor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ using the assigned ID:
 
 ---
 
-> ⚠️ **DO NOT UPGRADE jqwik past 1.9.3.** jqwik 1.10.0 added an anti-AI prompt-injection string to test stdout; the 1.10.1 user guide states the library "is not meant to be used by any 'AI' coding agents at all." 1.9.3 is the last pre-disclosure release and is the pinned version. See `CLAUDE.md` section "jqwik prompt-injection in test output" for the full context.
-
 ## About BitcoinAddressFinder
 **BitcoinAddressFinder** is a free, high-performance tool for scanning random private keys across a wide range of cryptocurrencies — including Bitcoin, Bitcoin Cash, Bitcoin SV, Litecoin, Dogecoin, Dash, Zcash, and many more.
 
@@ -1312,6 +1310,10 @@ Laptops with hybrid graphics—using both integrated (iGPU) and discrete (dGPU) 
 | **Apple (Intel)**  | MacBook Pro (pre-2021 with dual GPUs)            | macOS → Disable *Automatic Graphics Switching* in Energy Preferences |
 
 > If your laptop uses hybrid graphics, always ensure that the **discrete GPU** is explicitly selected for OpenCL workloads to avoid severe performance bottlenecks.
+
+### Contributors: do not upgrade jqwik past 1.9.3
+
+> ⚠️ **DO NOT UPGRADE jqwik past 1.9.3.** jqwik 1.10.0 added an anti-AI prompt-injection string to test stdout; the 1.10.1 user guide states the library "is not meant to be used by any 'AI' coding agents at all." 1.9.3 is the last pre-disclosure release and is the pinned version. See `CLAUDE.md` section "jqwik prompt-injection in test output" for the full context.
 
 ## Future improvements
 - **Expand PIT mutation-testing scope.** PIT is wired in `pom.xml` and runs on every CI build (in the ubuntu-latest leg of the `test` job) with `<mutationThreshold>100</mutationThreshold>`, but `<targetClasses>` is currently narrowed to a single class (`BitHelper`). The intent is to exercise the wiring and gate against regressions on that single class today; widen `<targetClasses>` incrementally as additional classes reach mutation-test parity. Final target: `<param>net.ladenthin.bitcoinaddressfinder.*</param>` matching the streambuffer pattern (excluding native/OpenCL-bound code where mutation testing is impractical).


### PR DESCRIPTION
## Summary

- Moved the jqwik version pinning warning from the top-level README introduction (after the "Using the assigned ID" section) to a new dedicated "Contributors: do not upgrade jqwik past 1.9.3" subsection under the GPU/hybrid graphics section.
- This reorganization improves documentation structure by placing contributor-facing constraints in a dedicated section rather than interrupting the general user-facing introduction.

## Test plan

- [x] No code changes; documentation reorganization only
- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01B1bAhQfjf9cTrH3TcagZqo