### PR TITLE
Add vmlens interleaving analysis tests for shutdown protocol

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,6 +138,33 @@ jobs:
         with: { name: pit-reports, path: target/pit-reports/ }
 
   # ---------------------------------------------------------------------------
+  # vmlens interleaving analysis — pure-Java, needs no LMDB or OpenCL device.
+  # Staged to a single smoke test for now (see the `vmlens` profile in pom.xml).
+  # ---------------------------------------------------------------------------
+  vmlens:
+    name: Test (vmlens interleavings)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+          cache: maven
+      - name: Test under vmlens (one class — staged scope)
+        run: >-
+          mvn --batch-mode --no-transfer-progress -Pvmlens test
+          -Dtest=VmlensInterleavingSmokeTest -DfailIfNoTests=false
+          -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: vmlens-report
+          path: target/vmlens-report/
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
   # Emulated-OpenCL coverage on a real CPU OpenCL device (pocl), kept separate
   # from the `test` matrix above. This is a REQUIRED gate — both Ubuntu pipelines
   # (the CPU-only `test` matrix where @OpenCLTest self-skips, and this emulated

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,10 +152,14 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
           cache: maven
-      - name: Test under vmlens (one class — staged scope)
+      - name: Test under vmlens (interleaving analysis)
+        # Add each new test in the `vmlens` package to this -Dtest list (surefire
+        # -Dtest matches simple class names, not package globs; the default suite is
+        # excluded from the vmlens package via pom.xml managed surefire <excludes>).
         run: >-
           mvn --batch-mode --no-transfer-progress -Pvmlens test
