### PR TITLE
Refactor: improve thread safety and code ordering

### DIFF
--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenClTask.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenClTask.java
@@ -55,6 +55,9 @@ public class OpenClTask implements ReleaseCLObject {
 
     private static final int PRIVATE_KEY_SOURCE_SIZE_IN_BYTES = OpenClKernelConstants.PRIVATE_KEY_MAX_NUM_BYTES;
 
+    /** Sentinel meaning "no profiling timestamp captured for the most recent launch". */
+    public static final long PROFILING_NOT_AVAILABLE = -1L;
+
     private final CProducerOpenCL cProducer;
 
     // JOCL cl_context is a native-pointer wrapper — toString is uninformative.
@@ -70,10 +73,7 @@ public class OpenClTask implements ReleaseCLObject {
     private final BigInteger maxPrivateKeyForBatchSize;
     private final PrivateKeyValidator privateKeyValidator;
 
-    private boolean closed = false;
-
-    /** Sentinel meaning "no profiling timestamp captured for the most recent launch". */
-    public static final long PROFILING_NOT_AVAILABLE = -1L;
+    private volatile boolean closed = false;
 
     // Device-side nanosecond timings of the most recent executeKernel() call. Only populated when
     // CProducerOpenCL.enableProfiling is true (a diagnostic/benchmark switch); otherwise they stay

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
@@ -198,7 +198,7 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
         int[] idx = {0};
         try (Stream<ByteBuffer> stream = source.addresses()) {
             stream.forEach(bb -> {
-                if (bb.remaining() == BYTES_PER_ADDRESS && idx[0] < keys.length) {
+                if (idx[0] < keys.length && bb.remaining() == BYTES_PER_ADDRESS) {
                     keys[idx[0]++] = bb.getLong(bb.position());
                 }
             });

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
@@ -271,7 +271,7 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
         int[] idx = {0};
         try (Stream<ByteBuffer> stream = source.addresses()) {
             stream.forEach(bb -> {
-                if (bb.remaining() == BYTES_PER_ADDRESS && idx[0] < keys.length) {
+                if (idx[0] < keys.length && bb.remaining() == BYTES_PER_ADDRESS) {
                     keys[idx[0]++] = bb.getLong(bb.position());
                 }
             });


### PR DESCRIPTION
## Summary

- Make `OpenClTask.closed` field `volatile` to ensure thread-safe visibility of state changes across threads
- Reorder constant and field declarations in `OpenClTask` for better code organization (constants before fields)
- Reorder condition checks in `BinaryFuse16AddressPresence` and `BinaryFuse8AddressPresence` to check array bounds before dereferencing buffer (short-circuit evaluation optimization)

## Test plan

- [x] Affected unit / integration tests pass locally
- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01M9yG5LR2RLX4URkY852myy