### PR TITLE
Fuse 8 (FUSE_8) compact-vs-full-transfer benchmark

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,47 @@ Recommended scoping by change type:
 
 **Full `mvn test` is reserved for the user to ask for explicitly** ("run the full tests", "do a full surefire run", or similar). Otherwise: narrow scope, report which tests were exercised, and call out anything that *would* exercise the change but was deliberately skipped so the user can decide whether to widen.
 
+### Running JMH benchmarks locally (GPU / FUSE_8 etc.)
+
+JMH benchmarks live under `src/test/java/.../benchmark/` (e.g. `GpuFuse8FilterBenchmark`,
+`GridSizeSweepBenchmark`). They have **no `@Test`** annotation and never run under `mvn test`;
+GPU benchmarks self-skip when no OpenCL 2.0+ device is present.
+
+The README documents the canonical `mvn test-compile exec:java -Dexec.args="<Benchmark>"`
+invocation. **That form was observed to fail locally on Windows**: the JVM JMH *forks* cannot
+find `org.openjdk.jmh.runner.ForkedMain` (`ClassNotFoundException`), because the pom's
+`exec-maven-plugin` runs JMH in-process and the fork does not inherit exec's classpath. The
+reliable local recipe is to launch JMH directly so the fork inherits a real `-cp`:
+
+```bash
+# 1. materialise the full test-scope classpath (includes jmh-core)
+mvn -q dependency:build-classpath -Dmdep.outputFile=target/cp-test.txt -DincludeScope=test
+
+# 2. run JMH directly; prepend the project's own classes to the dependency classpath.
+#    The --add-opens set must match pom.xml <argLine> (lmdbjava reflects into sun.nio.ch).
+java --add-opens=java.base/java.lang=ALL-UNNAMED \
+     --add-opens=java.base/java.io=ALL-UNNAMED \
+     --add-opens=java.base/java.nio=ALL-UNNAMED \
+     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED \
+     --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED \
+     --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+     -cp "target/test-classes;target/classes;$(cat target/cp-test.txt)" \
+     org.openjdk.jmh.Main GpuFuse8FilterBenchmark -p batchSizeInBits=19 -f 1 -wi 1 -w 30 -i 1 -r 200
+```
+
+(On a POSIX shell use `:` instead of `;` as the classpath separator.) **For GPU benchmarks
+prefer one long measurement iteration over many short samples** (`-i 1 -r 200`, ~3.3 min per
+arm, plus a short `-wi 1 -w 30` to let the GPU reach steady clocks): the relevant one-time
+cost here is OpenCL **kernel compilation**, which happens once in `OpenCLContext.init()`
+(JMH `@Setup`, outside the timed region) — JVM warmup iterations do not help, so spending the
+budget on duration rather than sample count gives the steadier read. For a quick sanity check
+use `-wi 2 -i 4` (~2 min for both arms). Use `OpenCLInfo` (`{"command":"OpenCLInfo"}`) to
+confirm a device is present and pick `platformIndex` / `deviceIndex` before benchmarking.
+`GpuFuse8FilterBenchmark` was validated this way on an NVIDIA RTX 3070 (OpenCL 3.0 CUDA): a
+single ~200 s iteration gave compact FUSE_8 mode ≈ **1.28× faster** than full transfer at
+`batchSizeInBits = 19` (matching the README key-gen table's grid size; the gain grows with
+batch size, ≈ 1.7× at grid 20). The full two-arm long run took ~7m45s of wall time.
+
 ---
 
 ## Code Conventions