-          -Dtest=VmlensInterleavingSmokeTest -DfailIfNoTests=false
+          -Dtest=VmlensInterleavingSmokeTest,KeyProducerQueueBufferedInterleavingTest
+          -DfailIfNoTests=false
           -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true
       - uses: actions/upload-artifact@v7
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,20 @@ SPDX-License-Identifier: Apache-2.0
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.6</version>
+                    <configuration>
+                        <!--
+                            The vmlens interleaving smoke test is meaningful only when run
+                            under the vmlens agent (the `vmlens` profile / CI job). Without the
+                            agent its AllInterleavings loop body never executes (a vacuous pass
+                            that also prints an "agent not configured" warning), so exclude it
+                            from the ordinary surefire run. The vmlens job re-includes it with
+                            `-Dtest=...`, which overrides this exclude. Merged with the main
+                            surefire <argLine>/fork config below via pluginManagement.
+                        -->
+                        <excludes>
+                            <exclude>**/VmlensInterleavingSmokeTest.java</exclude>
+                        </excludes>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -997,6 +1011,21 @@ SPDX-License-Identifier: Apache-2.0
             <version>${lincheck.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+            vmlens interleaving-analysis API. Test-scoped and transitive-dependency-free
+            (its own deps are all test-scope, hence not propagated), so it is safe on the
+            default test classpath under dependencyConvergence. Needed so the
+            VmlensInterleavingSmoke* test compiles in every build; it is only *executed*
+            under the `vmlens` profile (see that profile + the vmlens CI job). The default
+            surefire run excludes it (managed surefire <excludes> below) so the vmlens
+            agent's JDK 9 API class is never loaded outside the agent-driven run.
+        -->
+        <dependency>
+            <groupId>com.vmlens</groupId>
+            <artifactId>api</artifactId>
+            <version>${vmlens.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -1038,14 +1067,6 @@ SPDX-License-Identifier: Apache-2.0
         </profile>
         <profile>
             <id>vmlens</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.vmlens</groupId>
-                    <artifactId>api</artifactId>
-                    <version>${vmlens.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -1053,16 +1074,15 @@ SPDX-License-Identifier: Apache-2.0
                         <artifactId>vmlens-maven-plugin</artifactId>
                         <configuration>
                             <!--
-                                Lincheck generates its own TestThreadExecution class on the fly.
-                                That bytecode clashes with vmlens's load-time instrumentation
-                                (java.lang.VerifyError). Skip the Lincheck test under vmlens;
-                                the default test job still runs it.
-                                **/*$* is the plugin default - kept to preserve inner-class skip.
+                                Staged scope (one class for now): run vmlens interleaving
+                                analysis only on the minimal smoke test. The `com.vmlens:api`
+                                test dependency lives in the main <dependencies> block.
+                                Expand <includes> as more concurrency tests are added (the
+                                streambuffer repo runs vmlens over its whole suite).
                             -->
-                            <excludes>
-                                <exclude>**/*$*</exclude>
-                                <exclude>**/BitHelperLincheckTest.java</exclude>
-                            </excludes>
+                            <includes>
+                                <include>**/VmlensInterleavingSmokeTest.java</include>
+                            </includes>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -209,16 +209,16 @@ SPDX-License-Identifier: Apache-2.0
                     <version>3.5.6</version>
                     <configuration>
                         <!--
-                            The vmlens interleaving smoke test is meaningful only when run
-                            under the vmlens agent (the `vmlens` profile / CI job). Without the
-                            agent its AllInterleavings loop body never executes (a vacuous pass
-                            that also prints an "agent not configured" warning), so exclude it
-                            from the ordinary surefire run. The vmlens job re-includes it with
-                            `-Dtest=...`, which overrides this exclude. Merged with the main
-                            surefire <argLine>/fork config below via pluginManagement.
+                            Tests in the `vmlens` package are meaningful only under the vmlens
+                            agent (the `vmlens` profile / CI job). Without the agent an
+                            AllInterleavings loop body never executes (a vacuous pass that also
+                            prints an "agent not configured" warning), so exclude the whole
+                            package from the ordinary surefire run. The vmlens job re-includes
+                            them with `-Dtest=...`, which overrides this exclude. Merged with
+                            the main surefire <argLine>/fork config below via pluginManagement.
                         -->
                         <excludes>
-                            <exclude>**/VmlensInterleavingSmokeTest.java</exclude>
+                            <exclude>**/vmlens/*.java</exclude>
                         </excludes>
                     </configuration>
                 </plugin>
@@ -1074,14 +1074,15 @@ SPDX-License-Identifier: Apache-2.0
                         <artifactId>vmlens-maven-plugin</artifactId>
                         <configuration>
                             <!--
-                                Staged scope (one class for now): run vmlens interleaving
-                                analysis only on the minimal smoke test. The `com.vmlens:api`
-                                test dependency lives in the main <dependencies> block.
-                                Expand <includes> as more concurrency tests are added (the
-                                streambuffer repo runs vmlens over its whole suite).
+                                Run vmlens interleaving analysis over the whole `vmlens` test
+                                package: the smoke test plus the real interleaving tests (e.g.
+                                KeyProducerQueueBufferedInterleavingTest). The `com.vmlens:api`
+                                test dependency lives in the main <dependencies> block. Add new
+                                interleaving tests to the `vmlens` package and they are picked
+                                up automatically.
                             -->
                             <includes>
-                                <include>**/VmlensInterleavingSmokeTest.java</include>
+                                <include>**/vmlens/*.java</include>
                             </includes>
                         </configuration>
                         <executions>

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/vmlens/KeyProducerQueueBufferedInterleavingTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/vmlens/KeyProducerQueueBufferedInterleavingTest.java
@@ -6,9 +6,11 @@ package net.ladenthin.bitcoinaddressfinder.vmlens;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.vmlens.api.AllInterleavings;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaReceiver;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.AbstractKeyProducerQueueBuffered;
@@ -63,7 +65,14 @@ public class KeyProducerQueueBufferedInterleavingTest {
         public void interrupt() {
             signalShutdown();
         }
+
+        void addForTest(byte[] secret) {
+            addSecret(secret);
+        }
     }
+
+    /** secp256k1 private-key byte length; a real secret has this many bytes, the sentinel has zero. */
+    private static final int PRIVATE_KEY_BYTES = 32;
 
     /**
      * Verifies that {@code signalShutdown()} always unblocks a consumer parked in
@@ -99,6 +108,62 @@ public class KeyProducerQueueBufferedInterleavingTest {
                 shutdown.join();
 
                 assertThat(outcome.get(), is(instanceOf(NoMoreSecretsAvailableException.class)));
+            }
+        }
+    }
+
+    /**
+     * Verifies the drop-after-stop invariant: when {@code addSecret(...)} races
+     * {@code signalShutdown()}, a subsequent consume yields exactly one of two
+     * outcomes in every interleaving — the real key (it was enqueued ahead of the
+     * sentinel) or a clean {@link NoMoreSecretsAvailableException} — and the
+     * zero-length {@code SHUTDOWN_SENTINEL} is <em>never</em> decoded as a key.
+     *
+     * <p>This is a regression guard, not a bug reproduction: the protocol is correct
+     * by construction (source-side drop via the {@code shouldStop} guard in
+     * {@code addSecret}; the consumer always throws on the sentinel so it can never
+     * advance to an element behind it; and a reference-identity check plus a
+     * {@code length != 32} backstop keep the sentinel from being mistaken for a key).
+     * vmlens proves it holds across <em>all</em> writer interleavings.</p>
+     *
+     * @throws InterruptedException if joining a worker thread is interrupted
+     */
+    @Test
+    public void shutdownNeverLetsTheSentinelBeDecodedAsAKey() throws InterruptedException {
+        try (AllInterleavings allInterleavings =
+                new AllInterleavings("AbstractKeyProducerQueueBuffered.dropAfterStop")) {
+            while (allInterleavings.hasNext()) {
+                final ShutdownProbe producer = new ShutdownProbe(new CKeyProducerJavaReceiver(), keyUtility);
+                final byte[] key = new byte[PRIVATE_KEY_BYTES];
+                Arrays.fill(key, (byte) 0xAB);
+                final BigInteger expectedKey = new BigInteger(1, key);
+                final AtomicReference<Throwable> producerFailure = new AtomicReference<>();
+
+                final Thread transport = new Thread(() -> {
+                    try {
+                        producer.addForTest(key);
+                    } catch (Throwable t) {
+                        producerFailure.compareAndSet(null, t);
+                    }
+                });
+                final Thread shutdown = new Thread(producer::interrupt);
+
+                transport.start();
+                shutdown.start();
+                transport.join();
+                shutdown.join();
+                assertThat(producerFailure.get(), is(nullValue()));
+
+                // The sentinel is always enqueued (unbounded queue), so this consume
+                // never blocks; it must resolve to the real key or a clean termination.
+                try {
+                    final BigInteger[] secrets = producer.createSecrets(1, true);
+                    assertThat(secrets.length, is(1));
+                    assertThat(
+                            "only the real key may ever be decoded, never the sentinel", secrets[0], is(expectedKey));
+                } catch (NoMoreSecretsAvailableException terminated) {
+                    // Acceptable: the consumer observed the sentinel / shouldStop and stopped.
+                }
             }
         }
     }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/vmlens/KeyProducerQueueBufferedInterleavingTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/vmlens/KeyProducerQueueBufferedInterleavingTest.java
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.vmlens;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import com.vmlens.api.AllInterleavings;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaReceiver;
+import net.ladenthin.bitcoinaddressfinder.keyproducer.AbstractKeyProducerQueueBuffered;
+import net.ladenthin.bitcoinaddressfinder.secret.NoMoreSecretsAvailableException;
+import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
+import net.ladenthin.bitcoinaddressfinder.util.KeyUtility;
+import net.ladenthin.bitcoinaddressfinder.util.NetworkParameterFactory;
+import org.bitcoinj.base.Network;
+import org.junit.jupiter.api.Test;
+
+/**
+ * vmlens interleaving analysis of the shutdown hand-off in
+ * {@link AbstractKeyProducerQueueBuffered}.
+ *
+ * <p>The base class coordinates three roles over a {@code BlockingQueue} with a
+ * hand-rolled protocol: a consumer parked in {@code createSecrets(...)} (here on an
+ * indefinite {@code take()}), and a shutdown caller that performs two separate
+ * writes — set {@code volatile shouldStop = true}, then {@code offer} a
+ * reference-identity {@code SHUTDOWN_SENTINEL}. The consumer in turn does two
+ * separate reads — check {@code shouldStop} at the top of its loop, then block on
+ * {@code take()}.</p>
+ *
+ * <p>The liveness invariant that must hold under <em>every</em> interleaving:
+ * {@code signalShutdown()} always releases a parked consumer, which terminates with
+ * {@link NoMoreSecretsAvailableException} — there is no schedule in which the
+ * consumer is left blocked forever (lost wakeup). This is exactly the multi-write /
+ * multi-read ordering class vmlens enumerates and that the trivial single-{@code
+ * AtomicLong} smoke test cannot. Unlike the model-gated thread-pool tests in
+ * {@code AbstractKeyProducerQueueBufferedTest}, vmlens drives this exhaustively.</p>
+ *
+ * <p>Raw {@link Thread} usage is intentional here (the production "use executor
+ * services" convention does not apply): vmlens explores the interleavings of the
+ * threads it directly manages.</p>
+ */
+public class KeyProducerQueueBufferedInterleavingTest {
+
+    private final Network network = new NetworkParameterFactory().getNetwork();
+    private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
+
+    /** Minimal concrete receiver that blocks indefinitely and exposes the shutdown signal. */
+    private static final class ShutdownProbe extends AbstractKeyProducerQueueBuffered<CKeyProducerJavaReceiver> {
+        ShutdownProbe(CKeyProducerJavaReceiver config, KeyUtility keyUtility) {
+            super(config, keyUtility);
+        }
+
+        @Override
+        protected int getReadTimeout() {
+            return -1; // take(), block forever until a secret or the shutdown sentinel arrives
+        }
+
+        @Override
+        public void interrupt() {
+            signalShutdown();
+        }
+    }
+
+    /**
+     * Verifies that {@code signalShutdown()} always unblocks a consumer parked in
+     * {@code createSecrets(...)} — it terminates with
+     * {@link NoMoreSecretsAvailableException} in every interleaving (no lost wakeup).
+     *
+     * @throws InterruptedException if joining a worker thread is interrupted
+     */
+    @Test
+    public void shutdownAlwaysUnblocksParkedConsumer() throws InterruptedException {
+        try (AllInterleavings allInterleavings =
+                new AllInterleavings("AbstractKeyProducerQueueBuffered.shutdownUnblocks")) {
+            while (allInterleavings.hasNext()) {
+                final ShutdownProbe producer = new ShutdownProbe(new CKeyProducerJavaReceiver(), keyUtility);
+                final AtomicReference<Throwable> outcome = new AtomicReference<>();
+
+                final Thread consumer = new Thread(() -> {
+                    try {
+                        final BigInteger[] secrets = producer.createSecrets(1, true);
+                        outcome.compareAndSet(
+                                null,
+                                new AssertionError("createSecrets returned " + secrets.length
+                                        + " secrets instead of terminating on shutdown"));
+                    } catch (Throwable t) {
+                        outcome.compareAndSet(null, t);
+                    }
+                });
+                final Thread shutdown = new Thread(producer::interrupt);
+
+                consumer.start();
+                shutdown.start();
+                consumer.join();
+                shutdown.join();
+
+                assertThat(outcome.get(), is(instanceOf(NoMoreSecretsAvailableException.class)));
+            }
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/vmlens/VmlensInterleavingSmokeTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/vmlens/VmlensInterleavingSmokeTest.java
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.vmlens;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.vmlens.api.AllInterleavings;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Minimal vmlens interleaving-analysis smoke test demonstrating the setup.
+ *
+ * <p>Two threads each increment a shared {@link AtomicLong}; because
+ * {@link AtomicLong#incrementAndGet()} is atomic, the final value must always be
+ * {@code 2} regardless of how the two threads interleave. vmlens drives the body
+ * of the {@link AllInterleavings} loop through every possible interleaving and
+ * fails if any ordering violates the invariant.</p>
+ *
+ * <p>This test is meaningful only when executed under the vmlens java agent,
+ * which is wired up by the {@code vmlens} Maven profile and the dedicated vmlens
+ * CI job ({@code mvn -Pvmlens test}). Without the agent
+ * {@link AllInterleavings#hasNext()} returns {@code false} and the loop body is
+ * skipped, so the ordinary surefire run excludes this class (see the
+ * {@code maven-surefire-plugin} {@code <excludes>} in {@code pom.xml}). It is the
+ * staged "one class for now" baseline; widen the profile's {@code <includes>} as
+ * more concurrency tests are added.</p>
+ *
+ * <p>This is the one place in the project where raw {@link Thread} usage is
+ * intentional (the production "use executor services" convention does not apply):
+ * vmlens explores the interleavings of the threads it directly manages, and a
+ * thread pool's internal locks would explode the interleaving space without
+ * adding coverage value.</p>
+ */
+public class VmlensInterleavingSmokeTest {
+
+    /**
+     * Verifies that two concurrent atomic increments always sum to two under
+     * every thread interleaving explored by vmlens.
+     *
+     * @throws InterruptedException if joining a worker thread is interrupted
+     */
+    @Test
+    public void atomicIncrementsAreLinearizable() throws InterruptedException {
+        try (AllInterleavings allInterleavings = new AllInterleavings("VmlensInterleavingSmokeTest.atomicIncrements")) {
+            while (allInterleavings.hasNext()) {
+                final AtomicLong counter = new AtomicLong();
+
+                final Thread first = new Thread(counter::incrementAndGet);
+                final Thread second = new Thread(counter::incrementAndGet);
+
+                first.start();
+                second.start();
+                first.join();
+                second.join();
+
+                assertThat(counter.get(), is(2L));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add two new vmlens interleaving-analysis tests to verify the correctness of the shutdown hand-off protocol in `AbstractKeyProducerQueueBuffered` under all possible thread interleavings
- Add a minimal smoke test (`VmlensInterleavingSmokeTest`) to validate the vmlens test infrastructure
- Integrate vmlens test execution into the CI pipeline via a dedicated GitHub Actions job
- Move the vmlens API dependency from the `vmlens` profile to the main `<dependencies>` block and exclude vmlens tests from the default surefire run

## Details

The new tests use the vmlens interleaving-analysis framework to exhaustively verify two critical liveness properties of the key producer's shutdown mechanism:

1. **`shutdownAlwaysUnblocksParkedConsumer`**: Verifies that `signalShutdown()` always releases a consumer parked in `createSecrets(...)`, preventing lost wakeups under any thread interleaving.

2. **`shutdownNeverLetsTheSentinelBeDecodedAsAKey`**: Verifies the drop-after-stop invariant — when `addSecret(...)` races `signalShutdown()`, the consumer either receives the real key or terminates cleanly, and the zero-length `SHUTDOWN_SENTINEL` is never mistaken for a valid private key.

These tests complement the existing `AbstractKeyProducerQueueBufferedTest` (which uses thread pools and model-gated scenarios) by exploring the full interleaving space of the hand-rolled multi-write/multi-read shutdown protocol.

### Build & CI changes

- **pom.xml**: 
  - Move `com.vmlens:api` dependency to main `<dependencies>` (test-scoped, transitive-dependency-free)
  - Add managed surefire `<excludes>` to skip vmlens tests in the default run (they are only meaningful under the vmlens agent)
  - Simplify the `vmlens` profile to use `<includes>` for the vmlens-maven-plugin (auto-picks up new tests in the `vmlens` package)

- **.github/workflows/publish.yml**: 
  - Add a new `vmlens` CI job that runs interleaving analysis on the vmlens test package
  - Job is gated behind the `build` job and runs on ubuntu-latest with the vmlens Maven profile

## Test plan

- [x] New vmlens tests pass locally under the vmlens agent (`mvn -Pvmlens test`)
- [x] Default surefire run excludes vmlens tests (no spurious passes without the agent)
- [x] CI is green: the new `vmlens` job executes the smoke test and the shutdown protocol tests
- [x] Existing `AbstractKeyProducerQueueBufferedTest` continues to pass

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01HzCYFLjZZGFs4BsuUty35N