### PR TITLE
Fix ZMQ resource leaks in KeyProducerJavaZmqTest and increase fork timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,13 @@ See `examples/config_*.json` for all configuration variants.
 ### Conventions
 
 - Tests use forked JVMs (1 fork, no reuse) for isolation.
-- Test timeout: 60 seconds per test.
+- There is **no JUnit per-test timeout**. The only hard bound is the Surefire
+  whole-fork timeout (`forkedProcessTimeoutInSeconds`, 180s in `pom.xml`): with
+  `reuseForks=false` it must cover JVM startup + every method of one test class +
+  JVM shutdown. A fork that exceeds it is killed and the build fails with
+  "There was a timeout in the fork" — without per-test diagnostics. Test classes
+  must therefore never leak resources (sockets, ZMQ contexts, executors) that
+  could stall fork shutdown.
 - Base/utility test classes: `LMDBBase`, `BIP39DataProvider`, `TestTimeProvider`, `KeyProducerTestUtility`.
 - LMDB tests can be skipped with system property:
   ```

--- a/pom.xml
+++ b/pom.xml
@@ -640,8 +640,13 @@ SPDX-License-Identifier: Apache-2.0
                         <reuseForks>false</reuseForks>
                         <!-- Properly include JaCoCo agent and any other injected argLine -->
                         <argLine>@{argLine}</argLine>
-                        <!-- Increase timeout to ensure long-running tests don't break -->
-                        <forkedProcessTimeoutInSeconds>60</forkedProcessTimeoutInSeconds>
+                        <!-- Whole-fork budget: with reuseForks=false this must cover JVM
+                             startup + EVERY method of one test class + JVM shutdown.
+                             60s was sporadically exceeded by socket-heavy classes
+                             (e.g. KeyProducerJavaZmqTest) on loaded Windows runners,
+                             killing the fork with "There was a timeout in the fork"
+                             even though all tests passed. -->
+                        <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/AbstractKeyProducerQueueBuffered.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/AbstractKeyProducerQueueBuffered.java
@@ -96,7 +96,7 @@ public abstract class AbstractKeyProducerQueueBuffered<T extends CKeyProducerJav
                     }
                 }
 
-                if (secret == SHUTDOWN_SENTINEL) {
+                if (isShutdownSentinel(secret)) {
                     throw new NoMoreSecretsAvailableException(
                             "Shutdown sentinel received while waiting for secret at iteration " + i + "/" + length);
                 }
@@ -119,6 +119,21 @@ public abstract class AbstractKeyProducerQueueBuffered<T extends CKeyProducerJav
         }
 
         return secrets;
+    }
+
+    /**
+     * Checks whether the given secret is the {@link #SHUTDOWN_SENTINEL}.
+     *
+     * <p>The sentinel is detected by reference equality (==) by design: it is a
+     * private instance that {@link #addSecret(byte[])} can never enqueue, so no
+     * received message can be mistaken for it (see the field Javadoc).
+     *
+     * @param secret the dequeued secret to check
+     * @return {@code true} if the secret is the shutdown sentinel instance
+     */
+    @SuppressWarnings("ReferenceEquality") // identity check IS the sentinel contract
+    private static boolean isShutdownSentinel(byte[] secret) {
+        return secret == SHUTDOWN_SENTINEL;
     }
 
     /**

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaZmq.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaZmq.java
@@ -58,6 +58,10 @@ public class KeyProducerJavaZmq extends AbstractKeyProducerQueueBuffered<CKeyPro
         }
 
         socket.setReceiveTimeOut(cKeyProducerJava.timeoutMillis);
+        // A PULL socket never has pending outbound data, but its linger value still
+        // participates in context termination. Zero guarantees the context.close()
+        // in interrupt() can never stall on linger during shutdown.
+        socket.setLinger(0);
     }
 
     /**

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaZmqTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaZmqTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -33,19 +35,32 @@ public class KeyProducerJavaZmqTest {
     private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
     private final BitHelper bitHelper = new BitHelper();
     private ExecutorService executorService;
+    private List<KeyProducerJavaZmq> createdProducers;
 
     @BeforeEach
     public void setup() {
         executorService = Executors.newCachedThreadPool();
+        createdProducers = new ArrayList<>();
     }
 
     @AfterEach
     public void teardown() {
         executorService.shutdownNow();
+        // Interrupt every producer created by this test — including those a test
+        // deliberately leaves un-interrupted (e.g. the timeout scenario). A leaked
+        // ZContext keeps its internal I/O threads and a bound TCP port alive, which
+        // can stall the forked JVM's shutdown and trip the Surefire fork timeout on
+        // loaded CI runners. Double-interrupting producers a test already interrupted
+        // is safe: jeromq guards Socket.close()/ZContext.close() with closed-state
+        // flags, and signalShutdown()/join() are no-ops the second time.
+        for (KeyProducerJavaZmq producer : createdProducers) {
+            producer.interrupt();
+        }
     }
 
     private KeyProducerJavaZmq createKeyProducerJavaZmq(CKeyProducerJavaZmq config) {
         KeyProducerJavaZmq producer = new KeyProducerJavaZmq(config, keyUtility, bitHelper);
+        createdProducers.add(producer);
         producer.start();
         return producer;
     }
@@ -59,9 +74,11 @@ public class KeyProducerJavaZmqTest {
         config.address = address;
         config.mode = CKeyProducerJavaZmq.Mode.BIND;
         // Block until a message arrives (or signalShutdown via interrupt() wakes us).
-        // The JUnit per-test timeout (60s) is the upper bound when something is
-        // genuinely wrong — far more reliable than racing against a fixed receiver
-        // timeout under loaded CI conditions.
+        // There is no JUnit per-test timeout in this project; the only hard upper
+        // bound is the Surefire whole-fork timeout (forkedProcessTimeoutInSeconds in
+        // pom.xml), which must cover JVM startup + ALL methods of this class +
+        // shutdown. The @AfterEach teardown interrupts every producer, so a wedged
+        // receive cannot outlive its own test.
         config.timeoutMillis = -1;
         return config;
     }


### PR DESCRIPTION
## Summary

- **Track and interrupt all ZMQ producers in test teardown** to prevent resource leaks (sockets, ZContext, I/O threads) that can stall JVM shutdown on loaded CI runners.
- **Increase Surefire fork timeout from 60s to 180s** to accommodate socket-heavy test classes; the whole-fork budget must cover JVM startup + all test methods + shutdown with `reuseForks=false`.
- **Set ZMQ socket linger to 0** to prevent `context.close()` from blocking during shutdown.
- **Extract sentinel check into a named method** with reference-equality documentation to clarify the sentinel contract.
- **Update documentation** to reflect the absence of per-test timeouts and the resource-leak prevention requirement.

## Motivation

`KeyProducerJavaZmqTest` creates ZMQ producers that may be left un-interrupted (e.g., in timeout scenarios). A leaked `ZContext` keeps internal I/O threads and bound TCP ports alive, which can stall the forked JVM's shutdown and trigger the Surefire fork timeout on loaded CI runners, even when all tests pass. The 60-second timeout was sporadically exceeded on Windows runners.

The fix ensures every producer is interrupted in `@AfterEach`, and the socket linger is set to 0 so `context.close()` cannot block. The fork timeout is increased to 180s to provide adequate budget for JVM startup, all test methods, and shutdown.

## Changes

### Test class (`KeyProducerJavaZmqTest`)
- Added `createdProducers` list to track all producers created by the test.
- Updated `createKeyProducerJavaZmq()` to register each producer.
- Enhanced `@AfterEach` teardown to interrupt all tracked producers, with detailed comments explaining why (prevents resource leaks and fork timeout).
- Updated comments in `createBindConfig()` to reflect the absence of per-test JUnit timeout and the reliance on Surefire fork timeout.

### Key producer (`KeyProducerJavaZmq`)
- Set socket linger to 0 to prevent `context.close()` from stalling during shutdown.

### Queue-buffered producer (`AbstractKeyProducerQueueBuffered`)
- Extracted sentinel check into `isShutdownSentinel()` method with reference-equality documentation and `@SuppressWarnings` annotation.

### Build configuration (`pom.xml`)
- Increased `forkedProcessTimeoutInSeconds` from 60 to 180.
- Updated comment to explain the whole-fork budget and why 60s was insufficient.

### Documentation (`CLAUDE.md`)
- Clarified that there is **no per-test JUnit timeout**; the only hard bound is the Surefire whole-fork timeout.
- Added requirement that test classes must never leak resources that could stall fork shutdown.

## Test plan

- [x] Existing `KeyProducerJavaZmqTest` tests pass locally and on CI.
- [x] No new tests added; the fix is validated by the existing test suite not timing out on loaded runners.

## Related issues / PRs

<!-- None identified in the diff; this appears to be a stability fix for CI flakiness. -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01WUcbowwpGzWr5SBC2ESAp9