### PR TITLE
Configure Dependabot to ignore all jqwik updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Anti-AI policy: jqwik >=1.10 injects prompts targeting AI agents in test
+    # stdout. Pinned at 1.9.3; block ALL net.jqwik updates. See README.
+    ignore:
+      - dependency-name: "net.jqwik:*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/README.md
+++ b/README.md
@@ -1459,7 +1459,7 @@ Laptops with hybrid graphics—using both integrated (iGPU) and discrete (dGPU) 
 
 ### Contributors: do not upgrade jqwik past 1.9.3
 
-> ⚠️ **DO NOT UPGRADE jqwik past 1.9.3.** jqwik 1.10.0 added an anti-AI prompt-injection string to test stdout; the 1.10.1 user guide states the library "is not meant to be used by any 'AI' coding agents at all." 1.9.3 is the last pre-disclosure release and is the pinned version. See `CLAUDE.md` section "jqwik prompt-injection in test output" for the full context.
+> ⚠️ **DO NOT UPGRADE jqwik past 1.9.3.** jqwik 1.10.0 added an anti-AI prompt-injection string to test stdout; the 1.10.1 user guide states the library "is not meant to be used by any 'AI' coding agents at all." 1.9.3 is the last pre-disclosure release and is the pinned version. See `CLAUDE.md` section "jqwik prompt-injection in test output" for the full context. Dependabot is configured to ignore **all** `net.jqwik` updates (every version, including patches) — see the `ignore` rule in [`.github/dependabot.yml`](./.github/dependabot.yml).
 
 ## Future improvements
 - **Expand PIT mutation-testing scope.** PIT is wired in `pom.xml` and runs on every CI build (in the ubuntu-latest leg of the `test` job) with `<mutationThreshold>100</mutationThreshold>`, but `<targetClasses>` is currently narrowed to a single class (`BitHelper`). The intent is to exercise the wiring and gate against regressions on that single class today; widen `<targetClasses>` incrementally as additional classes reach mutation-test parity. Final target: `<param>net.ladenthin.bitcoinaddressfinder.*</param>` matching the streambuffer pattern (excluding native/OpenCL-bound code where mutation testing is impractical).


### PR DESCRIPTION
## Summary

- Added Dependabot `ignore` rule to block **all** `net.jqwik:*` updates (every version and patch)
- Updated README to document the Dependabot configuration and link to `.github/dependabot.yml`
- Reinforces the existing jqwik 1.9.3 pinning policy due to anti-AI prompt-injection in jqwik ≥1.10

## Rationale

jqwik 1.10.0+ injects anti-AI prompt-injection strings into test stdout. While 1.9.3 is already pinned in `pom.xml`, Dependabot would still propose updates. This change prevents Dependabot from creating unnecessary upgrade PRs by explicitly ignoring all jqwik dependency updates. The README now clearly documents this configuration and points readers to the Dependabot rules.

## Test plan

- [x] CI is green on this branch
- [x] Docs updated (README clarified with link to Dependabot config)

## Related issues / PRs

See `CLAUDE.md` section "jqwik prompt-injection in test output" for full context.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01XEjgThAas1gQV65HK6kSqM