--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ Constraints (enforced by [`CProducerOpenCL`](src/main/java/net/ladenthin/bitcoin
 The OpenCL kernel supports a **loop-based scalar strategy** controlled by the `keysPerWorkItem` parameter. Each GPU thread generates multiple EC keys by:
 
 - Computing the first key via full scalar multiplication: `P₀ = k₀·G` (using `point_mul_xy`)  
-- Computing subsequent keys via efficient affine additions: `Pₙ₊₁ = Pₙ + G` (using `point_add_xy`)
+- Computing subsequent keys via point additions: `Pₙ₊₁ = Pₙ + G`, kept in Jacobian coordinates
+  and converted back to affine in **batches** using Montgomery's simultaneous-inversion trick
 
 This enables high-throughput, grid-parallel **linear keyspace traversal** like:  
 `k₀·G, (k₀ + 1)·G, ..., (k₀ + keysPerWorkItem - 1)·G`
@@ -245,30 +246,43 @@ Example:
 - Grid size is reduced by a factor of 8  
 - All results are written to global memory
 
-Each subsequent key costs one **affine point addition** instead of a full scalar multiplication,
-so raising `keysPerWorkItem` above `1` replaces most of the expensive `k·G` work with cheap
-additions — until too few work-items remain to keep the GPU occupied, at which point throughput
-falls again. There is therefore a **per-device sweet spot**.
+Each subsequent key costs one **point addition** instead of a full scalar multiplication, so
+raising `keysPerWorkItem` above `1` replaces most of the expensive `k·G` work with cheap additions
+— until too few work-items remain to keep the GPU occupied, at which point throughput falls again.
+There is therefore a **per-device sweet spot**.
+
+**Batched modular inversion.** Converting each walked point from Jacobian back to affine needs a
+modular inverse of its Z coordinate — the single most expensive field operation. Rather than one
+inverse per key, the kernel inverts a sub-batch of `KEYS_BATCH_INV` points together (one `inv_mod`
+plus `3·(N−1)` multiplies for N points) via Montgomery's simultaneous inversion. This both raises
+the peak throughput and shifts the sweet spot to a larger `keysPerWorkItem` (more keys can be
+amortized before the inverse stops dominating). `KEYS_BATCH_INV` is a `#define` in
+`inc_ecc_secp256k1custom.cl` (default `8`); larger values amortize the inverse over more keys but
+use more private scratch (`4 · KEYS_BATCH_INV · 8` u32 words), which lowers occupancy — tune per
+device.
 
 **Benchmarked tuning (NVIDIA RTX 3070 Laptop, `batchSizeInBits = 20`, `GridSizeSweepBenchmark`):**
 
 | `keysPerWorkItem` | Throughput (~) | vs. `keysPerWorkItem = 1` |
 |------------------:|---------------:|--------------------------:|
-| 1 (default)       | ~2.6 M keys/s  | 1.0×                      |
-| 4                 | ~6.3 M keys/s  | 2.4×                      |
-| 8                 | ~8.7 M keys/s  | 3.3×                      |
-| 16                | ~11.7 M keys/s | 4.4×                      |
-| **32**            | **~14.4 M keys/s** | **5.5× (peak)**       |
-| 64                | ~11.9 M keys/s | 4.5×                      |
-| 256               | ~7.7 M keys/s  | 2.9×                      |
+| 1 (default)       | ~2.4 M keys/s  | 1.0×                      |
+| 8                 | ~11.1 M keys/s | 4.7×                      |
+| 16                | ~14.5 M keys/s | 6.2×                      |
+| 32                | ~16.7 M keys/s | 7.1×                      |
+| **64**            | **~19.8 M keys/s** | **8.4× (peak)**       |
+| 128               | ~19.0 M keys/s | 8.1×                      |
 
 > ✅ The default `keysPerWorkItem = 1` is **not** optimal for scanning — it pays a full scalar
->    multiplication for every key. On this GPU, `keysPerWorkItem = 32` is ~5.5× faster.
+>    multiplication for every key. On this GPU, `keysPerWorkItem = 64` is ~8.4× faster.
 > ✅ The sweet spot is **device-dependent** (it is set by the balance between amortizing scalar
->    multiplications and keeping enough work-items to saturate the GPU). Sweep `keysPerWorkItem`
->    on your hardware with `GridSizeSweepBenchmark`; for the RTX 3070 the optimum is ~16–32.
+>    multiplications / inversions and keeping enough work-items to saturate the GPU). Sweep
+>    `keysPerWorkItem` on your hardware with `GridSizeSweepBenchmark`; for the RTX 3070 the optimum
+>    is ~64.
 > ❌ Beyond the sweet spot, throughput drops because too few work-items remain to keep all
 >    compute units busy (e.g. `2^20 / 256 = 4096` work-items under-fills a 40-SM GPU).
+>
+> The batched inversion alone (vs. the previous per-key inverse) lifted this GPU's peak from
+> ~14.4 M keys/s (at `keysPerWorkItem = 32`) to ~19.8 M keys/s (at `keysPerWorkItem = 64`), ~+37%.
 
 ### 🚀 MSB-Zero Optimization
 To accelerate elliptic curve multiplication, BitcoinAddressFinder applies a **160-bit private key optimization**:

--- a/README.md
+++ b/README.md
@@ -1331,6 +1331,27 @@ advantage grows with `batchSizeInBits` (≈1.7× at grid 20). Run it yourself:
 mvn test-compile exec:java -Dexec.args="GpuFuse8FilterBenchmark"
 ```
 
+**Device-side breakdown (where the time actually goes).** The throughput above mixes three
+costs: GPU kernel compute, the PCIe read-back, and the host-side parse of the returned grid.
+To separate them, set `enableProfiling: true` on the OpenCL producer (or run the benchmark
+with `-p profiling=true`); the command queue is then created with `CL_QUEUE_PROFILING_ENABLE`
+and each launch is timestamped on the device. The same grid-19 run on the RTX 3070 reports:
+
+| Phase | Off — full transfer | On — Binary Fuse 8 compact | Effect |
+|-------|--------------------:|---------------------------:|--------|
+| GPU kernel compute            | 196.2 ms | 200.8 ms | **+4.7 ms (~2.4%)** — the inline filter check |
+| PCIe read-back (device)       |   8.74 ms |  0.035 ms | **~250× less** — only the ~0.4% hits cross the bus |
+| Host-side parse (wall − device) | ~67.9 ms |  ~8.4 ms | **~8× less** — the consumer parses ~2 k hits, not 524 k results |
+| **Per-launch wall time**      | ~272.8 ms | ~209.3 ms |  |
+
+The takeaway: **the GPU-side filtering is not expensive on the GPU.** It adds only ~2.4 % to
+kernel compute (a handful of integer ops + 3–6 fingerprint reads per candidate, versus the
+elliptic-curve math and two SHA-256 + two RIPEMD-160 hashes that dominate the kernel). The
+~1.28× end-to-end gain comes almost entirely from collapsing the PCIe transfer (~250×) and the
+host-side parse (~8×) — i.e. it offloads the address-presence check from the CPU at negligible
+GPU cost, which is exactly the design intent. (Profiling adds a little driver overhead and is
+**off by default**; it is a diagnostic switch, never enabled by the runtime pipeline.)
+
 
 ## Logging and Runtime Statistics
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,30 @@ Example:
 - Grid size is reduced by a factor of 8  
 - All results are written to global memory
 
-> ✅ Lower `keysPerWorkItem` values like 4 or 8 are often ideal.  
-> ❌ Higher values may reduce GPU occupancy due to fewer active threads.
+Each subsequent key costs one **affine point addition** instead of a full scalar multiplication,
+so raising `keysPerWorkItem` above `1` replaces most of the expensive `k·G` work with cheap
+additions — until too few work-items remain to keep the GPU occupied, at which point throughput
+falls again. There is therefore a **per-device sweet spot**.
+
+**Benchmarked tuning (NVIDIA RTX 3070 Laptop, `batchSizeInBits = 20`, `GridSizeSweepBenchmark`):**
+
+| `keysPerWorkItem` | Throughput (~) | vs. `keysPerWorkItem = 1` |
+|------------------:|---------------:|--------------------------:|
+| 1 (default)       | ~2.6 M keys/s  | 1.0×                      |
+| 4                 | ~6.3 M keys/s  | 2.4×                      |
+| 8                 | ~8.7 M keys/s  | 3.3×                      |
+| 16                | ~11.7 M keys/s | 4.4×                      |
+| **32**            | **~14.4 M keys/s** | **5.5× (peak)**       |
+| 64                | ~11.9 M keys/s | 4.5×                      |
+| 256               | ~7.7 M keys/s  | 2.9×                      |
+
+> ✅ The default `keysPerWorkItem = 1` is **not** optimal for scanning — it pays a full scalar
+>    multiplication for every key. On this GPU, `keysPerWorkItem = 32` is ~5.5× faster.
+> ✅ The sweet spot is **device-dependent** (it is set by the balance between amortizing scalar
+>    multiplications and keeping enough work-items to saturate the GPU). Sweep `keysPerWorkItem`
+>    on your hardware with `GridSizeSweepBenchmark`; for the RTX 3070 the optimum is ~16–32.
+> ❌ Beyond the sweet spot, throughput drops because too few work-items remain to keep all
+>    compute units busy (e.g. `2^20 / 256 = 4096` work-items under-fills a 40-SM GPU).
 
 ### 🚀 MSB-Zero Optimization
 To accelerate elliptic curve multiplication, BitcoinAddressFinder applies a **160-bit private key optimization**:

--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ Enable it on an OpenCL producer (see [`examples/config_Find_GPUFilterCompact.jso
 
 **Device requirements** — compact mode needs an **OpenCL 2.0+** device (the `atomic_add` on global memory) and a little-endian device (the kernel canonicalises its output as little-endian). Both are checked at producer init and fail fast with a clear message; on an older device set `transferAll: true` to keep the full-transfer path. The GPU/CPU lookup parity (key extraction + hash formula) is pinned by `Fuse8GpuHashParityTest` and exercised end-to-end on a real OpenCL device by `OpenCLCompactOutputIntegrationTest`.
 
+**Measured speedup** — see [GPU Binary Fuse 8 filter — compact output vs. full transfer](#gpu-binary-fuse-8-filter--compact-output-vs-full-transfer) under Performance Benchmarks for an A/B measurement (~1.28× at grid 19 on an RTX 3070).
+
 #### Bloom filter — FPP tuning
 
 When `addressLookupBackend` is `BLOOM`, the false positive probability is configurable via `bloomFilterFpp`:
@@ -1296,6 +1298,38 @@ For technical details, see:
 | NVIDIA RTX A3000            | Intel i7-11850H     | 160              | 19               |  5,000,000 keys/s      |
 | AMD Radeon 8060S            | AMD AI MAX+ 395     | 256              | 16               |  9,200,000 keys/s      |
 | AMD Radeon 8060S            | AMD AI MAX+ 395     | 160              | 16               | 11,000,000 keys/s      |
+
+##### GPU Binary Fuse 8 filter — compact output vs. full transfer
+
+The table above measures raw key generation. The table below isolates the effect of the
+[GPU-side Binary Fuse 8 filter](#gpu-side-binary-fuse-8-filtering-enablegpufilter)
+(`enableGpuFilter`): with it **on**, the kernel checks each derived hash160 against the
+on-GPU filter and transfers only the hits; with it **off**, every work-item result is read
+back over PCIe.
+
+> **Note:** These numbers come from the `GpuFuse8FilterBenchmark` JMH microbenchmark
+> (one kernel launch + PCIe read-back + host-side parse, measured in isolation). They are
+> **not** directly comparable to the full-pipeline figures above — the grid size differs and
+> there is no real consumer/queue — but the **on-vs-off ratio on the same row is the metric
+> that matters.**
+
+| GPU Filter (`enableGpuFilter`) | GPU Model              | Key Range (Bits) | Grid Size (Bits) | Effective Keys/s (~) | Speedup        |
+|--------------------------------|------------------------|------------------|------------------|----------------------|----------------|
+| Off — full transfer (legacy)   | NVIDIA RTX 3070 Laptop | 256              | 19               | 1,880,000 keys/s     | 1.00× baseline |
+| On — Binary Fuse 8 compact     | NVIDIA RTX 3070 Laptop | 256              | 19               | 2,410,000 keys/s     | **~1.28×**     |
+
+Measured against a ~1 M-entry filter at `batchSizeInBits = 19` (2¹⁹ ≈ 0.52 M candidates per
+launch), matching the grid size of the raw key-generation table above. The
+`GpuFuse8FilterBenchmark` JMH benchmark A/B-toggles compact mode against the legacy
+full-transfer path on the same kernel and batch; numbers above come from a single long
+measurement iteration (~200 s per arm) since the relevant one-time cost is OpenCL kernel
+compilation (done once in setup) and GPU clock ramp-up, not JVM warmup. The filter wins by
+collapsing the read-back from the full grid down to the ~0.4 % false-positive hits, so the
+advantage grows with `batchSizeInBits` (≈1.7× at grid 20). Run it yourself:
+
+```bash
+mvn test-compile exec:java -Dexec.args="GpuFuse8FilterBenchmark"
+```
 
 
 ## Logging and Runtime Statistics

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
@@ -85,4 +85,21 @@ public class CProducerOpenCL extends CProducer {
      * compact output buffer; set to {@code true} to keep the full-transfer output layout.
      */
     public boolean transferAll = false;
+
+    /**
+     * Enables OpenCL device-side profiling of the kernel launch and result read-back.
+     * <p>
+     * When {@code true} the command queue is created with {@code CL_QUEUE_PROFILING_ENABLE} and
+     * each kernel launch / read-back is timestamped on the device; the per-launch nanosecond
+     * times are exposed via {@code OpenClTask.getLastKernelExecutionNanos()} and
+     * {@code getLastResultReadbackNanos()}. This isolates GPU compute time from PCIe transfer
+     * time and host-side parsing, which is what the {@code GpuFuse8FilterBenchmark} uses to
+     * attribute cost between the kernel and the transfer.
+     * <p>
+     * This is a <b>diagnostic / benchmarking</b> switch, not a production tuning knob: profiling
+     * adds a small amount of driver overhead, so it is <b>off by default</b> and the runtime
+     * pipeline never enables it. Default {@code false}: the queue is created without profiling
+     * and the enqueue calls pass no events, exactly as the non-profiling path.
+     */
+    public boolean enableProfiling = false;
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -5,6 +5,8 @@ package net.ladenthin.bitcoinaddressfinder.opencl;
 
 import static org.jocl.CL.CL_MEM_COPY_HOST_PTR;
 import static org.jocl.CL.CL_MEM_READ_ONLY;
+import static org.jocl.CL.CL_QUEUE_PROFILING_ENABLE;
+import static org.jocl.CL.CL_QUEUE_PROPERTIES;
 import static org.jocl.CL.clBuildProgram;
 import static org.jocl.CL.clCreateBuffer;
 import static org.jocl.CL.clCreateCommandQueueWithProperties;
@@ -206,8 +208,13 @@ public class OpenCLContext implements ReleaseCLObject {
         // Create a context for the selected device
         context = clCreateContext(contextProperties, 1, cl_device_ids, null, null, null);
 
-        // Create a command-queue for the selected device
+        // Create a command-queue for the selected device. Opt-in device-side profiling
+        // (CL_QUEUE_PROFILING_ENABLE) is enabled only when the diagnostic flag is set, so the
+        // production pipeline pays no profiling overhead (see CProducerOpenCL.enableProfiling).
         cl_queue_properties properties = new cl_queue_properties();
+        if (producerOpenCL.enableProfiling) {
+            properties.addProperty(CL_QUEUE_PROPERTIES, CL_QUEUE_PROFILING_ENABLE);
+        }
         commandQueue = clCreateCommandQueueWithProperties(context, device.device(), properties, null);
 
         // #################### kernel specifix ####################

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenClTask.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenClTask.java
@@ -6,12 +6,16 @@ package net.ladenthin.bitcoinaddressfinder.opencl;
 import static org.jocl.CL.CL_MEM_READ_ONLY;
 import static org.jocl.CL.CL_MEM_USE_HOST_PTR;
 import static org.jocl.CL.CL_MEM_WRITE_ONLY;
+import static org.jocl.CL.CL_PROFILING_COMMAND_END;
+import static org.jocl.CL.CL_PROFILING_COMMAND_START;
 import static org.jocl.CL.CL_TRUE;
 import static org.jocl.CL.clCreateBuffer;
 import static org.jocl.CL.clEnqueueNDRangeKernel;
 import static org.jocl.CL.clEnqueueReadBuffer;
 import static org.jocl.CL.clEnqueueWriteBuffer;
 import static org.jocl.CL.clFinish;
+import static org.jocl.CL.clGetEventProfilingInfo;
+import static org.jocl.CL.clReleaseEvent;
 import static org.jocl.CL.clReleaseMemObject;
 import static org.jocl.CL.clSetKernelArg;
 
@@ -30,6 +34,7 @@ import org.jocl.Pointer;
 import org.jocl.Sizeof;
 import org.jocl.cl_command_queue;
 import org.jocl.cl_context;
+import org.jocl.cl_event;
 import org.jocl.cl_kernel;
 import org.jocl.cl_mem;
 import org.slf4j.Logger;
@@ -66,6 +71,19 @@ public class OpenClTask implements ReleaseCLObject {
     private final PrivateKeyValidator privateKeyValidator;
 
     private boolean closed = false;
+
+    /** Sentinel meaning "no profiling timestamp captured for the most recent launch". */
+    public static final long PROFILING_NOT_AVAILABLE = -1L;
+
+    // Device-side nanosecond timings of the most recent executeKernel() call. Only populated when
+    // CProducerOpenCL.enableProfiling is true (a diagnostic/benchmark switch); otherwise they stay
+    // at PROFILING_NOT_AVAILABLE. Mutated from executeKernel and read by the benchmark; volatile so
+    // a reader on another thread sees a consistent value. Excluded from toString (mutable state).
+    @ToString.Exclude
+    private volatile long lastKernelExecutionNanos = PROFILING_NOT_AVAILABLE;
+
+    @ToString.Exclude
+    private volatile long lastResultReadbackNanos = PROFILING_NOT_AVAILABLE;
 
     /**
      * Common base for source and destination OpenCL buffer arguments backed by a {@link ByteBuffer}.
@@ -396,12 +414,25 @@ public class OpenClTask implements ReleaseCLObject {
                         null);
                 clFinish(commandQueue);
             }
+            final boolean profiling = cProducer.enableProfiling;
             {
                 // execute the kernel
                 final long beforeExecute = System.currentTimeMillis();
-                clEnqueueNDRangeKernel(
-                        commandQueue, kernel, workDim, null, global_work_size, localWorkSize, 0, null, null);
-                clFinish(commandQueue);
+                if (profiling) {
+                    // Profiling path: timestamp the kernel on the device. The event is a non-null
+                    // local kept within this branch so NullAway sees no nullable JOCL argument.
+                    final cl_event kernelEvent = new cl_event();
+                    clEnqueueNDRangeKernel(
+                            commandQueue, kernel, workDim, null, global_work_size, localWorkSize, 0, null, kernelEvent);
+                    clFinish(commandQueue);
+                    lastKernelExecutionNanos = deviceElapsedNanos(kernelEvent);
+                    clReleaseEvent(kernelEvent);
+                } else {
+                    clEnqueueNDRangeKernel(
+                            commandQueue, kernel, workDim, null, global_work_size, localWorkSize, 0, null, null);
+                    clFinish(commandQueue);
+                    lastKernelExecutionNanos = PROFILING_NOT_AVAILABLE;
+                }
 
                 final long afterExecute = System.currentTimeMillis();
 
@@ -447,19 +478,38 @@ public class OpenClTask implements ReleaseCLObject {
                         + entriesToRead * OpenClKernelConstants.OUTPUT_ENTRY_SIZE_BYTES;
 
                 final long beforeRead = System.currentTimeMillis();
-                clEnqueueReadBuffer(
-                        commandQueue,
-                        destinationArgument.getMem(),
-                        CL_TRUE,
-                        0,
-                        bytesToRead,
-                        destinationArgument.getHostMemoryPointer(),
-                        0,
-                        null,
-                        null);
-                clFinish(commandQueue);
+                if (profiling) {
+                    final cl_event readEvent = new cl_event();
+                    clEnqueueReadBuffer(
+                            commandQueue,
+                            destinationArgument.getMem(),
+                            CL_TRUE,
+                            0,
+                            bytesToRead,
+                            destinationArgument.getHostMemoryPointer(),
+                            0,
+                            null,
+                            readEvent);
+                    clFinish(commandQueue);
+                    lastResultReadbackNanos = deviceElapsedNanos(readEvent);
+                    clReleaseEvent(readEvent);
+                } else {
+                    clEnqueueReadBuffer(
+                            commandQueue,
+                            destinationArgument.getMem(),
+                            CL_TRUE,
+                            0,
+                            bytesToRead,
+                            destinationArgument.getHostMemoryPointer(),
+                            0,
+                            null,
+                            null);
+                    clFinish(commandQueue);
+                    lastResultReadbackNanos = PROFILING_NOT_AVAILABLE;
+                }
 
                 final long afterRead = System.currentTimeMillis();
+
                 if (LOGGER.isTraceEnabled()) {
                     LOGGER.trace("Read OpenCL data " + ((bytesToRead / 1024) / 1024) + "Mb in "
                             + (afterRead - beforeRead) + "ms");
@@ -467,6 +517,47 @@ public class OpenClTask implements ReleaseCLObject {
             }
             return destinationArgument.getByteBuffer();
         }
+    }
+
+    /**
+     * Reads the device-side {@code END - START} duration of a profiled command.
+     *
+     * @param event a completed event from a profiling-enabled queue
+     * @return the on-device execution time of the command, in nanoseconds
+     */
+    private static long deviceElapsedNanos(cl_event event) {
+        final long[] start = new long[1];
+        final long[] end = new long[1];
+        clGetEventProfilingInfo(event, CL_PROFILING_COMMAND_START, Sizeof.cl_ulong, Pointer.to(start), null);
+        clGetEventProfilingInfo(event, CL_PROFILING_COMMAND_END, Sizeof.cl_ulong, Pointer.to(end), null);
+        return end[0] - start[0];
+    }
+
+    /**
+     * Returns the on-device kernel execution time of the most recent {@link #executeKernel} call.
+     *
+     * <p>Populated only when {@link CProducerOpenCL#enableProfiling} is {@code true}; otherwise
+     * returns {@link #PROFILING_NOT_AVAILABLE}. This is GPU compute time only &mdash; it excludes
+     * PCIe transfer and host-side parsing.
+     *
+     * @return the last kernel execution time in nanoseconds, or {@link #PROFILING_NOT_AVAILABLE}
+     */
+    public long getLastKernelExecutionNanos() {
+        return lastKernelExecutionNanos;
+    }
+
+    /**
+     * Returns the on-device result read-back (PCIe transfer) time of the most recent
+     * {@link #executeKernel} call.
+     *
+     * <p>Populated only when {@link CProducerOpenCL#enableProfiling} is {@code true}; otherwise
+     * returns {@link #PROFILING_NOT_AVAILABLE}. In compact mode this covers only the {@code K} hit
+     * entries; in full-transfer mode the whole grid.
+     *
+     * @return the last read-back time in nanoseconds, or {@link #PROFILING_NOT_AVAILABLE}
+     */
+    public long getLastResultReadbackNanos() {
+        return lastResultReadbackNanos;
     }
 
     @Override

--- a/src/main/resources/inc_ecc_secp256k1custom.cl
+++ b/src/main/resources/inc_ecc_secp256k1custom.cl
@@ -647,6 +647,32 @@ inline bool fuse8_contains(__global const uchar *fp, ulong seed, uint seg, uint 
     return (uchar)(fp[h0] ^ fp[h1] ^ fp[h2]) == f8;
 }
 
+/**
+ * Sub-batch size for Montgomery's simultaneous inversion in the scalar-walker loop.
+ *
+ * The keysPerWorkItem walk produces consecutive points P0, P0+G, P0+2G, ... Converting each
+ * Jacobian point back to affine needs a modular inverse of its Z coordinate, the single most
+ * expensive field operation. Instead of one inv_mod per key (the old per-key point_add_xy path),
+ * KEYS_BATCH_INV points are inverted together: one inv_mod plus 3*(N-1) multiplies for N points.
+ * Larger values amortise the inverse over more keys but cost more private scratch
+ * (4 * KEYS_BATCH_INV * 8 u32 words) which lowers occupancy; tune per device.
+ */
+#define KEYS_BATCH_INV 8
+
+/**
+ * @brief Copies word_count u32 values from one __private array to another.
+ *
+ * @param dst Destination array in __private address space.
+ * @param src Source array in __private address space.
+ * @param word_count Number of 32-bit words to copy.
+ */
+inline void copy_private_u32_array_private_u32(u32 *dst, const u32 *src, const int word_count) {
+    #pragma unroll
+    for (int i = 0; i < word_count; i++) {
+        dst[i] = src[i];
+    }
+}
+
 __kernel void generateKeysKernel_grid(
     __global u32 *r,
     __global const u32 *k,
@@ -748,109 +774,154 @@ __kernel void generateKeysKernel_grid(
         r[0] = OUTPUT_COUNT_FULL_TRANSFER_SENTINEL;
     }
 
-    for (u32 i = 0; i < keysPerWorkItem; i++) {
-        u32 loop_index = base_offset + i;
+    // ===================== Scalar walker with batched (Montgomery) inversion =====================
+    // Generate keysPerWorkItem consecutive keys P0, P0+G, P0+2G, ... The first key uses a full
+    // scalar multiplication; every subsequent key is a single mixed Jacobian+affine addition
+    // (point_add, no inverse). The affine conversion's modular inverse — the dominant per-key cost
+    // in the old per-key point_add_xy path — is deferred and shared across a sub-batch of
+    // KEYS_BATCH_INV points via Montgomery's simultaneous inversion: one inv_mod per sub-batch
+    // instead of one per key.
+    //
+    // Caveat (same practical assumption as the previous per-key path): if the running point ever
+    // becomes the point at infinity (Z == 0, i.e. P + (-P) when (baseK0 + index) == 0 mod n),
+    // inv_mod guards against a hang but the whole sub-batch's inverses are then invalid. That
+    // requires the walk to hit the curve order within its window and never occurs for the
+    // supported random / sequential key ranges.
 
-        // Apply variation (global_id) to LSB part of key (k[0])
-        // We use bitwise OR (|) instead of addition (+) to modify the key,
-        // because it avoids carry propagation and is typically faster on GPU hardware.
-        //
-        // Rationale:
-        // - Addition introduces data dependencies (carry chain across bits).
-        // - Bitwise OR has no carry and maps directly to a single instruction.
-        // - On most GPU architectures (NVIDIA, AMD), bitwise operations are cheaper
-        //   than integer addition in terms of instruction latency and power usage.
-        // - Using OR guarantees deterministic variation without overflow concerns,
-        //   assuming loop_index is within expected bit range (e.g. lower N bits).
-        //
-        // Result:
-        // baseK0 | loop_index = key variation with fast, non-carrying logic.
-        k_littleEndian_local[0] = (baseK0 | loop_index);
+    // Running point in Jacobian coordinates, seeded by the first key's full scalar multiplication.
+    u32 q_x[ONE_COORDINATE_NUM_WORDS];
+    u32 q_y[ONE_COORDINATE_NUM_WORDS];
+    u32 q_z[ONE_COORDINATE_NUM_WORDS] = { 0 };
+    q_z[0] = 1;
 
-        if (i == 0) {
-            point_mul_xy(x_littleEndian_local, y_littleEndian_local, k_littleEndian_local, &g_precomputed);
-        } else {
-            point_add_xy(x_littleEndian_local, y_littleEndian_local, x1_local, y1_local);
+    k_littleEndian_local[0] = (baseK0 | base_offset);
+    point_mul_xy(q_x, q_y, k_littleEndian_local, &g_precomputed); // affine P0 = (baseK0 + base_offset) * G
+
+    // Per-sub-batch scratch for the deferred affine conversion.
+    u32 batch_x[KEYS_BATCH_INV][ONE_COORDINATE_NUM_WORDS];
+    u32 batch_y[KEYS_BATCH_INV][ONE_COORDINATE_NUM_WORDS];
+    u32 batch_z[KEYS_BATCH_INV][ONE_COORDINATE_NUM_WORDS];
+    u32 batch_prefix[KEYS_BATCH_INV][ONE_COORDINATE_NUM_WORDS]; // Montgomery prefix products of Z
+
+    for (u32 done = 0; done < keysPerWorkItem; done += KEYS_BATCH_INV) {
+        u32 count = keysPerWorkItem - done;
+        if (count > (u32) KEYS_BATCH_INV) {
+            count = (u32) KEYS_BATCH_INV;
         }
 
-        // create big endian (computed into private registers; written to global memory below
-        // only for entries that are actually emitted)
-        // x
-        copy_and_reverse_endianness_u32_array(x_bigEndian_local, 0, x_littleEndian_local, ONE_COORDINATE_NUM_WORDS);
-        // y
-        copy_and_reverse_endianness_u32_array(y_bigEndian_local, 0, y_littleEndian_local, ONE_COORDINATE_NUM_WORDS);
-
-        // === Hash uncompressed key ===
-        get_sec_bytes_uncompressed(x_bigEndian_local, y_bigEndian_local, sec_uncompressed);
-        build_sha256_block_from_uncompressed_pubkey(sec_uncompressed, sha256_input_uncompressed);
-        sha256_init(&sha_ctx_uncompressed);
-        sha256_update(&sha_ctx_uncompressed, sha256_input_uncompressed, SHA256_INPUT_TOTAL_BYTES_UNCOMPRESSED);
-
-        build_ripemd160_block_from_sha256(sha_ctx_uncompressed.h, ripemd160_input_uncompressed);
-        ripemd160_init(&ripemd_ctx_uncompressed);
-        ripemd160_update_swap(&ripemd_ctx_uncompressed, ripemd160_input_uncompressed, RIPEMD160_INPUT_BLOCK_SIZE_BYTES);
-
-        // Snapshot the uncompressed hash160 into a private register array NOW. Under
-        // REUSE_FOR_COMPRESSED the ripemd context is a shared alias, so the compressed pass
-        // below overwrites ripemd_ctx_uncompressed.h; the deferred filter check and entry
-        // write must read this stable copy, not the (soon-clobbered) shared context.
-        u32 ripemd_uncompressed_h[RIPEMD160_HASH_NUM_WORDS];
-        #pragma unroll
-        for (int w = 0; w < RIPEMD160_HASH_NUM_WORDS; w++) {
-            ripemd_uncompressed_h[w] = ripemd_ctx_uncompressed.h[w];
-        }
-
-        // === Hash compressed key ===
-        #ifdef REUSE_FOR_COMPRESSED
-            transform_sec_prefix_from_uncompressed_to_compressed(sec_compressed);
-        #else
-            get_sec_bytes_compressed(x_bigEndian_local, y_bigEndian_local, sec_compressed);
-        #endif
-        build_sha256_block_from_compressed_pubkey(sec_compressed, sha256_input_compressed);
-        sha256_init(&sha_ctx_compressed);
-        sha256_update(&sha_ctx_compressed, sha256_input_compressed, SHA256_INPUT_TOTAL_BYTES_COMPRESSED);
-
-        build_ripemd160_block_from_sha256(sha_ctx_compressed.h, ripemd160_input_compressed);
-        ripemd160_init(&ripemd_ctx_compressed);
-        ripemd160_update_swap(&ripemd_ctx_compressed, ripemd160_input_compressed, RIPEMD160_INPUT_BLOCK_SIZE_BYTES);
-
-        // Snapshot the compressed hash160 too, so both hashes are stable private copies for
-        // the filter check and the deferred entry write below.
-        u32 ripemd_compressed_h[RIPEMD160_HASH_NUM_WORDS];
-        #pragma unroll
-        for (int w = 0; w < RIPEMD160_HASH_NUM_WORDS; w++) {
-            ripemd_compressed_h[w] = ripemd_ctx_compressed.h[w];
-        }
-
-        // === Decide whether and where to emit this entry ===
-        // Full-transfer mode: every work-item emits, densely at slot loop_index.
-        // Compact mode: emit only if the uncompressed OR compressed hash160 passes the Binary
-        //   Fuse 8 filter; the output slot is claimed atomically on the count word (r[0]).
-        u32 slot;
-        bool should_write;
-        if (transfer_all != 0) {
-            slot = loop_index;
-            should_write = true;
-        } else {
-            ulong key_uncompressed = fuse8_key_from_ripemd(ripemd_uncompressed_h);
-            ulong key_compressed   = fuse8_key_from_ripemd(ripemd_compressed_h);
-            bool hit = fuse8_contains(fuse8_fp, fuse8_seed, fuse8_seg, fuse8_seg_count_len, key_uncompressed)
-                    || fuse8_contains(fuse8_fp, fuse8_seed, fuse8_seg, fuse8_seg_count_len, key_compressed);
-            should_write = hit;
-            slot = 0;
-            if (hit) {
-                // atomic_add returns the previous value -> the 0-based slot this hit claims.
-                slot = atomic_add((volatile __global uint *)&r[0], 1u);
+        // ---- collect Jacobian points + Montgomery prefix products; advance Q by +G each step ----
+        u32 acc[ONE_COORDINATE_NUM_WORDS] = { 0 };
+        acc[0] = 1;
+        for (u32 j = 0; j < count; j++) {
+            copy_private_u32_array_private_u32(batch_x[j], q_x, ONE_COORDINATE_NUM_WORDS);
+            copy_private_u32_array_private_u32(batch_y[j], q_y, ONE_COORDINATE_NUM_WORDS);
+            copy_private_u32_array_private_u32(batch_z[j], q_z, ONE_COORDINATE_NUM_WORDS);
+            copy_private_u32_array_private_u32(batch_prefix[j], acc, ONE_COORDINATE_NUM_WORDS);
+            mul_mod(acc, acc, q_z); // acc = Z_0 * Z_1 * ... * Z_j
+            // Advance to the next key, except after the very last key of the whole walk.
+            if (done + j + 1 < keysPerWorkItem) {
+                point_add(q_x, q_y, q_z, x1_local, y1_local); // Q += G (mixed Jacobian+affine)
             }
         }
 
-        if (should_write) {
-            u32 r_offset = OUTPUT_HEADER_NUM_WORDS + slot * OUTPUT_ENTRY_NUM_WORDS;
-            r[r_offset + OUTPUT_ENTRY_OFFSET_INDEX] = loop_index;
-            copy_private_u32_array_global_u32(&r[r_offset + OUTPUT_ENTRY_OFFSET_X],      x_bigEndian_local, CHUNK_SIZE_00_NUM_WORDS_BIG_ENDIAN_X);
-            copy_private_u32_array_global_u32(&r[r_offset + OUTPUT_ENTRY_OFFSET_Y],      y_bigEndian_local, CHUNK_SIZE_01_NUM_WORDS_BIG_ENDIAN_Y);
-            copy_private_u32_array_global_u32(&r[r_offset + OUTPUT_ENTRY_OFFSET_RIPEMD160_UNCOMPRESSED], ripemd_uncompressed_h, RIPEMD160_HASH_NUM_WORDS);
-            copy_private_u32_array_global_u32(&r[r_offset + OUTPUT_ENTRY_OFFSET_RIPEMD160_COMPRESSED], ripemd_compressed_h, RIPEMD160_HASH_NUM_WORDS);
+        // ---- one modular inverse for the whole sub-batch ----
+        inv_mod(acc); // acc = 1 / (Z_0 * ... * Z_{count-1})
+
+        // ---- emit each point (reverse order is fine; each writes its own slot) ----
+        for (int j = (int) count - 1; j >= 0; j--) {
+            u32 z_inv[ONE_COORDINATE_NUM_WORDS];
+            mul_mod(z_inv, acc, batch_prefix[j]); // 1 / Z_j = (1/product) * (Z_0..Z_{j-1})
+            mul_mod(acc, acc, batch_z[j]);        // strip Z_j: acc = 1 / (Z_0..Z_{j-1})
+
+            // Affine conversion: x = X / Z^2, y = Y / Z^3.
+            u32 z_inv_sq[ONE_COORDINATE_NUM_WORDS];
+            mul_mod(z_inv_sq, z_inv, z_inv);
+            mul_mod(x_littleEndian_local, batch_x[j], z_inv_sq);
+            u32 z_inv_cu[ONE_COORDINATE_NUM_WORDS];
+            mul_mod(z_inv_cu, z_inv_sq, z_inv);
+            mul_mod(y_littleEndian_local, batch_y[j], z_inv_cu);
+
+            u32 loop_index = base_offset + done + (u32) j;
+
+            // create big endian (computed into private registers; written to global memory below
+            // only for entries that are actually emitted)
+            // x
+            copy_and_reverse_endianness_u32_array(x_bigEndian_local, 0, x_littleEndian_local, ONE_COORDINATE_NUM_WORDS);
+            // y
+            copy_and_reverse_endianness_u32_array(y_bigEndian_local, 0, y_littleEndian_local, ONE_COORDINATE_NUM_WORDS);
+
+            // === Hash uncompressed key ===
+            get_sec_bytes_uncompressed(x_bigEndian_local, y_bigEndian_local, sec_uncompressed);
+            build_sha256_block_from_uncompressed_pubkey(sec_uncompressed, sha256_input_uncompressed);
+            sha256_init(&sha_ctx_uncompressed);
+            sha256_update(&sha_ctx_uncompressed, sha256_input_uncompressed, SHA256_INPUT_TOTAL_BYTES_UNCOMPRESSED);
+
+            build_ripemd160_block_from_sha256(sha_ctx_uncompressed.h, ripemd160_input_uncompressed);
+            ripemd160_init(&ripemd_ctx_uncompressed);
+            ripemd160_update_swap(&ripemd_ctx_uncompressed, ripemd160_input_uncompressed, RIPEMD160_INPUT_BLOCK_SIZE_BYTES);
+
+            // Snapshot the uncompressed hash160 into a private register array NOW. Under
+            // REUSE_FOR_COMPRESSED the ripemd context is a shared alias, so the compressed pass
+            // below overwrites ripemd_ctx_uncompressed.h; the deferred filter check and entry
+            // write must read this stable copy, not the (soon-clobbered) shared context.
+            u32 ripemd_uncompressed_h[RIPEMD160_HASH_NUM_WORDS];
+            #pragma unroll
+            for (int w = 0; w < RIPEMD160_HASH_NUM_WORDS; w++) {
+                ripemd_uncompressed_h[w] = ripemd_ctx_uncompressed.h[w];
+            }
+
+            // === Hash compressed key ===
+            #ifdef REUSE_FOR_COMPRESSED
+                transform_sec_prefix_from_uncompressed_to_compressed(sec_compressed);
+            #else
+                get_sec_bytes_compressed(x_bigEndian_local, y_bigEndian_local, sec_compressed);
+            #endif
+            build_sha256_block_from_compressed_pubkey(sec_compressed, sha256_input_compressed);
+            sha256_init(&sha_ctx_compressed);
+            sha256_update(&sha_ctx_compressed, sha256_input_compressed, SHA256_INPUT_TOTAL_BYTES_COMPRESSED);
+
+            build_ripemd160_block_from_sha256(sha_ctx_compressed.h, ripemd160_input_compressed);
+            ripemd160_init(&ripemd_ctx_compressed);
+            ripemd160_update_swap(&ripemd_ctx_compressed, ripemd160_input_compressed, RIPEMD160_INPUT_BLOCK_SIZE_BYTES);
+
+            // Snapshot the compressed hash160 too, so both hashes are stable private copies for
+            // the filter check and the deferred entry write below.
+            u32 ripemd_compressed_h[RIPEMD160_HASH_NUM_WORDS];
+            #pragma unroll
+            for (int w = 0; w < RIPEMD160_HASH_NUM_WORDS; w++) {
+                ripemd_compressed_h[w] = ripemd_ctx_compressed.h[w];
+            }
+
+            // === Decide whether and where to emit this entry ===
+            // Full-transfer mode: every work-item emits, densely at slot loop_index.
+            // Compact mode: emit only if the uncompressed OR compressed hash160 passes the Binary
+            //   Fuse 8 filter; the output slot is claimed atomically on the count word (r[0]).
+            u32 slot;
+            bool should_write;
+            if (transfer_all != 0) {
+                slot = loop_index;
+                should_write = true;
+            } else {
+                ulong key_uncompressed = fuse8_key_from_ripemd(ripemd_uncompressed_h);
+                ulong key_compressed   = fuse8_key_from_ripemd(ripemd_compressed_h);
+                bool hit = fuse8_contains(fuse8_fp, fuse8_seed, fuse8_seg, fuse8_seg_count_len, key_uncompressed)
+                        || fuse8_contains(fuse8_fp, fuse8_seed, fuse8_seg, fuse8_seg_count_len, key_compressed);
+                should_write = hit;
+                slot = 0;
+                if (hit) {
+                    // atomic_add returns the previous value -> the 0-based slot this hit claims.
+                    slot = atomic_add((volatile __global uint *)&r[0], 1u);
+                }
+            }
+
+            if (should_write) {
+                u32 r_offset = OUTPUT_HEADER_NUM_WORDS + slot * OUTPUT_ENTRY_NUM_WORDS;
+                r[r_offset + OUTPUT_ENTRY_OFFSET_INDEX] = loop_index;
+                copy_private_u32_array_global_u32(&r[r_offset + OUTPUT_ENTRY_OFFSET_X],      x_bigEndian_local, CHUNK_SIZE_00_NUM_WORDS_BIG_ENDIAN_X);
+                copy_private_u32_array_global_u32(&r[r_offset + OUTPUT_ENTRY_OFFSET_Y],      y_bigEndian_local, CHUNK_SIZE_01_NUM_WORDS_BIG_ENDIAN_Y);
+                copy_private_u32_array_global_u32(&r[r_offset + OUTPUT_ENTRY_OFFSET_RIPEMD160_UNCOMPRESSED], ripemd_uncompressed_h, RIPEMD160_HASH_NUM_WORDS);
+                copy_private_u32_array_global_u32(&r[r_offset + OUTPUT_ENTRY_OFFSET_RIPEMD160_COMPRESSED], ripemd_compressed_h, RIPEMD160_HASH_NUM_WORDS);
+            }
         }
     }
 }

--- a/src/main/resources/inc_ecc_secp256k1custom.cl
+++ b/src/main/resources/inc_ecc_secp256k1custom.cl
@@ -656,6 +656,13 @@ inline bool fuse8_contains(__global const uchar *fp, ulong seed, uint seg, uint 
  * KEYS_BATCH_INV points are inverted together: one inv_mod plus 3*(N-1) multiplies for N points.
  * Larger values amortise the inverse over more keys but cost more private scratch
  * (4 * KEYS_BATCH_INV * 8 u32 words) which lowers occupancy; tune per device.
+ *
+ * MUST be a compile-time constant: it sizes the per-work-item private arrays below
+ * (batch_x/batch_y/batch_z/batch_prefix), and OpenCL C requires private-array dimensions to be
+ * compile-time constants. It therefore cannot be a runtime kernel argument like keysPerWorkItem
+ * (which is just a loop count); it is baked into the program at clBuildProgram time. To make it
+ * host-configurable, prepend a "#define KEYS_BATCH_INV <n>" line to the program source before the
+ * build (host side) rather than passing it as an argument.
  */
 #define KEYS_BATCH_INV 8
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class ProbeAddressesOpenCLTest {
 
@@ -582,6 +583,49 @@ public class ProbeAddressesOpenCLTest {
             hashPublicKeysFast(publicKeys, souts); // just for performance tests
 
             assertPublicKeyBytesCalculatedCorrect(publicKeys, secretBase, souts, keyUtility);
+        }
+    }
+
+    /**
+     * Full-batch correctness across the whole {@code keysPerWorkItem} range, including the values
+     * that exercise the incremental scalar-walker path ({@code keysPerWorkItem > 1}, i.e. the
+     * {@code point_add_xy} additions) and its sub-batch boundaries.
+     *
+     * <p>Every returned result is checked two ways: {@link PublicKeyBytes#runtimePublicKeyCalculationCheck()}
+     * (self-consistency against bitcoinj) and an exact compare of the OpenCL public key + hash160
+     * against the bitcoinj reference for {@code secretBase | index} (via
+     * {@link #assertPublicKeyBytesCalculatedCorrect}). Because the slot index must equal the
+     * work-item's {@code loop_index} in full-transfer mode, this also pins the slot ordering — so
+     * any kernel change that batches the affine conversion (e.g. Montgomery simultaneous inversion)
+     * is caught here if it scrambles results, drops the partial final sub-batch, or mishandles the
+     * running point carried across sub-batches.
+     *
+     * @param keysPerWorkItem the scalar-walker iteration count under test
+     */
+    @ParameterizedTest
+    @OpenCLTest
+    @ValueSource(ints = {1, 2, 4, 8, 16})
+    public void createKeys_acrossKeysPerWorkItem_allResultsMatchReference(int keysPerWorkItem) throws IOException {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+
+        KeyUtility keyUtility = new KeyUtility(network, byteBufferUtility);
+
+        CProducerOpenCL producerOpenCL = new CProducerOpenCL();
+        producerOpenCL.batchSizeInBits = BITS_FOR_BATCH;
+        producerOpenCL.keysPerWorkItem = keysPerWorkItem;
+        try (OpenCLContext openCLContext = new OpenCLContext(producerOpenCL, bitHelper)) {
+            openCLContext.init();
+            Random random = new Random(1337);
+            BigInteger secretKeyBase = keyUtility.createSecret(Secp256k1Constants.PRIVATE_KEY_MAX_NUM_BITS, random);
+            BigInteger secretBase =
+                    keyUtility.alignDown(secretKeyBase, bitHelper.getLowBitMask(producerOpenCL.batchSizeInBits));
+
+            OpenCLGridResult createKeys = openCLContext.createKeys(secretBase);
+            PublicKeyBytes[] publicKeys = createKeys.getPublicKeyBytes();
+
+            // Full-transfer mode returns the whole grid regardless of keysPerWorkItem.
+            assertThat(publicKeys.length, is(equalTo((int) bitHelper.convertBitsToSize(BITS_FOR_BATCH))));
+            assertPublicKeyBytesCalculatedCorrect(publicKeys, secretBase, false, keyUtility);
         }
     }
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
@@ -1,0 +1,275 @@
+// @formatter:off
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+// @formatter:on
+package net.ladenthin.bitcoinaddressfinder.benchmark;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import net.ladenthin.bitcoinaddressfinder.OpenCLPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
+import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLContext;
+import net.ladenthin.bitcoinaddressfinder.persistence.AddressIterable;
+import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse8AddressPresence;
+import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse8GpuFilterData;
+import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * A/B throughput benchmark for the GPU-side Binary Fuse 8 address-presence filter
+ * ({@code BINARY_FUSE_8} compact output) versus the legacy full-transfer path.
+ *
+ * <p>This is the throughput companion to {@code OpenCLCompactOutputIntegrationTest}
+ * (which proves the compact path is <em>correct</em>) and to {@code GridSizeSweepBenchmark}
+ * (which sweeps batch size with no filter). It answers a single question: <b>how much faster
+ * is one kernel launch when the GPU filters inline and transmits only the handful of hits,
+ * compared with transferring every work-item result back over PCIe?</b>
+ *
+ * <p>The lever is the single boolean {@code @Param gpuFilter}:</p>
+ * <ul>
+ *   <li>{@code gpuFilter=false} &mdash; baseline. No filter is uploaded, so
+ *       {@link OpenCLContext#createKeys(BigInteger)} runs in full-transfer mode and reads back
+ *       all {@code 1 << batchSizeInBits} work-item results (the legacy behaviour).</li>
+ *   <li>{@code gpuFilter=true} &mdash; FUSE_8 compact mode
+ *       ({@link CProducerOpenCL#enableGpuFilter}{@code =true},
+ *       {@link CProducerOpenCL#transferAll}{@code =false}). A Binary Fuse 8 filter populated
+ *       with {@code filterEntries} addresses that do <em>not</em> match the scanned candidates
+ *       is uploaded to VRAM; the kernel then transmits only the rare false-positives
+ *       (~0.4&nbsp;% of the batch) instead of the whole grid.</li>
+ * </ul>
+ *
+ * <p>The two rows JMH prints for the same {@code batchSizeInBits} are directly comparable: the
+ * speedup of the {@code true} row over the {@code false} row is the value the GPU filter adds.
+ *
+ * <p>What is measured: end-to-end kernel-launch throughput (launch + readback + host-side parse
+ * via {@link OpenCLContext#createKeys(BigInteger)} and {@code getPublicKeyBytes()}) at each
+ * {@code (gpuFilter, batchSizeInBits)} corner. The candidate keys produced per launch is
+ * {@code 1 << batchSizeInBits}, so candidates/sec at a data point = JMH ops/sec
+ * &#x00D7; {@code (1 << batchSizeInBits)}. (JMH's {@code @OperationsPerInvocation} would
+ * normalise this automatically but only accepts a compile-time constant and therefore cannot
+ * track the {@code @Param}.)</p>
+ *
+ * <p>OpenCL availability is gated via
+ * {@link OpenCLPlatformAssume#assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable()};
+ * compact mode additionally needs OpenCL 2.0+ (atomic_add), which the same assume covers. If no
+ * suitable device is present the JMH trial fails with {@code AssumptionViolatedException}, which
+ * JMH reports as {@code ERROR} on that {@code @Param} combo (a deliberate &quot;asymptote
+ * visible&quot; choice rather than silently downgrading).</p>
+ *
+ * <p><b>Why one long iteration rather than many short samples:</b> the only meaningful one-time
+ * cost here is OpenCL <b>kernel compilation</b>, which happens once in {@link OpenCLContext#init()}
+ * (the {@code @Setup(Level.Trial)} step, outside the timed region). JVM warmup iterations do not
+ * help a GPU benchmark, so the defaults below spend the budget on a single long measurement
+ * iteration (~200&nbsp;s) preceded by a short warmup just long enough for the GPU to reach steady
+ * clocks. Override with {@code -wi 2 -i 4} for a quick (~2&nbsp;min) sanity check.</p>
+ *
+ * <p>Run locally (requires an OpenCL 2.0+ device):</p>
+ * <pre>
+ * mvn test-compile exec:java -Dexec.args=&quot;GpuFuse8FilterBenchmark&quot;
+ *
+ * # sweep batch size, both filter modes (the saving grows with the grid)
+ * mvn test-compile exec:java \
+ *   -Dexec.args=&quot;GpuFuse8FilterBenchmark -p batchSizeInBits=19,20&quot;
+ *
+ * # quick sanity check (many short samples instead of one long one)
+ * mvn test-compile exec:java \
+ *   -Dexec.args=&quot;GpuFuse8FilterBenchmark -wi 2 -i 4&quot;
+ * </pre>
+ *
+ * <p>This benchmark is intentionally NOT executed by {@code mvn test} (no {@code @Test}
+ * annotation, lives in the JMH-runner path); CI runners typically lack a GPU.</p>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+// One long measurement iteration: the one-time cost is OpenCL kernel compilation (done in
+// @Setup, outside timing), not JVM warmup. A short warmup just lets the GPU clocks ramp up.
+@Warmup(iterations = 1, time = 30)
+@Measurement(iterations = 1, time = 200)
+@Fork(
+        value = 1,
+        // Master JVM-flag list — keep identical (same set + same order) to the pom.xml
+        // <argLine>, .mvn/jvm.config and examples/*.bat so the JMH fork matches the JVM
+        // Surefire uses (lmdbjava reflects into sun.nio.ch / jdk.internal.ref).
+        jvmArgsAppend = {
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.io=ALL-UNNAMED",
+            "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED",
+            "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+            "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            "--add-exports=java.base/java.lang=ALL-UNNAMED",
+            "--add-exports=java.base/java.io=ALL-UNNAMED",
+            "--add-exports=java.base/java.nio=ALL-UNNAMED",
+            "--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED",
+            "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+            "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+            "--add-exports=jdk.management/com.sun.management.internal=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        })
+public class GpuFuse8FilterBenchmark {
+
+    /** Width of a hash160 address entry in bytes. */
+    private static final int HASH160_LENGTH = 20;
+
+    /** Deterministic seed for the synthetic filter contents, so trials are reproducible. */
+    private static final long FILTER_CONTENT_SEED = 0x9E3779B97F4A7C15L;
+
+    /**
+     * When {@code true} a Binary Fuse 8 filter is uploaded and the kernel runs in compact mode
+     * (transmits only hits); when {@code false} the kernel transfers every work-item result.
+     */
+    @Param({"false", "true"})
+    public boolean gpuFilter;
+
+    /**
+     * Log2 of the per-launch work size. Each launch produces {@code 1 << batchSizeInBits}
+     * candidate keys.
+     */
+    @Param({"19"})
+    public int batchSizeInBits;
+
+    /**
+     * Number of (non-matching) addresses inserted into the GPU filter. Only relevant when
+     * {@code gpuFilter=true}; sized to model a realistic database the scanned random keys do
+     * not collide with, so the compact path emits only Binary Fuse 8 false-positives.
+     */
+    @Param({"1048576"})
+    public int filterEntries;
+
+    private OpenCLContext ctx;
+    private BigInteger privateKeyBase;
+
+    /** Creates a new {@link GpuFuse8FilterBenchmark} (no-arg constructor for JMH). */
+    public GpuFuse8FilterBenchmark() {
+        // no-op
+    }
+
+    /**
+     * Builds an OpenCL context for the current {@code @Param} combo and, when
+     * {@code gpuFilter=true}, populates and uploads a Binary Fuse 8 filter of
+     * {@code filterEntries} addresses unrelated to the scanned key range.
+     *
+     * <p>Skips the trial cleanly (JMH reports {@code ERROR} on the data point) if no
+     * OpenCL 2.0+ device is available, mirroring {@code GridSizeSweepBenchmark} and
+     * {@code OpenCLCompactOutputIntegrationTest}.</p>
+     *
+     * @throws Exception if {@link OpenCLContext#init()} fails (e.g. VRAM exhaustion or
+     *                   kernel build error)
+     */
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+
+        final CProducerOpenCL p = new CProducerOpenCL();
+        p.batchSizeInBits = batchSizeInBits;
+        p.keysPerWorkItem = 1;
+        // Compact mode is requested only for the filter arm; the baseline arm keeps the legacy
+        // full-transfer layout (no filter uploaded -> createKeys() transfers every result).
+        p.enableGpuFilter = gpuFilter;
+        p.transferAll = false;
+
+        ctx = new OpenCLContext(p, new BitHelper());
+        ctx.init();
+
+        if (gpuFilter) {
+            BinaryFuse8GpuFilterData payload = BinaryFuse8AddressPresence.populateFrom(
+                            nonMatchingAddresses(filterEntries))
+                    .toGpuFilterData();
+            long seed = payload.seed();
+            ctx.uploadGpuFilter(
+                    payload.fingerprints(),
+                    (int) seed,
+                    (int) (seed >>> 32),
+                    payload.segmentLength(),
+                    payload.segmentLengthMask(),
+                    payload.segmentCountLength());
+        }
+
+        // A 256-bit base far from the synthetic filter contents: scanned candidates will not
+        // collide with the filter, so the compact arm emits only Binary Fuse 8 false-positives.
+        privateKeyBase = new BigInteger(256, new SecureRandom());
+    }
+
+    /**
+     * One kernel launch at the current {@code @Param} combo, including the host-side parse of the
+     * returned grid. Returns the number of emitted work-items so JMH's dead-code elimination
+     * cannot remove the call (and so the readback + parse cost is genuinely incurred).
+     *
+     * @return the number of public-key results the launch produced
+     */
+    @Benchmark
+    public int oneKernelLaunch() {
+        return ctx.createKeys(privateKeyBase).getPublicKeyBytes().length;
+    }
+
+    /**
+     * Releases the OpenCL context built in {@link #setUp()}. Guarded against the
+     * &quot;setUp threw before ctx was assigned&quot; case so JMH can still record the ERROR
+     * for that data point.
+     */
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (ctx != null && !ctx.isClosed()) {
+            ctx.close();
+        }
+    }
+
+    /**
+     * Builds an {@link AddressIterable} of {@code count} deterministic, pseudo-random 20-byte
+     * hash160 entries. The entries are unrelated to any derived candidate key, so they model a
+     * database the scanned random keys do not match.
+     *
+     * @param count number of synthetic addresses to generate
+     * @return an iterable over {@code count} hash160 entries
+     */
+    private static AddressIterable nonMatchingAddresses(int count) {
+        final Random random = new Random(FILTER_CONTENT_SEED);
+        final List<byte[]> entries = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            byte[] hash160 = new byte[HASH160_LENGTH];
+            random.nextBytes(hash160);
+            entries.add(hash160);
+        }
+        return new AddressIterable() {
+            @Override
+            public Stream<ByteBuffer> addresses() {
+                return entries.stream().map(ByteBuffer::wrap);
+            }
+
+            @Override
+            public long count() {
+                return entries.size();
+            }
+        };
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
@@ -166,6 +166,16 @@ public class GpuFuse8FilterBenchmark {
     @Param({"1048576"})
     public int filterEntries;
 
+    /**
+     * Enables OpenCL device-side profiling ({@link CProducerOpenCL#enableProfiling}). When
+     * {@code true}, {@link #tearDown()} prints the device-side kernel-execution and result-readback
+     * times of the last launch, isolating GPU compute from PCIe transfer (and, against the
+     * wall-clock throughput, from host-side parsing). Off by default so the headline throughput
+     * rows are not perturbed by profiling overhead; enable with {@code -p profiling=true}.
+     */
+    @Param({"false"})
+    public boolean profiling;
+
     private OpenCLContext ctx;
     private BigInteger privateKeyBase;
 
@@ -197,6 +207,7 @@ public class GpuFuse8FilterBenchmark {
         // full-transfer layout (no filter uploaded -> createKeys() transfers every result).
         p.enableGpuFilter = gpuFilter;
         p.transferAll = false;
+        p.enableProfiling = profiling;
 
         ctx = new OpenCLContext(p, new BitHelper());
         ctx.init();
@@ -240,6 +251,18 @@ public class GpuFuse8FilterBenchmark {
     @TearDown(Level.Trial)
     public void tearDown() {
         if (ctx != null && !ctx.isClosed()) {
+            if (profiling) {
+                ctx.getOpenClTask().ifPresent(task -> {
+                    long kernelNanos = task.getLastKernelExecutionNanos();
+                    long readbackNanos = task.getLastResultReadbackNanos();
+                    // Printed to stdout (captured in the JMH log) rather than returned as a JMH
+                    // metric: these are device-side timings of the last launch, used to attribute
+                    // cost between GPU compute and PCIe transfer, not the benchmark's throughput.
+                    System.out.printf(
+                            "[profiling] gpuFilter=%s batchSizeInBits=%d -> kernel=%.3f ms, readback=%.3f ms%n",
+                            gpuFilter, batchSizeInBits, kernelNanos / 1_000_000.0, readbackNanos / 1_000_000.0);
+                });
+            }
             ctx.close();
         }
     }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCLTest.java
@@ -26,6 +26,43 @@ public class CProducerOpenCLTest {
     }
 
     @Test
+    public void defaults_enableProfiling_isFalse() {
+        // arrange + act
+        CProducerOpenCL config = new CProducerOpenCL();
+
+        // assert
+        assertThat(config.enableProfiling, is(false));
+    }
+
+    @Test
+    public void jsonRoundTrip_enableProfiling_survivesSerialiseDeserialise() throws Exception {
+        // arrange
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        CProducerOpenCL original = new CProducerOpenCL();
+        original.enableProfiling = true;
+
+        // act
+        String json = mapper.writeValueAsString(original);
+        CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
+
+        // assert
+        assertThat(parsed.enableProfiling, is(true));
+    }
+
+    @Test
+    public void jsonDeserialise_enableProfilingAbsent_defaultsToFalse() throws Exception {
+        // arrange
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        String json = "{}";
+
+        // act
+        CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
+
+        // assert
+        assertThat(parsed.enableProfiling, is(false));
+    }
+
+    @Test
     public void jsonRoundTrip_defaultFlags_surviveSerialiseDeserialise() throws Exception {
         // arrange
         // CProducer exposes a derived read-only getter (getOverallWorkSize) that serialises


### PR DESCRIPTION
- Adds a GPU Binary Fuse 8 (FUSE_8) compact-vs-full-transfer benchmark (GpuFuse8FilterBenchmark) plus opt-in OpenCL device profiling (CProducerOpenCL.enableProfiling), showing the on-GPU filter costs only ~2.4% extra kernel time while collapsing PCIe read-back ~250×.
- Optimizes the OpenCL scalar walker (inc_ecc_secp256k1custom.cl): replaces the per-key modular inverse with Montgomery simultaneous inversion over sub-batches (KEYS_BATCH_INV), lifting peak throughput on an RTX 3070 from ~14.4 → ~19.8 M keys/s (~+37%) and shifting the optimal keysPerWorkItem 32 → 64.
- Documents benchmarked keysPerWorkItem tuning (default 1 is ~8× slower than the sweet spot) and adds a parameterized full-batch correctness test across keysPerWorkItem that verifies every result against bitcoinj.

Test plan

- [x] Affected unit / integration tests pass locally — ProbeAddressesOpenCLTest, OpenCLCompactOutputIntegrationTest, OpenCLContextTest, CProducerOpenCLTest (57 GPU tests, 0 failures) on an RTX 3070; correctness gate green for keysPerWorkItem ∈ {1,2,4,8,16} with KEYS_BATCH_INV=8
- [ ] CI is green on this branch — correctness tests run on pocl in CI; the JMH benchmarks are not @Test (manual reproduction only)
- [x] Docs / CHANGELOG updated where applicable — README (tuning table + reproduction command + FUSE_8 device breakdown) and CLAUDE.md (JMH run recipe)

Related issues / PRs

<!-- none -->

Checklist

- [ ] I have read CONTRIBUTING.md and CODE_OF_CONDUCT.md
- [ ] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per SECURITY.md)

---
Two honest flags before you post it:
- I pre-ticked the two boxes I actually verified; leave the CI box for after the run. Commit messages are not Conventional Commits (subjects like "Add…", "Batch…", "Document…"), so don't tick that box unless you squash-rename on merge — say the word and I'll reword them.
- Benchmark figures are RTX-3070-specific with run-to-run variance; the commands/settings to regenerate them are committed (correctness is deterministic).