### PR TITLE
Decouple GPU pre-filter from CPU lookup backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,20 +308,22 @@ This reduction in scalar size speeds up `k·G` computations, resulting in signif
 
 ### 🚀 Pluggable Address Lookup Backends (`addressLookupBackend`)
 
-As of version 1.6.0, the address presence check is decoupled from the on-disk LMDB store via a small `AddressPresence` interface. The consumer's scan hot path queries through whichever backend is selected in the config — LMDB itself, a Bloom filter in front of LMDB, or a self-contained in-memory snapshot that lets the LMDB env be closed and garbage-collected after population.
+As of version 1.6.0, the address presence check is decoupled from the on-disk LMDB store via a small `AddressPresence` interface. The consumer's scan hot path queries through whichever backend is selected in the config — LMDB itself, a Bloom/Binary-Fuse filter in front of LMDB, or a self-contained in-memory snapshot that lets the LMDB env be closed and garbage-collected after population.
 
 ```json
-"addressLookupBackend": "BLOOM"
+"addressLookupBackend": "LMDB_ONLY"
 ```
+
+**The default is `LMDB_ONLY`: no in-RAM filter, LMDB stays open and answers every lookup exactly.** This is the safest baseline — an exact backend can never report a false positive as a hit — and the in-RAM filters below are opt-in optimisations you add only when you want them. (Note the GPU pre-filter, `producerOpenCL.enableGpuFilter`, is independent of this setting and works with the `LMDB_ONLY` default; see below.)
 
 Supported values:
 
 | Value               | RAM cost                | Lookup latency       | LMDB stays open? | Best for                                                                                |
 |---------------------|-------------------------|----------------------|------------------|-----------------------------------------------------------------------------------------|
-| `LMDB_ONLY`         | minimal (mmap only)     | slowest              | yes              | very large databases that do not fit in RAM at all                                      |
-| `BLOOM`             | ~80 MB – ~1.5 GB (FPP)  | fast for misses      | yes              | when LMDB must stay open and most queries miss the database                             |
+| `LMDB_ONLY`         | minimal (mmap only)     | slowest              | yes              | **default** — exact, no filter, can never produce a false hit; also the simplest base for GPU pre-filtering |
+| `BLOOM`             | ~80 MB – ~1.5 GB (FPP)  | fast for misses      | yes              | when you want to skip LMDB for the common miss case but keep it open to verify hits      |
 | `HASHSET`           | ~80 B / entry           | fast                 | **no**           | small databases where memory is plentiful and exact lookup is required by callers       |
-| `TRUNCATED_LONG_64` | **~8 B / entry**        | **near HASHSET**     | **no**           | **recommended default for any in-RAM choice** — best memory/latency trade-off           |
+| `TRUNCATED_LONG_64` | **~8 B / entry**        | **near HASHSET**     | **no**           | best in-RAM trade-off when you *do* want to drop LMDB — near-`HASHSET` latency at ~10× less RAM |
 | `BINARY_FUSE_8`     | **~1.3 B / entry**      | **fast**             | yes              | ultra-low RAM filter in front of LMDB; 0.4% of filter hits are verified against LMDB (also feeds the GPU pre-filter) |
 | `BINARY_FUSE_16`    | **~2.6 B / entry**      | **fast**             | yes              | like Fuse-8 but 0.0015% FPR — fewer LMDB verifications; use when Fuse-8's verification cost is measurable |
 
@@ -406,13 +408,15 @@ mvn test-compile exec:java -Dexec.args="BinaryFuseBenchmark"
 
 #### GPU-side Binary Fuse 8 filtering (`enableGpuFilter`)
 
-By default the OpenCL kernel transfers **every** derived work-item result back to the host, and the consumer then checks each hash160 against the selected `addressLookupBackend`. When the database is loaded as `BINARY_FUSE_8`, that same filter can instead be pushed **onto the GPU** so the kernel checks each derived hash160 inline and transmits only the candidates the filter marks as possibly present. This collapses the PCIe read-back from the full `2^batchSizeInBits` grid down to the handful of hits per batch — the dominant cost on large batches.
+By default the OpenCL kernel transfers **every** derived work-item result back to the host, and the consumer then checks each hash160 against the selected `addressLookupBackend`. With `enableGpuFilter`, a Binary Fuse 8 filter is instead pushed **onto the GPU** so the kernel checks each derived hash160 inline and transmits only the candidates the filter marks as possibly present. This collapses the PCIe read-back from the full `2^batchSizeInBits` grid down to the handful of hits per batch — the dominant cost on large batches.
+
+The GPU pre-filter is **independent of the CPU `addressLookupBackend`.** It is built once from LMDB purely as a transient VRAM-upload artifact (the host copy is freed after the one-time upload), so it works with the `LMDB_ONLY` default — you do **not** have to set the CPU backend to `BINARY_FUSE_8`. The survivors that come back from the GPU are verified directly against LMDB on the CPU, so they are never "double filtered". (If the CPU backend already *is* `BINARY_FUSE_8`, that filter is reused for the upload to avoid a second LMDB scan.)
 
 Enable it on an OpenCL producer (see [`examples/config_Find_GPUFilterCompact.json`](examples/config_Find_GPUFilterCompact.json)):
 
 ```json
 "consumerJava": {
-  "lmdbConfigurationReadOnly": { "addressLookupBackend": "BINARY_FUSE_8" }
+  "lmdbConfigurationReadOnly": { "addressLookupBackend": "LMDB_ONLY" }
 },
 "producerOpenCL": [
   { "enableGpuFilter": true, "transferAll": false }
@@ -421,7 +425,7 @@ Enable it on an OpenCL producer (see [`examples/config_Find_GPUFilterCompact.jso
 
 | Field | Default | Effect |
 |-------|:-------:|--------|
-| `enableGpuFilter` | `false` | When `true` **and** the consumer backend is `BINARY_FUSE_8`, the filter is uploaded to GPU VRAM and the kernel filters inline (compact output). |
+| `enableGpuFilter` | `false` | When `true`, a Binary Fuse 8 filter is built from LMDB and uploaded to GPU VRAM (once per session); the kernel filters inline (compact output). Independent of the CPU `addressLookupBackend` — requires only that LMDB is open (it is under the `LMDB_ONLY` default). |
 | `transferAll` | `false` | Forces full-transfer (legacy) output even when `enableGpuFilter` is on. `Finder` sets this to `true` automatically — with a warning — whenever `enableVanity = true`, because vanity scanning must see every derived address. |
 
 **How compact mode works** — the kernel checks both the compressed and uncompressed hash160 of each candidate against the uploaded filter; a work-item that hits claims an output slot via an `atomic_add` on a shared count word and writes its entry there, so the buffer holds exactly the hits (each entry carries its own work-item index for secret-key reconstruction). A non-hit writes nothing.

--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ Supported values:
 | `BLOOM`             | ~80 MB – ~1.5 GB (FPP)  | fast for misses      | yes              | when LMDB must stay open and most queries miss the database                             |
 | `HASHSET`           | ~80 B / entry           | fast                 | **no**           | small databases where memory is plentiful and exact lookup is required by callers       |
 | `TRUNCATED_LONG_64` | **~8 B / entry**        | **near HASHSET**     | **no**           | **recommended default for any in-RAM choice** — best memory/latency trade-off           |
-| `BINARY_FUSE_8`     | **~1.3 B / entry**      | **fast**             | **no**           | ultra-low RAM with 0.4% false-positive rate (LMDB fallback); closes LMDB after load    |
-| `BINARY_FUSE_16`    | **~2.6 B / entry**      | **fast**             | **no**           | 0.0015% false-positive rate — use when 0.4% LMDB fallback cost is measurable           |
+| `BINARY_FUSE_8`     | **~1.3 B / entry**      | **fast**             | **no**           | ultra-low RAM; closes LMDB after load — 0.4% false positives surface as rare unverified hits |
+| `BINARY_FUSE_16`    | **~2.6 B / entry**      | **fast**             | **no**           | closes LMDB after load — 0.0015% false-positive rate; use when Fuse-8's 0.4% spurious-hit rate is too high |
 
 #### Memory footprint per backend across the published database tiers
 
@@ -347,7 +347,7 @@ Supported values:
 
 #### Why `TRUNCATED_LONG_64` is so close to `HASHSET` despite being a binary search
 
-hash160 is the output of SHA-256 followed by RIPEMD-160 and is cryptographically uniform; any subset of its bits is also uniform. `TRUNCATED_LONG_64` keeps only the 8 bytes after the bucket byte (72 bits of total resolution: 8-bit bucket + 64-bit stored value). The probability that a random query collides with one of N stored entries is N/2⁶⁴, which for the largest published database tier is ~7.5 × 10⁻¹¹ per query — and any such collision falls through to the LMDB delegate. In return:
+hash160 is the output of SHA-256 followed by RIPEMD-160 and is cryptographically uniform; any subset of its bits is also uniform. `TRUNCATED_LONG_64` keeps only the 8 bytes after the bucket byte (72 bits of total resolution: 8-bit bucket + 64-bit stored value). The probability that a random query collides with one of N stored entries is N/2⁶⁴, which for the largest published database tier is ~7.5 × 10⁻¹¹ per query — rare enough that surfacing such a collision as an unverified hit is harmless (LMDB is closed after population, like the Binary Fuse backends). In return:
 
 - **Cache-line dense**: 8 longs per 64-byte cache line, the binary search walks very little memory.
 - **JDK intrinsic**: `Arrays.binarySearch(long[], long)` is heavily JIT-optimised and produces branchless comparisons on modern CPUs.
@@ -365,10 +365,10 @@ hit ⟺  fingerprints[h0] ⊕ fingerprints[h1] ⊕ fingerprints[h2] == fingerpri
 ```
 
 **No false negatives** — every key inserted via `populateFrom` is always found.  
-**False-positive rate** — 1/256 ≈ 0.4% for Fuse-8 (8-bit fingerprint), 1/65536 ≈ 0.0015% for Fuse-16 (16-bit fingerprint). False positives fall through to the LMDB delegate as in any other probabilistic backend.  
+**False-positive rate** — 1/256 ≈ 0.4% for Fuse-8 (8-bit fingerprint), 1/65536 ≈ 0.0015% for Fuse-16 (16-bit fingerprint). Because the filter is self-contained (see below), LMDB is closed after population, so a false positive is **not** re-verified against it — it surfaces as a reported hit. Genuine hits are astronomically rare under random scanning, so an occasional spurious hit is a negligible cost (it is logged for manual inspection).  
 **Self-contained** — `requiresBackend()` returns `false`; the LMDB env is closed and its mmap pages are released after population, identical to `HASHSET` and `TRUNCATED_LONG_64`.
 
-Choose between the two variants based on how expensive the LMDB fallback is in your workload. For most use cases with a light or full database, `BINARY_FUSE_8` gives the best RAM-to-latency trade-off: lower memory than `BLOOM` (no LMDB open) with a higher FPR, while `BINARY_FUSE_16` halves the FPR at the cost of 2× the fingerprint array size.
+Choose between the two variants based on how costly a spurious (unverified) hit is in your workflow. For most use cases with a light or full database, `BINARY_FUSE_8` gives the best RAM-to-latency trade-off: lower memory than `BLOOM` (no LMDB open) with a higher FPR, while `BINARY_FUSE_16` drops the FPR ~256× at the cost of 2× the fingerprint array size.
 
 #### Benchmark numbers
 
@@ -426,7 +426,7 @@ Enable it on an OpenCL producer (see [`examples/config_Find_GPUFilterCompact.jso
 
 **How compact mode works** — the kernel checks both the compressed and uncompressed hash160 of each candidate against the uploaded filter; a work-item that hits claims an output slot via an `atomic_add` on a shared count word and writes its entry there, so the buffer holds exactly the hits (each entry carries its own work-item index for secret-key reconstruction). A non-hit writes nothing.
 
-**No false negatives** — the Binary Fuse 8 guarantee carries to the GPU unchanged: any address actually in the database is always flagged. The ~0.4 % false positives fall through to the LMDB verifier exactly as they do for the in-RAM `BINARY_FUSE_8` backend.
+**No false negatives** — the Binary Fuse 8 guarantee carries to the GPU unchanged: any address actually in the database is always flagged. The ~0.4 % false positives surface as reported hits exactly as they do for the in-RAM `BINARY_FUSE_8` backend (LMDB is closed once the filter is built, so they are not re-verified).
 
 **Device requirements** — compact mode needs an **OpenCL 2.0+** device (the `atomic_add` on global memory) and a little-endian device (the kernel canonicalises its output as little-endian). Both are checked at producer init and fail fast with a clear message; on an older device set `transferAll: true` to keep the full-transfer path. The GPU/CPU lookup parity (key extraction + hash formula) is pinned by `Fuse8GpuHashParityTest` and exercised end-to-end on a real OpenCL device by `OpenCLCompactOutputIntegrationTest`.
 
@@ -770,8 +770,8 @@ LMDBToAddressFile_Light_HexHash.zip	SHA3-512	29CA44CD666D7B8CF9EAD4B340620FBB7ED
 > | Choice              | RAM needed at Full DB | LMDB stays open? | When to pick |
 > |---------------------|-----------------------|------------------|--------------|
 > | `TRUNCATED_LONG_64` | ~11 GB                | **no**           | recommended if you can spare ~12 GB; closes LMDB and releases its mmap pages |
-> | `BINARY_FUSE_8`     | **~1.8 GB**           | **no**           | closes LMDB like `TRUNCATED_LONG_64`; 0.4% FPR redirects those misses to LMDB as a one-time verifier (then it is closed) |
-> | `BINARY_FUSE_16`    | ~3.6 GB               | **no**           | same as Fuse-8 but with 0.0015% FPR — use when the LMDB fallback cost matters |
+> | `BINARY_FUSE_8`     | **~1.8 GB**           | **no**           | closes LMDB like `TRUNCATED_LONG_64` once the filter is built; 0.4% of queries are false positives, surfaced as rare unverified hits |
+> | `BINARY_FUSE_16`    | ~3.6 GB               | **no**           | same as Fuse-8 but with 0.0015% FPR — use when Fuse-8's spurious-hit rate matters |
 > | `BLOOM` (FPP 0.01)  | ~1.6 GB               | yes              | keeps LMDB open as the verifier; skips it for the overwhelming majority of misses |
 > | `LMDB_ONLY`         | minimal (mmap only)   | yes              | fallback when there is essentially no spare RAM and disk-backed mmap is acceptable |
 >

--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ Supported values:
 | `BLOOM`             | ~80 MB – ~1.5 GB (FPP)  | fast for misses      | yes              | when LMDB must stay open and most queries miss the database                             |
 | `HASHSET`           | ~80 B / entry           | fast                 | **no**           | small databases where memory is plentiful and exact lookup is required by callers       |
 | `TRUNCATED_LONG_64` | **~8 B / entry**        | **near HASHSET**     | **no**           | **recommended default for any in-RAM choice** — best memory/latency trade-off           |
-| `BINARY_FUSE_8`     | **~1.3 B / entry**      | **fast**             | **no**           | ultra-low RAM; closes LMDB after load — 0.4% false positives surface as rare unverified hits |
-| `BINARY_FUSE_16`    | **~2.6 B / entry**      | **fast**             | **no**           | closes LMDB after load — 0.0015% false-positive rate; use when Fuse-8's 0.4% spurious-hit rate is too high |
+| `BINARY_FUSE_8`     | **~1.3 B / entry**      | **fast**             | yes              | ultra-low RAM filter in front of LMDB; 0.4% of filter hits are verified against LMDB (also feeds the GPU pre-filter) |
+| `BINARY_FUSE_16`    | **~2.6 B / entry**      | **fast**             | yes              | like Fuse-8 but 0.0015% FPR — fewer LMDB verifications; use when Fuse-8's verification cost is measurable |
 
 #### Memory footprint per backend across the published database tiers
 
@@ -347,7 +347,7 @@ Supported values:
 
 #### Why `TRUNCATED_LONG_64` is so close to `HASHSET` despite being a binary search
 
-hash160 is the output of SHA-256 followed by RIPEMD-160 and is cryptographically uniform; any subset of its bits is also uniform. `TRUNCATED_LONG_64` keeps only the 8 bytes after the bucket byte (72 bits of total resolution: 8-bit bucket + 64-bit stored value). The probability that a random query collides with one of N stored entries is N/2⁶⁴, which for the largest published database tier is ~7.5 × 10⁻¹¹ per query — rare enough that surfacing such a collision as an unverified hit is harmless (LMDB is closed after population, like the Binary Fuse backends). In return:
+hash160 is the output of SHA-256 followed by RIPEMD-160 and is cryptographically uniform; any subset of its bits is also uniform. `TRUNCATED_LONG_64` keeps only the 8 bytes after the bucket byte (72 bits of total resolution: 8-bit bucket + 64-bit stored value). The probability that a random query collides with one of N stored entries is N/2⁶⁴, which for the largest published database tier is ~7.5 × 10⁻¹¹ per query — rare enough that surfacing such a collision as an unverified hit is harmless (LMDB is closed after population, like `HASHSET`). Unlike the Binary Fuse backends, whose 0.4%/0.0015% FPR is far too high to leave unverified, `TRUNCATED_LONG_64` needs no LMDB verifier. In return:
 
 - **Cache-line dense**: 8 longs per 64-byte cache line, the binary search walks very little memory.
 - **JDK intrinsic**: `Arrays.binarySearch(long[], long)` is heavily JIT-optimised and produces branchless comparisons on modern CPUs.
@@ -364,11 +364,11 @@ h2 = reduce(hash64(key, rotl(seed,42)),  segSize) + 2·segSize
 hit ⟺  fingerprints[h0] ⊕ fingerprints[h1] ⊕ fingerprints[h2] == fingerprint(key)
 ```
 
-**No false negatives** — every key inserted via `populateFrom` is always found.  
-**False-positive rate** — 1/256 ≈ 0.4% for Fuse-8 (8-bit fingerprint), 1/65536 ≈ 0.0015% for Fuse-16 (16-bit fingerprint). Because the filter is self-contained (see below), LMDB is closed after population, so a false positive is **not** re-verified against it — it surfaces as a reported hit. Genuine hits are astronomically rare under random scanning, so an occasional spurious hit is a negligible cost (it is logged for manual inspection).  
-**Self-contained** — `requiresBackend()` returns `false`; the LMDB env is closed and its mmap pages are released after population, identical to `HASHSET` and `TRUNCATED_LONG_64`.
+**No false negatives** — every key inserted via `populateFrom` is always found, so a filter **miss** is definitive.  
+**False-positive rate** — 1/256 ≈ 0.4% for Fuse-8 (8-bit fingerprint), 1/65536 ≈ 0.0015% for Fuse-16 (16-bit fingerprint). That FPR is far too high to report a filter hit as a final hit (at 0.4% roughly one in every 250 scanned addresses would be a spurious hit), so the filter is used **exactly like `BLOOM`**: a miss short-circuits without touching LMDB, a hit falls through to LMDB to confirm the address or reject it as a false positive.  
+**Decorator, not a replacement** — `BinaryFuseAccelerator` wraps the filter plus the LMDB delegate; `requiresBackend()` returns `true`, so the LMDB env **stays open** as the exact verifier (unlike the self-contained `HASHSET` / `TRUNCATED_LONG_64` snapshots, which drop LMDB).
 
-Choose between the two variants based on how costly a spurious (unverified) hit is in your workflow. For most use cases with a light or full database, `BINARY_FUSE_8` gives the best RAM-to-latency trade-off: lower memory than `BLOOM` (no LMDB open) with a higher FPR, while `BINARY_FUSE_16` drops the FPR ~256× at the cost of 2× the fingerprint array size.
+Choose between the two variants based on how expensive the LMDB verification of filter hits is in your workload. For most use cases with a light or full database, `BINARY_FUSE_8` gives the best RAM-to-latency trade-off: a tiny in-RAM filter that skips LMDB for the ~99.6% of queries that miss, while `BINARY_FUSE_16` drops the FPR ~256× (fewer LMDB verifications) at the cost of 2× the fingerprint array size.
 
 #### Benchmark numbers
 
@@ -426,7 +426,7 @@ Enable it on an OpenCL producer (see [`examples/config_Find_GPUFilterCompact.jso
 
 **How compact mode works** — the kernel checks both the compressed and uncompressed hash160 of each candidate against the uploaded filter; a work-item that hits claims an output slot via an `atomic_add` on a shared count word and writes its entry there, so the buffer holds exactly the hits (each entry carries its own work-item index for secret-key reconstruction). A non-hit writes nothing.
 
-**No false negatives** — the Binary Fuse 8 guarantee carries to the GPU unchanged: any address actually in the database is always flagged. The ~0.4 % false positives surface as reported hits exactly as they do for the in-RAM `BINARY_FUSE_8` backend (LMDB is closed once the filter is built, so they are not re-verified).
+**No false negatives** — the Binary Fuse 8 guarantee carries to the GPU unchanged: any address actually in the database is always flagged. The GPU pre-filter only shrinks the GPU→CPU transfer; the ~0.4 % false positives among the survivors are verified against LMDB on the CPU exactly as for the in-RAM `BINARY_FUSE_8` backend (LMDB stays open as the verifier), so no false positive is ever reported as a hit.
 
 **Device requirements** — compact mode needs an **OpenCL 2.0+** device (the `atomic_add` on global memory) and a little-endian device (the kernel canonicalises its output as little-endian). Both are checked at producer init and fail fast with a clear message; on an older device set `transferAll: true` to keep the full-transfer path. The GPU/CPU lookup parity (key extraction + hash formula) is pinned by `Fuse8GpuHashParityTest` and exercised end-to-end on a real OpenCL device by `OpenCLCompactOutputIntegrationTest`.
 
@@ -712,7 +712,7 @@ If you're missing any information or have questions about usage or content, feel
 > ```json
 > "addressLookupBackend" : "TRUNCATED_LONG_64"
 > ```
-> See [Pluggable Address Lookup Backends](#-pluggable-address-lookup-backends-addresslookupbackend) above for the full trade-off matrix and benchmark numbers. `TRUNCATED_LONG_64` loads every hash160 into RAM once at startup as 256 sorted `long[]` buckets (~1.1 GB for the Light DB), then closes the LMDB env and releases its mmap pages — near-`HASHSET` lookup latency at ~10× lower memory cost. If you have memory to spare and prefer exact-bit storage with no probabilistic fallthrough, `HASHSET` (~10 GB for the Light DB) is the next step up. If RAM is tight, `BINARY_FUSE_8` (~172 MB for the Light DB) is the lowest-footprint self-contained option: it closes LMDB like `TRUNCATED_LONG_64` and redirects the ~0.4% false-positive rate back to LMDB as a verifier. `BLOOM` (~150 MB) covers a similar niche but keeps LMDB open.
+> See [Pluggable Address Lookup Backends](#-pluggable-address-lookup-backends-addresslookupbackend) above for the full trade-off matrix and benchmark numbers. `TRUNCATED_LONG_64` loads every hash160 into RAM once at startup as 256 sorted `long[]` buckets (~1.1 GB for the Light DB), then closes the LMDB env and releases its mmap pages — near-`HASHSET` lookup latency at ~10× lower memory cost. If you have memory to spare and prefer exact-bit storage with no probabilistic fallthrough, `HASHSET` (~10 GB for the Light DB) is the next step up. If RAM is tight, `BINARY_FUSE_8` (~172 MB for the Light DB) is the lowest-footprint filter: like `BLOOM` it keeps LMDB open and verifies the ~0.4% of filter hits against it (rejecting false positives), but at a fraction of `BLOOM`'s memory. `BLOOM` (~150 MB) covers a similar niche.
 
 <details>
 <summary>Checksums lmdb_light.zip</summary>
@@ -770,8 +770,8 @@ LMDBToAddressFile_Light_HexHash.zip	SHA3-512	29CA44CD666D7B8CF9EAD4B340620FBB7ED
 > | Choice              | RAM needed at Full DB | LMDB stays open? | When to pick |
 > |---------------------|-----------------------|------------------|--------------|
 > | `TRUNCATED_LONG_64` | ~11 GB                | **no**           | recommended if you can spare ~12 GB; closes LMDB and releases its mmap pages |
-> | `BINARY_FUSE_8`     | **~1.8 GB**           | **no**           | closes LMDB like `TRUNCATED_LONG_64` once the filter is built; 0.4% of queries are false positives, surfaced as rare unverified hits |
-> | `BINARY_FUSE_16`    | ~3.6 GB               | **no**           | same as Fuse-8 but with 0.0015% FPR — use when Fuse-8's spurious-hit rate matters |
+> | `BINARY_FUSE_8`     | **~1.8 GB**           | yes              | tiny filter in front of LMDB; keeps LMDB open to verify the 0.4% of filter hits; also feeds the GPU pre-filter |
+> | `BINARY_FUSE_16`    | ~3.6 GB               | yes              | same as Fuse-8 but with 0.0015% FPR — fewer LMDB verifications |
 > | `BLOOM` (FPP 0.01)  | ~1.6 GB               | yes              | keeps LMDB open as the verifier; skips it for the overwhelming majority of misses |
 > | `LMDB_ONLY`         | minimal (mmap only)   | yes              | fallback when there is essentially no spare RAM and disk-backed mmap is acceptable |
 >

--- a/README.md
+++ b/README.md
@@ -428,6 +428,16 @@ Enable it on an OpenCL producer (see [`examples/config_Find_GPUFilterCompact.jso
 | `enableGpuFilter` | `false` | When `true`, a Binary Fuse 8 filter is built from LMDB during consumer init and uploaded to GPU VRAM (once per session); the kernel filters inline (compact output). Independent of the CPU `addressLookupBackend` — built while LMDB is open, so it works with every backend including the `LMDB_ONLY` default. |
 | `transferAll` | `false` | Forces full-transfer (legacy) output even when `enableGpuFilter` is on. `Finder` sets this to `true` automatically — with a warning — whenever `enableVanity = true`, because vanity scanning must see every derived address. |
 
+The two flags are **independent**, not opposites — a common point of confusion. `enableGpuFilter` decides *whether the filter runs on the GPU*; `transferAll` decides *which output layout the kernel uses* (send back **all** derived results, or only the filtered hits). `transferAll` is really a "force full-transfer" override, so `enableGpuFilter: true, transferAll: false` is the normal compact-filtering case — filter on, send back only the hits. How they combine:
+
+| `enableGpuFilter` | `transferAll` | Behaviour |
+|:---:|:---:|---|
+| `true`  | **`false`** | **Compact mode** — filter on the GPU, only the matching candidates are transferred back (the recommended, fastest setup). |
+| `true`  | `true`  | Filter is uploaded but **overridden** to full transfer — every derived result is sent back (e.g. vanity scanning, or a device without OpenCL 2.0+ compact support). |
+| `false` | *(any)* | No GPU filter — full transfer (legacy); the consumer checks every result against `addressLookupBackend` on the CPU. |
+
+Compact mode runs only when a filter was uploaded **and** `transferAll` is false (`OpenCLContext` computes `transferAll = producerOpenCL.transferAll || !gpuFilterUploaded`).
+
 **How compact mode works** — the kernel checks both the compressed and uncompressed hash160 of each candidate against the uploaded filter; a work-item that hits claims an output slot via an `atomic_add` on a shared count word and writes its entry there, so the buffer holds exactly the hits (each entry carries its own work-item index for secret-key reconstruction). A non-hit writes nothing.
 
 **No false negatives** — the Binary Fuse 8 guarantee carries to the GPU unchanged: any address actually in the database is always flagged. The GPU pre-filter only shrinks the GPU→CPU transfer; the ~0.4 % false positives among the survivors are verified against LMDB on the CPU exactly as for the in-RAM `BINARY_FUSE_8` backend (LMDB stays open as the verifier), so no false positive is ever reported as a hit.

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ mvn test-compile exec:java -Dexec.args="BinaryFuseBenchmark"
 
 By default the OpenCL kernel transfers **every** derived work-item result back to the host, and the consumer then checks each hash160 against the selected `addressLookupBackend`. With `enableGpuFilter`, a Binary Fuse 8 filter is instead pushed **onto the GPU** so the kernel checks each derived hash160 inline and transmits only the candidates the filter marks as possibly present. This collapses the PCIe read-back from the full `2^batchSizeInBits` grid down to the handful of hits per batch — the dominant cost on large batches.
 
-The GPU pre-filter is **independent of the CPU `addressLookupBackend`.** It is built once from LMDB purely as a transient VRAM-upload artifact (the host copy is freed after the one-time upload), so it works with the `LMDB_ONLY` default — you do **not** have to set the CPU backend to `BINARY_FUSE_8`. The survivors that come back from the GPU are verified directly against LMDB on the CPU, so they are never "double filtered". (If the CPU backend already *is* `BINARY_FUSE_8`, that filter is reused for the upload to avoid a second LMDB scan.)
+The GPU pre-filter is **independent of the CPU `addressLookupBackend`.** It is built once during consumer init — while LMDB is still open, *before* a self-contained backend (`HASHSET`/`TRUNCATED_LONG_64`) would close it — purely as a transient VRAM-upload artifact (the host copy is freed after the one-time upload). So it works with **every** backend, including the `LMDB_ONLY` default; you do **not** have to set the CPU backend to `BINARY_FUSE_8`. The survivors that come back from the GPU are verified directly against the CPU lookup, so they are never "double filtered". (If the CPU backend already *is* `BINARY_FUSE_8`, that filter is reused for the upload to avoid a second LMDB scan.)
 
 Enable it on an OpenCL producer (see [`examples/config_Find_GPUFilterCompact.json`](examples/config_Find_GPUFilterCompact.json)):
 
@@ -425,7 +425,7 @@ Enable it on an OpenCL producer (see [`examples/config_Find_GPUFilterCompact.jso
 
 | Field | Default | Effect |
 |-------|:-------:|--------|
-| `enableGpuFilter` | `false` | When `true`, a Binary Fuse 8 filter is built from LMDB and uploaded to GPU VRAM (once per session); the kernel filters inline (compact output). Independent of the CPU `addressLookupBackend` — requires only that LMDB is open (it is under the `LMDB_ONLY` default). |
+| `enableGpuFilter` | `false` | When `true`, a Binary Fuse 8 filter is built from LMDB during consumer init and uploaded to GPU VRAM (once per session); the kernel filters inline (compact output). Independent of the CPU `addressLookupBackend` — built while LMDB is open, so it works with every backend including the `LMDB_ONLY` default. |
 | `transferAll` | `false` | Forces full-transfer (legacy) output even when `enableGpuFilter` is on. `Finder` sets this to `true` automatically — with a warning — whenever `enableVanity = true`, because vanity scanning must see every derived address. |
 
 **How compact mode works** — the kernel checks both the compressed and uncompressed hash160 of each candidate against the uploaded filter; a work-item that hits claims an output slot via an `atomic_add` on a shared count word and writes its entry there, so the buffer holds exactly the hits (each entry carries its own work-item index for secret-key reconstruction). A non-hit writes nothing.

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Choose between the two variants based on how expensive the LMDB verification of 
 | `BINARY_FUSE_8`     |   ~25   |
 | `BINARY_FUSE_16`    |   ~25   |
 
-`TRUNCATED_LONG_64` reaches near-`HASHSET` latency at ~10× lower memory cost and is the recommended default for most cases. `BINARY_FUSE_8` and `BINARY_FUSE_16` offer even lower memory with O(1) lookup (3 direct array reads + 3 hashes); cache-cold latency grows with filter size, but for small-to-medium databases the three-read pattern typically stays in L2 or L3 cache.
+The default backend is `LMDB_ONLY` (no in-RAM structure, exact, can never produce a false hit). When you *do* want to trade RAM for speed, `TRUNCATED_LONG_64` reaches near-`HASHSET` latency at ~10× lower memory cost and is the best in-RAM choice for most cases. `BINARY_FUSE_8` and `BINARY_FUSE_16` offer even lower memory with O(1) lookup (3 direct array reads + 3 hashes) but keep LMDB open to verify hits; cache-cold latency grows with filter size, but for small-to-medium databases the three-read pattern typically stays in L2 or L3 cache.
 
 Run the backend comparison benchmark yourself with:
 

--- a/examples/config_Find_1OpenCLDevice.json
+++ b/examples/config_Find_1OpenCLDevice.json
@@ -62,7 +62,7 @@
         "useProxyOptimal": true,
         "logStatsOnInit": true,
         "logStatsOnClose": false,
-        "addressLookupBackend" : "BINARY_FUSE_8",
+        "addressLookupBackend" : "LMDB_ONLY",
         "disableAddressLookup" : false
       },
       "printStatisticsEveryNSeconds": 10,

--- a/examples/config_Find_1OpenCLDeviceAnd2CPUProducer.json
+++ b/examples/config_Find_1OpenCLDeviceAnd2CPUProducer.json
@@ -27,7 +27,7 @@
         "useProxyOptimal": true,
         "logStatsOnInit": true,
         "logStatsOnClose": false,
-        "addressLookupBackend" : "BINARY_FUSE_8",
+        "addressLookupBackend" : "LMDB_ONLY",
         "disableAddressLookup" : false
       },
       "printStatisticsEveryNSeconds": 10,

--- a/examples/config_Find_GPUFilterCompact.json
+++ b/examples/config_Find_GPUFilterCompact.json
@@ -15,7 +15,7 @@
         "useProxyOptimal": true,
         "logStatsOnInit": true,
         "logStatsOnClose": false,
-        "addressLookupBackend": "BINARY_FUSE_8",
+        "addressLookupBackend": "LMDB_ONLY",
         "disableAddressLookup": false
       },
       "printStatisticsEveryNSeconds": 10,

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/AddressLookupBackend.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/AddressLookupBackend.java
@@ -29,14 +29,16 @@ package net.ladenthin.bitcoinaddressfinder.configuration;
  *       {@code long} binary search uses the JDK intrinsic and is typically the fastest
  *       lookup of any backend (~10&#x00d7; more compact than HASHSET at near-HASHSET
  *       latency).</li>
- *   <li>{@link #BINARY_FUSE_8} - Binary Fuse Filter snapshot with 8-bit fingerprints.
- *       ~1.14 B/entry, FPR &#x2248; 0.4&nbsp;%. No false negatives. LMDB env closed and
- *       GC'd after population. Recommended for most workloads — fits Full DB (~1.6 GB)
- *       on any modern workstation.</li>
- *   <li>{@link #BINARY_FUSE_16} - Binary Fuse Filter snapshot with 16-bit fingerprints.
- *       ~2.28 B/entry, FPR &#x2248; 0.0015&nbsp;%. No false negatives. LMDB env closed
- *       and GC'd after population. Use when the 0.4&nbsp;% false-positive rate of
- *       {@link #BINARY_FUSE_8} causes measurable LMDB overhead.</li>
+ *   <li>{@link #BINARY_FUSE_8} - Binary Fuse Filter (8-bit fingerprints) in front of LMDB.
+ *       ~1.14 B/entry, FPR &#x2248; 0.4&nbsp;%. No false negatives. Like {@link #BLOOM} it is a
+ *       decorator: a filter miss is definitive, a filter hit falls through to LMDB to reject
+ *       false positives, so the LMDB env must stay open. Recommended for most workloads — the
+ *       filter fits Full DB in ~1.8 GB on any modern workstation and also feeds the optional
+ *       GPU pre-filter.</li>
+ *   <li>{@link #BINARY_FUSE_16} - Binary Fuse Filter (16-bit fingerprints) in front of LMDB.
+ *       ~2.28 B/entry, FPR &#x2248; 0.0015&nbsp;%. No false negatives. Same decorator behaviour
+ *       as {@link #BINARY_FUSE_8}; LMDB stays open. Use when the 0.4&nbsp;% false-positive rate
+ *       of {@link #BINARY_FUSE_8} sends too many hits to LMDB for verification.</li>
  * </ul>
  */
 public enum AddressLookupBackend {
@@ -54,16 +56,17 @@ public enum AddressLookupBackend {
     TRUNCATED_LONG_64,
 
     /**
-     * Binary Fuse Filter snapshot with 8-bit fingerprints. ~1.14 B/entry, FPR &#x2248; 0.4 %.
-     * No false negatives. LMDB env closed and GC'd after population.
-     * Recommended for most workloads — fits Full DB (~1.6 GB) on any modern workstation.
+     * Binary Fuse Filter (8-bit fingerprints) in front of LMDB. ~1.14 B/entry, FPR &#x2248; 0.4 %.
+     * No false negatives. Decorator like BLOOM: filter hits are verified against LMDB to reject
+     * false positives, so LMDB must stay open. Recommended for most workloads and feeds the GPU
+     * pre-filter.
      */
     BINARY_FUSE_8,
 
     /**
-     * Binary Fuse Filter snapshot with 16-bit fingerprints. ~2.28 B/entry, FPR &#x2248; 0.0015 %.
-     * No false negatives. LMDB env closed and GC'd after population.
-     * Use when the 0.4 % false-positive rate of BINARY_FUSE_8 causes measurable LMDB overhead.
+     * Binary Fuse Filter (16-bit fingerprints) in front of LMDB. ~2.28 B/entry, FPR &#x2248; 0.0015 %.
+     * No false negatives. Decorator like BINARY_FUSE_8; LMDB stays open. Use when the 0.4 %
+     * false-positive rate of BINARY_FUSE_8 sends too many hits to LMDB for verification.
      */
     BINARY_FUSE_16
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CLMDBConfigurationReadOnly.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CLMDBConfigurationReadOnly.java
@@ -42,10 +42,14 @@ public class CLMDBConfigurationReadOnly {
     /**
      * Selects the address-lookup chain placed in front of LMDB. See
      * {@link AddressLookupBackend} for the full trade-off matrix. Defaults to
-     * {@link AddressLookupBackend#BLOOM} which matches the historical behaviour of
-     * {@code useBloomFilter = true}.
+     * {@link AddressLookupBackend#LMDB_ONLY}: no in-RAM filter, LMDB stays open and answers
+     * every lookup exactly. This is the safest default — an exact backend can never report a
+     * false positive as a hit — and the in-RAM filters ({@code BLOOM}, {@code BINARY_FUSE_8},
+     * the exact snapshots) are opt-in latency optimisations. The GPU pre-filter
+     * ({@code producerOpenCL.enableGpuFilter}) is independent of this setting and works with the
+     * {@code LMDB_ONLY} default.
      */
-    public AddressLookupBackend addressLookupBackend = AddressLookupBackend.BLOOM;
+    public AddressLookupBackend addressLookupBackend = AddressLookupBackend.LMDB_ONLY;
 
     /**
      * The expected false positive probability (FPP) for the Bloom filter. Consulted only

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
@@ -26,6 +26,7 @@ import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
 import net.ladenthin.bitcoinaddressfinder.core.FireAndForget;
 import net.ladenthin.bitcoinaddressfinder.core.InterruptedRuntimeException;
 import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
+import net.ladenthin.bitcoinaddressfinder.persistence.AddressIterable;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.Persistence;
 import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
@@ -297,21 +298,35 @@ public class ConsumerJava implements Consumer {
     }
 
     /**
-     * Returns the GPU-upload payload for the active Binary Fuse 8 filter, if the configured
-     * address-lookup backend built one.
+     * Builds the GPU-upload payload of a Binary Fuse 8 filter for the OpenCL pre-filter,
+     * independently of the CPU lookup backend.
      *
-     * <p>Exposed so the engine ({@code Finder}) can read the filter the consumer built and route
-     * it to the OpenCL producers for VRAM upload (the consumer never touches the OpenCL layer
-     * directly). Returns {@link Optional#empty()} for every backend other than
-     * {@code BINARY_FUSE_8} and before {@link #initLMDB()} has run.
+     * <p>The GPU pre-filter and the CPU lookup are deliberately decoupled: the CPU lookup may be
+     * {@code LMDB_ONLY} (exact, no CPU-side filter) while the GPU still runs a Fuse-8 filter to
+     * shrink the GPU&#x2192;CPU transfer. The filter is therefore built here as a transient
+     * artifact purely for VRAM upload — it is <em>not</em> retained as the lookup, so survivors
+     * of the GPU pre-filter are never "double filtered" on the CPU; they are verified directly
+     * against LMDB.
      *
-     * @return the Binary Fuse 8 GPU-upload payload, or empty if the active lookup is not a
-     *     {@link BinaryFuseAccelerator} wrapping a {@link BinaryFuse8AddressPresence}
+     * <p>If the CPU lookup already built a Fuse-8 filter (backend {@code BINARY_FUSE_8}), that
+     * filter is reused to avoid a second full LMDB scan. Otherwise a fresh filter is built from
+     * the open LMDB env. Returns {@link Optional#empty()} when LMDB is not available (a
+     * self-contained backend such as {@code HASHSET}/{@code TRUNCATED_LONG_64} released it) or
+     * before {@link #initLMDB()} has run.
+     *
+     * @return the Binary Fuse 8 GPU-upload payload, or empty if it cannot be built
      */
-    public Optional<BinaryFuse8GpuFilterData> getGpuFilterData() {
+    public Optional<BinaryFuse8GpuFilterData> buildGpuFilterData() {
         AddressPresence localLookup = lookup;
         if (localLookup instanceof BinaryFuseAccelerator accelerator) {
-            return accelerator.getGpuFilterData();
+            Optional<BinaryFuse8GpuFilterData> existing = accelerator.getGpuFilterData();
+            if (existing.isPresent()) {
+                return existing;
+            }
+        }
+        Persistence localPersistence = persistence;
+        if (localPersistence instanceof AddressIterable iterable) {
+            return Optional.of(BinaryFuse8AddressPresence.populateFrom(iterable).toGpuFilterData());
         }
         return Optional.empty();
     }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
@@ -33,6 +33,7 @@ import net.ladenthin.bitcoinaddressfinder.persistence.bloom.BloomFilterAccelerat
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse16AddressPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse8AddressPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse8GpuFilterData;
+import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuseAccelerator;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.HashSetAddressPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.TruncatedLong64SortedArrayPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.lmdb.LMDBPersistence;
@@ -305,12 +306,12 @@ public class ConsumerJava implements Consumer {
      * {@code BINARY_FUSE_8} and before {@link #initLMDB()} has run.
      *
      * @return the Binary Fuse 8 GPU-upload payload, or empty if the active lookup is not a
-     *     {@link BinaryFuse8AddressPresence}
+     *     {@link BinaryFuseAccelerator} wrapping a {@link BinaryFuse8AddressPresence}
      */
     public Optional<BinaryFuse8GpuFilterData> getGpuFilterData() {
         AddressPresence localLookup = lookup;
-        if (localLookup instanceof BinaryFuse8AddressPresence fuse8) {
-            return Optional.of(fuse8.toGpuFilterData());
+        if (localLookup instanceof BinaryFuseAccelerator accelerator) {
+            return accelerator.getGpuFilterData();
         }
         return Optional.empty();
     }
@@ -322,8 +323,8 @@ public class ConsumerJava implements Consumer {
             case BLOOM -> BloomFilterAccelerator.populateFrom(lmdb, lmdb, bloomFpp);
             case HASHSET -> HashSetAddressPresence.populateFrom(lmdb);
             case TRUNCATED_LONG_64 -> TruncatedLong64SortedArrayPresence.populateFrom(lmdb);
-            case BINARY_FUSE_8 -> BinaryFuse8AddressPresence.populateFrom(lmdb);
-            case BINARY_FUSE_16 -> BinaryFuse16AddressPresence.populateFrom(lmdb);
+            case BINARY_FUSE_8 -> new BinaryFuseAccelerator(BinaryFuse8AddressPresence.populateFrom(lmdb), lmdb);
+            case BINARY_FUSE_16 -> new BinaryFuseAccelerator(BinaryFuse16AddressPresence.populateFrom(lmdb), lmdb);
         };
     }
 

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
@@ -26,7 +26,6 @@ import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
 import net.ladenthin.bitcoinaddressfinder.core.FireAndForget;
 import net.ladenthin.bitcoinaddressfinder.core.InterruptedRuntimeException;
 import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
-import net.ladenthin.bitcoinaddressfinder.persistence.AddressIterable;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.Persistence;
 import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
@@ -145,6 +144,25 @@ public class ConsumerJava implements Consumer {
      * in-memory snapshot ({@code HASHSET}, {@code TRUNCATED_LONG_64}).
      */
     protected @Nullable AddressPresence lookup;
+
+    /**
+     * Whether {@link #initLMDB()} should build the Binary Fuse 8 GPU pre-filter payload.
+     * Set by the engine ({@code Finder}) <em>before</em> {@link #initLMDB()} when any OpenCL
+     * producer runs in compact mode. It must be decided up-front because the payload has to be
+     * built while LMDB is still open — for a self-contained backend ({@code HASHSET},
+     * {@code TRUNCATED_LONG_64}) {@link #initLMDB()} closes the env once the snapshot is built,
+     * so a later build would have no source to read from.
+     */
+    private boolean gpuFilterRequested = false;
+
+    /**
+     * The Binary Fuse 8 GPU-upload payload built by {@link #initLMDB()} when
+     * {@link #gpuFilterRequested} is set. Held until the engine uploads it to the OpenCL
+     * producers and then released via {@link #discardGpuFilterData()} so the (potentially
+     * multi-GB) fingerprint array does not linger on the host for the whole session.
+     */
+    @ToString.Exclude
+    private @Nullable BinaryFuse8GpuFilterData gpuFilterData;
 
     private final PersistenceUtils persistenceUtils;
 
@@ -288,6 +306,13 @@ public class ConsumerJava implements Consumer {
         AddressPresence chain = buildLookupChain(lmdb, cfg.addressLookupBackend, cfg.bloomFilterFpp);
         lookup = chain;
 
+        // Build the GPU pre-filter payload now, while LMDB is guaranteed open. This must happen
+        // before the self-contained close below, otherwise a HASHSET/TRUNCATED_LONG_64 backend
+        // would have already released the only source the filter can be built from.
+        if (gpuFilterRequested) {
+            gpuFilterData = computeGpuFilterPayload(chain, lmdb);
+        }
+
         if (!chain.requiresBackend()) {
             LOGGER.info(
                     "Address lookup backend {} is self-contained; closing LMDB env to release on-disk resources.",
@@ -298,37 +323,63 @@ public class ConsumerJava implements Consumer {
     }
 
     /**
-     * Builds the GPU-upload payload of a Binary Fuse 8 filter for the OpenCL pre-filter,
-     * independently of the CPU lookup backend.
+     * Requests (or clears the request for) the Binary Fuse 8 GPU pre-filter to be built during
+     * {@link #initLMDB()}. Must be called <em>before</em> {@link #initLMDB()}.
+     *
+     * <p>The engine sets this when any OpenCL producer runs in compact mode. The decision has to
+     * be made up-front because the payload is built while LMDB is still open; for a self-contained
+     * backend {@link #initLMDB()} closes the env afterwards, so a later build would find no source.
+     *
+     * @param requested {@code true} to build the GPU filter payload in {@link #initLMDB()}
+     */
+    public void setGpuFilterRequested(boolean requested) {
+        this.gpuFilterRequested = requested;
+    }
+
+    /**
+     * Returns the Binary Fuse 8 GPU-upload payload built by {@link #initLMDB()}, if it was
+     * requested via {@link #setGpuFilterRequested(boolean)} before init.
      *
      * <p>The GPU pre-filter and the CPU lookup are deliberately decoupled: the CPU lookup may be
      * {@code LMDB_ONLY} (exact, no CPU-side filter) while the GPU still runs a Fuse-8 filter to
-     * shrink the GPU&#x2192;CPU transfer. The filter is therefore built here as a transient
-     * artifact purely for VRAM upload — it is <em>not</em> retained as the lookup, so survivors
-     * of the GPU pre-filter are never "double filtered" on the CPU; they are verified directly
-     * against LMDB.
+     * shrink the GPU&#x2192;CPU transfer. The filter is a transient artifact for VRAM upload — it
+     * is <em>not</em> the lookup, so survivors of the GPU pre-filter are verified directly against
+     * LMDB and never "double filtered".
      *
-     * <p>If the CPU lookup already built a Fuse-8 filter (backend {@code BINARY_FUSE_8}), that
-     * filter is reused to avoid a second full LMDB scan. Otherwise a fresh filter is built from
-     * the open LMDB env. Returns {@link Optional#empty()} when LMDB is not available (a
-     * self-contained backend such as {@code HASHSET}/{@code TRUNCATED_LONG_64} released it) or
-     * before {@link #initLMDB()} has run.
-     *
-     * @return the Binary Fuse 8 GPU-upload payload, or empty if it cannot be built
+     * @return the Binary Fuse 8 GPU-upload payload, or {@link Optional#empty()} if it was not
+     *     requested, has already been discarded, or {@link #initLMDB()} has not run
      */
-    public Optional<BinaryFuse8GpuFilterData> buildGpuFilterData() {
-        AddressPresence localLookup = lookup;
-        if (localLookup instanceof BinaryFuseAccelerator accelerator) {
+    public Optional<BinaryFuse8GpuFilterData> getGpuFilterData() {
+        return Optional.ofNullable(gpuFilterData);
+    }
+
+    /**
+     * Releases the host-side reference to the GPU filter payload after the engine has uploaded it
+     * to the OpenCL producers. The producers free their own copy once it is in VRAM, so dropping
+     * this reference lets the (potentially multi-GB) fingerprint array be garbage-collected
+     * instead of lingering for the whole session.
+     */
+    public void discardGpuFilterData() {
+        gpuFilterData = null;
+    }
+
+    /**
+     * Builds the Binary Fuse 8 GPU-upload payload from the still-open LMDB env. Reuses the CPU
+     * lookup's filter if the backend is {@code BINARY_FUSE_8} (avoiding a second full LMDB scan);
+     * otherwise builds a fresh transient filter from the LMDB address stream.
+     *
+     * @param chain the lookup chain just built by {@link #initLMDB()}
+     * @param lmdb  the open LMDB persistence (also an {@link AddressIterable} source)
+     * @return the GPU-upload payload (never {@code null})
+     */
+    private static BinaryFuse8GpuFilterData computeGpuFilterPayload(AddressPresence chain, LMDBPersistence lmdb) {
+        if (chain instanceof BinaryFuseAccelerator accelerator) {
             Optional<BinaryFuse8GpuFilterData> existing = accelerator.getGpuFilterData();
             if (existing.isPresent()) {
-                return existing;
+                return existing.get();
             }
         }
-        Persistence localPersistence = persistence;
-        if (localPersistence instanceof AddressIterable iterable) {
-            return Optional.of(BinaryFuse8AddressPresence.populateFrom(iterable).toGpuFilterData());
-        }
-        return Optional.empty();
+        return BinaryFuse8AddressPresence.populateFrom(lmdb).toGpuFilterData();
     }
 
     private static AddressPresence buildLookupChain(

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/Finder.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/Finder.java
@@ -267,14 +267,21 @@ public class Finder implements Interruptable {
     }
 
     /**
-     * Stages the consumer's Binary Fuse 8 filter on each compact-mode OpenCL producer.
+     * Builds the Binary Fuse 8 GPU pre-filter <em>once</em> and uploads it to every compact-mode
+     * OpenCL producer.
      *
-     * <p>Routed through the producer (not the consumer) to respect the layered architecture: the
-     * engine reads the filter payload from the consumer ({@code engine -> consumer/persistence}),
-     * decomposes it into primitives, and hands them to the producer
-     * ({@code engine -> producer -> opencl}). Producers with {@code enableGpuFilter = false}, or
-     * forced to full transfer (e.g. by vanity), are skipped, as is the case where the configured
-     * lookup backend did not build a Binary Fuse 8 filter.
+     * <p>The GPU pre-filter is decoupled from the CPU lookup backend: it is built purely as a
+     * transient VRAM-upload artifact (independent of whether the CPU lookup is {@code LMDB_ONLY},
+     * {@code BINARY_FUSE_8}, etc.) so the survivors that come back to the CPU are verified
+     * directly against LMDB and never "double filtered". Routed through the producer (not the
+     * consumer) to respect the layered architecture: the engine reads the filter payload from the
+     * consumer, decomposes it into primitives, and hands them to the producer
+     * ({@code engine -> producer -> opencl}). The host-side fingerprint array is released after
+     * each producer copies it into device memory (see {@code ProducerOpenCL#initProducer}); the
+     * upload happens only once per session.
+     *
+     * <p>Producers with {@code enableGpuFilter = false}, or forced to full transfer (e.g. by
+     * vanity), are skipped. If no producer requests the filter, nothing is built.
      */
     private void uploadGpuFilterToProducers() {
         ConsumerJava localConsumer = consumerJava;
@@ -282,31 +289,36 @@ public class Finder implements Interruptable {
             return;
         }
         List<CProducerOpenCL> configs = finder.producerOpenCL;
+        boolean anyCompactMode = configs.stream().anyMatch(c -> c.enableGpuFilter && !c.transferAll);
+        if (!anyCompactMode) {
+            return;
+        }
+
+        // Build the Fuse-8 filter exactly once, regardless of how many producers consume it.
+        Optional<BinaryFuse8GpuFilterData> payload = localConsumer.buildGpuFilterData();
+        if (payload.isEmpty()) {
+            LOGGER.warn("producerOpenCL.enableGpuFilter is true but the GPU filter could not be built "
+                    + "(LMDB is not open — the configured addressLookupBackend released it); running full transfer.");
+            return;
+        }
+        BinaryFuse8GpuFilterData data = payload.get();
         for (int i = 0; i < openCLProducers.size(); i++) {
-            stageGpuFilterOnProducer(configs.get(i), openCLProducers.get(i), localConsumer);
+            stageGpuFilterOnProducer(configs.get(i), openCLProducers.get(i), data);
         }
     }
 
     /**
-     * Stages the consumer's Binary Fuse 8 filter on a single OpenCL producer, if applicable.
-     * Skips producers with {@code enableGpuFilter = false} or forced to full transfer, and the
-     * case where the configured lookup backend did not build a Binary Fuse 8 filter.
+     * Stages the already-built Binary Fuse 8 filter payload on a single OpenCL producer, unless
+     * the producer has {@code enableGpuFilter = false} or is forced to full transfer.
      *
      * @param config   the producer configuration
      * @param producer the producer to stage the filter on
-     * @param consumer the consumer holding the built filter
+     * @param data     the GPU-upload payload built once by {@link #uploadGpuFilterToProducers()}
      */
-    private void stageGpuFilterOnProducer(CProducerOpenCL config, ProducerOpenCL producer, ConsumerJava consumer) {
+    private void stageGpuFilterOnProducer(CProducerOpenCL config, ProducerOpenCL producer, BinaryFuse8GpuFilterData data) {
         if (!config.enableGpuFilter || config.transferAll) {
             return;
         }
-        Optional<BinaryFuse8GpuFilterData> payload = consumer.getGpuFilterData();
-        if (payload.isEmpty()) {
-            LOGGER.warn("producerOpenCL.enableGpuFilter is true but the consumer's address-lookup backend "
-                    + "did not build a Binary Fuse 8 filter (backend must be BINARY_FUSE_8); running full transfer.");
-            return;
-        }
-        BinaryFuse8GpuFilterData data = payload.get();
         long seed = data.seed();
         producer.setGpuFilter(
                 data.fingerprints(),

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/Finder.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/Finder.java
@@ -201,9 +201,30 @@ public class Finder implements Interruptable {
         final ConsumerJava localConsumerJava =
                 new ConsumerJava(localCConsumerJava, keyUtility, persistenceUtils, runtimeStatistics);
         consumerJava = localConsumerJava;
+        // Decide up-front whether the GPU pre-filter is needed so initLMDB() can build it while
+        // LMDB is still open — a self-contained backend closes the env at the end of initLMDB().
+        localConsumerJava.setGpuFilterRequested(isGpuFilterRequested());
         localConsumerJava.initLMDB();
         localConsumerJava.startConsumer();
         localConsumerJava.startStatisticsTimer();
+    }
+
+    /**
+     * Returns whether any OpenCL producer will run in compact (GPU pre-filter) mode, so the
+     * consumer should build the Binary Fuse 8 GPU payload during {@code initLMDB()}.
+     *
+     * <p>Mirrors the vanity rule applied later by {@link #applyVanityFullTransferOverride()}:
+     * vanity scanning forces every producer to full transfer, so no GPU filter is needed then.
+     *
+     * @return {@code true} if at least one OpenCL producer requests compact mode and vanity is off
+     */
+    private boolean isGpuFilterRequested() {
+        CConsumerJava localCConsumerJava = finder.consumerJava;
+        if (localCConsumerJava != null && localCConsumerJava.enableVanity) {
+            return false;
+        }
+        List<CProducerOpenCL> configs = finder.producerOpenCL;
+        return configs != null && configs.stream().anyMatch(c -> c.enableGpuFilter && !c.transferAll);
     }
 
     /**
@@ -294,17 +315,20 @@ public class Finder implements Interruptable {
             return;
         }
 
-        // Build the Fuse-8 filter exactly once, regardless of how many producers consume it.
-        Optional<BinaryFuse8GpuFilterData> payload = localConsumer.buildGpuFilterData();
+        // The payload was built once during the consumer's initLMDB() (while LMDB was open).
+        Optional<BinaryFuse8GpuFilterData> payload = localConsumer.getGpuFilterData();
         if (payload.isEmpty()) {
-            LOGGER.warn("producerOpenCL.enableGpuFilter is true but the GPU filter could not be built "
-                    + "(LMDB is not open — the configured addressLookupBackend released it); running full transfer.");
+            LOGGER.warn("producerOpenCL.enableGpuFilter is true but the GPU filter payload is absent; "
+                    + "running full transfer.");
             return;
         }
         BinaryFuse8GpuFilterData data = payload.get();
         for (int i = 0; i < openCLProducers.size(); i++) {
             stageGpuFilterOnProducer(configs.get(i), openCLProducers.get(i), data);
         }
+        // Release the host-side copy now it is staged on every producer; each producer frees its
+        // own copy after the one-time VRAM upload in initProducer().
+        localConsumer.discardGpuFilterData();
     }
 
     /**

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/AbstractFilterAccelerator.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/AbstractFilterAccelerator.java
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence;
+
+import java.nio.ByteBuffer;
+import lombok.ToString;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Base class for read-only accelerators that place a <em>probabilistic</em> filter in front of an
+ * exact {@link AddressPresence} delegate (typically the LMDB read store).
+ *
+ * <p>A probabilistic filter (Bloom, Binary Fuse, …) has <em>no false negatives</em> but a non-zero
+ * <em>false-positive</em> rate, so a filter "maybe present" answer can never be reported as a final
+ * hit on the CPU — it must be verified against the exact delegate. This base hard-codes that
+ * contract so every concrete accelerator gets it for free and cannot get it wrong:
+ *
+ * <ul>
+ *   <li>a filter <em>miss</em> is definitive — the address is absent and the delegate is never
+ *       consulted (the fast, overwhelmingly common path during a key scan);</li>
+ *   <li>a filter <em>hit</em> is only probable — the call falls through to the exact delegate to
+ *       confirm the address or reject it as a false positive.</li>
+ * </ul>
+ *
+ * <p>Because positives must be disambiguated against the delegate, {@link #requiresBackend()}
+ * always returns {@code true}: the backing storage must stay open for the lifetime of the
+ * accelerator. Both {@link #containsAddress(ByteBuffer)} and {@link #requiresBackend()} are
+ * {@code final} — a subclass only supplies the filter probe via {@link #mightContain(ByteBuffer)},
+ * so it is structurally impossible for a probabilistic accelerator to (a) report an unverified hit
+ * or (b) claim it does not need its backend.
+ *
+ * @param <D> the delegate type; {@link AddressPresence} is enough for presence-only filters, while
+ *     value-carrying accelerators (e.g. a Bloom filter that also answers {@code getAmount}) use a
+ *     wider type such as {@link AddressLookup} and reach it via {@link #delegate()}
+ */
+@ToString
+public abstract class AbstractFilterAccelerator<D extends AddressPresence> implements AddressPresence {
+
+    private final @NonNull D delegate;
+
+    /**
+     * Creates an accelerator wrapping the given exact delegate.
+     *
+     * @param delegate the exact lookup consulted to disambiguate filter positives
+     */
+    protected AbstractFilterAccelerator(@NonNull D delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Returns the exact delegate, for subclasses that expose additional delegate-backed operations
+     * (e.g. value lookups).
+     *
+     * @return the wrapped delegate
+     */
+    protected final @NonNull D delegate() {
+        return delegate;
+    }
+
+    /**
+     * Probes the probabilistic filter. Implementations must not consult the delegate here.
+     *
+     * @param hash160 the address hash to test; its position/limit must be restored before return
+     * @return {@code true} if the filter reports the address as <em>possibly</em> present
+     */
+    protected abstract boolean mightContain(ByteBuffer hash160);
+
+    /**
+     * Returns {@code true} only when the filter reports a hit <em>and</em> the exact delegate
+     * confirms the address. A filter miss short-circuits and never touches the delegate.
+     *
+     * @param hash160 the address hash to look up; its position/limit are restored by both the
+     *                filter probe and the delegate per the {@link AddressPresence} contract
+     * @return {@code true} if the address is confirmed present by the delegate
+     */
+    @Override
+    public final boolean containsAddress(ByteBuffer hash160) {
+        if (!mightContain(hash160)) {
+            return false;
+        }
+        return delegate.containsAddress(hash160);
+    }
+
+    /**
+     * A probabilistic filter hit may be a false positive that must be disambiguated against the
+     * delegate, so the backing storage must remain open.
+     *
+     * @return {@code true} - the delegate must always be available
+     */
+    @Override
+    public final boolean requiresBackend() {
+        return true;
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/bloom/BloomFilterAccelerator.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/bloom/BloomFilterAccelerator.java
@@ -8,6 +8,7 @@ import com.google.common.hash.Funnels;
 import java.nio.ByteBuffer;
 import java.util.stream.Stream;
 import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.persistence.AbstractFilterAccelerator;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressIterable;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressLookup;
 import org.bitcoinj.base.Coin;
@@ -35,15 +36,12 @@ import org.jspecify.annotations.NonNull;
  * {@link BloomFilter} are thread-safe. Guava's {@link BloomFilter#mightContain} is safe for
  * concurrent reads.
  */
-@ToString
-public final class BloomFilterAccelerator implements AddressLookup {
+@ToString(callSuper = true)
+public final class BloomFilterAccelerator extends AbstractFilterAccelerator<AddressLookup> implements AddressLookup {
 
     // BloomFilter.toString dumps the full bit array — potentially millions of bits.
     @ToString.Exclude
     private final @NonNull BloomFilter<byte[]> bloom;
-
-    // Recurses into the wrapped lookup chain; bounded by the wrapped class's own @ToString.
-    private final @NonNull AddressLookup delegate;
 
     /**
      * Creates a new accelerator.
@@ -52,37 +50,29 @@ public final class BloomFilterAccelerator implements AddressLookup {
      * @param delegate the underlying lookup consulted on Bloom hits and for {@link #getAmount}
      */
     public BloomFilterAccelerator(@NonNull BloomFilter<byte[]> bloom, @NonNull AddressLookup delegate) {
+        super(delegate);
         this.bloom = bloom;
-        this.delegate = delegate;
     }
 
+    /**
+     * Probes the Bloom filter. A {@code mightContain == false} answer is definitive (no false
+     * negatives); a {@code true} answer is verified against the delegate by the base class.
+     *
+     * @param hash160 the address hash to test; its position is restored before return
+     * @return {@code true} if the Bloom filter reports the address as possibly present
+     */
     @Override
-    public boolean containsAddress(ByteBuffer hash160) {
+    protected boolean mightContain(ByteBuffer hash160) {
         byte[] bytes = new byte[hash160.remaining()];
         hash160.get(bytes);
         hash160.rewind();
-        if (!bloom.mightContain(bytes)) {
-            return false;
-        }
-        return delegate.containsAddress(hash160);
+        return bloom.mightContain(bytes);
     }
 
     @Override
     public Coin getAmount(ByteBuffer hash160) {
         // Bloom filter has no value information; always delegate.
-        return delegate.getAmount(hash160);
-    }
-
-    /**
-     * Bloom is a probabilistic decorator: a {@code mightContain == true} answer may be a
-     * false positive that must be disambiguated against the delegate. The backing
-     * storage must therefore remain open for the lifetime of this accelerator.
-     *
-     * @return {@code true} - bloom always requires its delegate to be available
-     */
-    @Override
-    public boolean requiresBackend() {
-        return true;
+        return delegate().getAmount(hash160);
     }
 
     /**

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
@@ -33,10 +33,10 @@ import org.jspecify.annotations.NonNull;
  *
  * <h2>False-positive rate</h2>
  * With 16-bit fingerprints the theoretical FPR is approximately 1/65536 &#x2248; 0.0015&nbsp;%.
- * Use this variant when the 0.4&nbsp;% FPR of {@link BinaryFuse8AddressPresence} produces
- * too many spurious (unverified) hits on high-throughput workloads. Like Fuse-8 this filter
- * is self-contained ({@link #requiresBackend()} returns {@code false}); LMDB is closed after
- * population, so false positives are not re-verified against it.
+ * Use this variant when the 0.4&nbsp;% FPR of {@link BinaryFuse8AddressPresence} sends too many
+ * hits to the exact delegate for verification on high-throughput workloads. Like Fuse-8 this
+ * filter is wrapped by {@link BinaryFuseAccelerator}, which verifies every filter hit against
+ * the LMDB read store; the lower FPR simply means fewer verifications.
  *
  * <h2>Memory cost</h2>
  * Approximately 2.60&nbsp;bytes per entry (one {@code short} slot per fingerprint position,
@@ -48,9 +48,11 @@ import org.jspecify.annotations.NonNull;
  * found by {@link #containsAddress(ByteBuffer)}.
  *
  * <h2>Lifecycle</h2>
- * Once populated this class holds no reference to its source.
- * {@link #requiresBackend()} returns {@code false}; the backing storage can be
- * closed and garbage collected after population.
+ * Once populated this class holds no reference to its source. As a bare filter it owns no
+ * delegate, so {@link #requiresBackend()} returns {@code false}; in production it is wrapped by
+ * {@link BinaryFuseAccelerator}, whose {@code requiresBackend()} returns {@code true} to keep
+ * the LMDB verifier open. Unlike the exact snapshots ({@code HASHSET}, {@code TRUNCATED_LONG_64})
+ * the LMDB env is therefore <em>not</em> released after population.
  *
  * <h2>Concurrency</h2>
  * Thread-safe for concurrent reads after construction. No mutation API is exposed.

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
@@ -33,8 +33,10 @@ import org.jspecify.annotations.NonNull;
  *
  * <h2>False-positive rate</h2>
  * With 16-bit fingerprints the theoretical FPR is approximately 1/65536 &#x2248; 0.0015&nbsp;%.
- * Use this variant when the 0.4&nbsp;% FPR of {@link BinaryFuse8AddressPresence} causes
- * measurable LMDB fallback overhead on high-throughput workloads.
+ * Use this variant when the 0.4&nbsp;% FPR of {@link BinaryFuse8AddressPresence} produces
+ * too many spurious (unverified) hits on high-throughput workloads. Like Fuse-8 this filter
+ * is self-contained ({@link #requiresBackend()} returns {@code false}); LMDB is closed after
+ * population, so false positives are not re-verified against it.
  *
  * <h2>Memory cost</h2>
  * Approximately 2.60&nbsp;bytes per entry (one {@code short} slot per fingerprint position,

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
@@ -35,10 +35,11 @@ import org.jspecify.annotations.NonNull;
  *
  * <h2>False-positive rate</h2>
  * With 8-bit fingerprints the theoretical FPR is approximately 1/256 &#x2248; 0.4&nbsp;%.
- * Because this filter is self-contained ({@link #requiresBackend()} returns {@code false}),
- * the LMDB env is closed after population and a false positive is <em>not</em> re-verified
- * against it — it surfaces as a reported hit. Genuine hits are astronomically rare under
- * random scanning, so an occasional spurious hit is a negligible cost.
+ * That rate is far too high to treat a filter hit as a final answer, so this filter is not
+ * used standalone: it is wrapped by {@link BinaryFuseAccelerator}, which verifies every hit
+ * against an exact delegate (the LMDB read store) and rejects false positives. Because there
+ * are no false negatives, a filter <em>miss</em> is always definitive and short-circuits
+ * without consulting the delegate.
  *
  * <h2>Memory cost</h2>
  * Approximately 1.30&nbsp;bytes per entry (one {@code byte} slot per fingerprint position,
@@ -50,9 +51,11 @@ import org.jspecify.annotations.NonNull;
  * found by {@link #containsAddress(ByteBuffer)}.
  *
  * <h2>Lifecycle</h2>
- * Once populated this class holds no reference to its source.
- * {@link #requiresBackend()} returns {@code false}; the backing storage can be
- * closed and garbage collected after population.
+ * Once populated this class holds no reference to its source. As a bare filter it owns no
+ * delegate, so {@link #requiresBackend()} returns {@code false}; in production it is wrapped by
+ * {@link BinaryFuseAccelerator}, whose {@code requiresBackend()} returns {@code true} to keep
+ * the LMDB verifier open. Unlike the exact snapshots ({@code HASHSET}, {@code TRUNCATED_LONG_64})
+ * the LMDB env is therefore <em>not</em> released after population.
  *
  * <h2>Concurrency</h2>
  * Thread-safe for concurrent reads after construction. No mutation API is exposed.

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
@@ -35,9 +35,10 @@ import org.jspecify.annotations.NonNull;
  *
  * <h2>False-positive rate</h2>
  * With 8-bit fingerprints the theoretical FPR is approximately 1/256 &#x2248; 0.4&nbsp;%.
- * Any positive answer from this filter that is not resolved by exact LMDB lookup is
- * an address collision; at the project's largest published database size (~1.4&nbsp;B
- * entries) this is expected to be negligible in practice.
+ * Because this filter is self-contained ({@link #requiresBackend()} returns {@code false}),
+ * the LMDB env is closed after population and a false positive is <em>not</em> re-verified
+ * against it — it surfaces as a reported hit. Genuine hits are astronomically rare under
+ * random scanning, so an occasional spurious hit is a negligible cost.
  *
  * <h2>Memory cost</h2>
  * Approximately 1.30&nbsp;bytes per entry (one {@code byte} slot per fingerprint position,

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuseAccelerator.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuseAccelerator.java
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence.inmemory;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.persistence.AddressPresence;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Read-only accelerator that places a Binary Fuse Filter ({@link BinaryFuse8AddressPresence}
+ * or {@link BinaryFuse16AddressPresence}) in front of an exact {@link AddressPresence}
+ * delegate (typically the LMDB read store).
+ *
+ * <p>Binary Fuse Filters have <em>no false negatives</em> but a non-negligible
+ * <em>false-positive</em> rate (&#x2248; 0.4&nbsp;% for the 8-bit variant,
+ * &#x2248; 0.0015&nbsp;% for the 16-bit variant). That rate is far too high to report a filter
+ * positive as a final hit — at a 0.4&nbsp;% FPR roughly one in every 250 scanned addresses
+ * would be a spurious hit. The filter is therefore used exactly like a Bloom filter (see
+ * {@code net.ladenthin.bitcoinaddressfinder.persistence.bloom.BloomFilterAccelerator}):
+ *
+ * <ul>
+ *   <li>a filter <em>miss</em> is definitive — the address is absent and the delegate is never
+ *       consulted (the fast, overwhelmingly common path during a key scan);</li>
+ *   <li>a filter <em>hit</em> is only probable — the call falls through to the exact delegate
+ *       to confirm the address or reject it as a false positive.</li>
+ * </ul>
+ *
+ * <p>Because positives must be disambiguated against the delegate, {@link #requiresBackend()}
+ * returns {@code true}: the backing storage (LMDB env + mmap) must stay open for the lifetime
+ * of this accelerator and is <em>not</em> released after the filter is built. This is the only
+ * difference from the exact self-contained snapshots ({@code HASHSET}, {@code TRUNCATED_LONG_64}),
+ * whose answers are definitive so they can drop LMDB.
+ *
+ * <h2>GPU pre-filtering</h2>
+ * When the wrapped filter is a {@link BinaryFuse8AddressPresence}, {@link #getGpuFilterData()}
+ * exposes its VRAM-upload payload so the OpenCL producer can run the same filter on the GPU to
+ * shrink the GPU&#x2192;CPU transfer. Survivors of the GPU pre-filter are still verified against
+ * the exact delegate on the CPU through {@link #containsAddress(ByteBuffer)}.
+ *
+ * <h2>Concurrency</h2>
+ * Thread-safe for concurrent reads as long as the wrapped filter and delegate are; the Binary
+ * Fuse filters and the {@code LMDBPersistence} read path both are.
+ */
+@ToString
+public final class BinaryFuseAccelerator implements AddressPresence {
+
+    private final @NonNull AddressPresence filter;
+    private final @NonNull AddressPresence delegate;
+
+    /**
+     * Creates a new accelerator.
+     *
+     * @param filter   the pre-populated Binary Fuse filter consulted first
+     * @param delegate the exact lookup consulted to disambiguate filter positives
+     */
+    public BinaryFuseAccelerator(@NonNull AddressPresence filter, @NonNull AddressPresence delegate) {
+        this.filter = filter;
+        this.delegate = delegate;
+    }
+
+    /**
+     * Returns {@code true} only when the filter reports a hit <em>and</em> the exact delegate
+     * confirms the address. A filter miss short-circuits and never touches the delegate.
+     *
+     * @param hash160 the address hash to look up; its position/limit are restored by both the
+     *                filter and the delegate per the {@link AddressPresence} contract
+     * @return {@code true} if the address is confirmed present by the delegate
+     */
+    @Override
+    public boolean containsAddress(ByteBuffer hash160) {
+        if (!filter.containsAddress(hash160)) {
+            return false;
+        }
+        return delegate.containsAddress(hash160);
+    }
+
+    /**
+     * A Binary Fuse filter is probabilistic: a filter hit may be a false positive that must be
+     * disambiguated against the delegate, so the backing storage must remain open.
+     *
+     * @return {@code true} - the delegate must always be available
+     */
+    @Override
+    public boolean requiresBackend() {
+        return true;
+    }
+
+    /**
+     * Returns the GPU VRAM-upload payload of the wrapped filter, if it is a
+     * {@link BinaryFuse8AddressPresence}.
+     *
+     * @return the Binary Fuse 8 GPU-upload payload, or {@link Optional#empty()} if the wrapped
+     *     filter is not a {@link BinaryFuse8AddressPresence} (e.g. the 16-bit variant, which has
+     *     no GPU path)
+     */
+    public Optional<BinaryFuse8GpuFilterData> getGpuFilterData() {
+        if (filter instanceof BinaryFuse8AddressPresence fuse8) {
+            return Optional.of(fuse8.toGpuFilterData());
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuseAccelerator.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuseAccelerator.java
@@ -6,6 +6,7 @@ package net.ladenthin.bitcoinaddressfinder.persistence.inmemory;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.persistence.AbstractFilterAccelerator;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressPresence;
 import org.jspecify.annotations.NonNull;
 
@@ -18,21 +19,9 @@ import org.jspecify.annotations.NonNull;
  * <em>false-positive</em> rate (&#x2248; 0.4&nbsp;% for the 8-bit variant,
  * &#x2248; 0.0015&nbsp;% for the 16-bit variant). That rate is far too high to report a filter
  * positive as a final hit — at a 0.4&nbsp;% FPR roughly one in every 250 scanned addresses
- * would be a spurious hit. The filter is therefore used exactly like a Bloom filter (see
- * {@code net.ladenthin.bitcoinaddressfinder.persistence.bloom.BloomFilterAccelerator}):
- *
- * <ul>
- *   <li>a filter <em>miss</em> is definitive — the address is absent and the delegate is never
- *       consulted (the fast, overwhelmingly common path during a key scan);</li>
- *   <li>a filter <em>hit</em> is only probable — the call falls through to the exact delegate
- *       to confirm the address or reject it as a false positive.</li>
- * </ul>
- *
- * <p>Because positives must be disambiguated against the delegate, {@link #requiresBackend()}
- * returns {@code true}: the backing storage (LMDB env + mmap) must stay open for the lifetime
- * of this accelerator and is <em>not</em> released after the filter is built. This is the only
- * difference from the exact self-contained snapshots ({@code HASHSET}, {@code TRUNCATED_LONG_64}),
- * whose answers are definitive so they can drop LMDB.
+ * would be a spurious hit. The verify-on-hit behaviour and the {@code requiresBackend() == true}
+ * contract are inherited from {@link AbstractFilterAccelerator} (shared with the Bloom filter
+ * accelerator); this class only supplies the Fuse filter probe via {@link #mightContain(ByteBuffer)}.
  *
  * <h2>GPU pre-filtering</h2>
  * When the wrapped filter is a {@link BinaryFuse8AddressPresence}, {@link #getGpuFilterData()}
@@ -44,11 +33,10 @@ import org.jspecify.annotations.NonNull;
  * Thread-safe for concurrent reads as long as the wrapped filter and delegate are; the Binary
  * Fuse filters and the {@code LMDBPersistence} read path both are.
  */
-@ToString
-public final class BinaryFuseAccelerator implements AddressPresence {
+@ToString(callSuper = true)
+public final class BinaryFuseAccelerator extends AbstractFilterAccelerator<AddressPresence> {
 
     private final @NonNull AddressPresence filter;
-    private final @NonNull AddressPresence delegate;
 
     /**
      * Creates a new accelerator.
@@ -57,35 +45,19 @@ public final class BinaryFuseAccelerator implements AddressPresence {
      * @param delegate the exact lookup consulted to disambiguate filter positives
      */
     public BinaryFuseAccelerator(@NonNull AddressPresence filter, @NonNull AddressPresence delegate) {
+        super(delegate);
         this.filter = filter;
-        this.delegate = delegate;
     }
 
     /**
-     * Returns {@code true} only when the filter reports a hit <em>and</em> the exact delegate
-     * confirms the address. A filter miss short-circuits and never touches the delegate.
+     * Probes the Binary Fuse filter; no false negatives, so a miss is definitive.
      *
-     * @param hash160 the address hash to look up; its position/limit are restored by both the
-     *                filter and the delegate per the {@link AddressPresence} contract
-     * @return {@code true} if the address is confirmed present by the delegate
+     * @param hash160 the address hash to test (position/limit preserved by the filter)
+     * @return {@code true} if the filter reports the address as possibly present
      */
     @Override
-    public boolean containsAddress(ByteBuffer hash160) {
-        if (!filter.containsAddress(hash160)) {
-            return false;
-        }
-        return delegate.containsAddress(hash160);
-    }
-
-    /**
-     * A Binary Fuse filter is probabilistic: a filter hit may be a false positive that must be
-     * disambiguated against the delegate, so the backing storage must remain open.
-     *
-     * @return {@code true} - the delegate must always be available
-     */
-    @Override
-    public boolean requiresBackend() {
-        return true;
+    protected boolean mightContain(ByteBuffer hash160) {
+        return filter.containsAddress(hash160);
     }
 
     /**

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBBase.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBBase.java
@@ -13,6 +13,7 @@ import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
 import net.ladenthin.bitcoinaddressfinder.persistence.bloom.BloomFilterAccelerator;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse16AddressPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse8AddressPresence;
+import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuseAccelerator;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.HashSetAddressPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.TruncatedLong64SortedArrayPresence;
 import net.ladenthin.bitcoinaddressfinder.persistence.lmdb.LMDBPersistence;
@@ -73,8 +74,8 @@ public class LMDBBase {
                         BloomFilterAccelerator.populateFrom(lmdb, lmdb, lmdbConfigurationReadOnly.bloomFilterFpp);
                     case HASHSET -> HashSetAddressPresence.populateFrom(lmdb);
                     case TRUNCATED_LONG_64 -> TruncatedLong64SortedArrayPresence.populateFrom(lmdb);
-                    case BINARY_FUSE_8 -> BinaryFuse8AddressPresence.populateFrom(lmdb);
-                    case BINARY_FUSE_16 -> BinaryFuse16AddressPresence.populateFrom(lmdb);
+                    case BINARY_FUSE_8 -> new BinaryFuseAccelerator(BinaryFuse8AddressPresence.populateFrom(lmdb), lmdb);
+                    case BINARY_FUSE_16 -> new BinaryFuseAccelerator(BinaryFuse16AddressPresence.populateFrom(lmdb), lmdb);
                 };
 
         return new LMDBHandle(lmdb, lookup);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
@@ -116,6 +116,37 @@ public class ConsumerJavaTest {
         }
     }
 
+    @Test
+    public void initLMDB_binaryFuse8Backend_keepsEnvOpenToVerifyFilterHits() throws Exception {
+        // BINARY_FUSE_8 is a probabilistic filter (~0.4% FPR), so it is wrapped by
+        // BinaryFuseAccelerator and must keep LMDB open to verify filter hits. initLMDB must
+        // therefore NOT close the env (regression: it previously closed it, which would turn
+        // ~0.4% of all scanned addresses into unverified false hits).
+        new LMDBPlatformAssume().assumeLMDBExecution();
+        TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
+        TestAddressesFiles testAddresses = new TestAddressesFiles(false);
+        File lmdbFolderPath = testAddressesLMDB.createTestLMDB(folder, testAddresses, true, true);
+
+        CConsumerJava cConsumerJava = new CConsumerJava();
+        cConsumerJava.lmdbConfigurationReadOnly = new CLMDBConfigurationReadOnly();
+        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = lmdbFolderPath.getAbsolutePath();
+        cConsumerJava.lmdbConfigurationReadOnly.addressLookupBackend =
+                net.ladenthin.bitcoinaddressfinder.configuration.AddressLookupBackend.BINARY_FUSE_8;
+        ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
+        try {
+            consumerJava.initLMDB();
+
+            // env must stay open: persistence is retained (not nulled) and a lookup succeeds
+            // through the live env rather than throwing Env$AlreadyClosedException.
+            assertThat(consumerJava.persistence, is(notNullValue()));
+            ByteBuffer buffer = ByteBuffer.allocateDirect(OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES);
+            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73());
+            consumerJava.consumeOneCycle(buffer);
+        } finally {
+            consumerJava.interrupt();
+        }
+    }
+
     // <editor-fold defaultstate="collapsed" desc="getGpuFilterData (Step H)">
     @Test
     public void getGpuFilterData_binaryFuse8Backend_returnsPayload() throws Exception {

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
@@ -147,9 +147,9 @@ public class ConsumerJavaTest {
         }
     }
 
-    // <editor-fold defaultstate="collapsed" desc="getGpuFilterData (Step H)">
+    // <editor-fold defaultstate="collapsed" desc="buildGpuFilterData (GPU pre-filter, decoupled from CPU lookup)">
     @Test
-    public void getGpuFilterData_binaryFuse8Backend_returnsPayload() throws Exception {
+    public void buildGpuFilterData_binaryFuse8Backend_reusesCpuFilter() throws Exception {
         new LMDBPlatformAssume().assumeLMDBExecution();
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(false);
@@ -163,16 +163,19 @@ public class ConsumerJavaTest {
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
         try {
             consumerJava.initLMDB();
-            // the Binary Fuse 8 backend builds a filter, so the GPU-upload payload is present
-            assertThat(consumerJava.getGpuFilterData().isPresent(), is(true));
-            assertThat(consumerJava.getGpuFilterData().get().fingerprints().length > 0, is(true));
+            // the Binary Fuse 8 backend already built a filter, so it is reused for GPU upload
+            assertThat(consumerJava.buildGpuFilterData().isPresent(), is(true));
+            assertThat(consumerJava.buildGpuFilterData().get().fingerprints().length > 0, is(true));
         } finally {
             consumerJava.interrupt();
         }
     }
 
     @Test
-    public void getGpuFilterData_lmdbOnlyBackend_returnsEmpty() throws Exception {
+    public void buildGpuFilterData_lmdbOnlyBackend_buildsFilterFromOpenLmdb() throws Exception {
+        // Decoupling: the GPU pre-filter must be available even when the CPU lookup is LMDB_ONLY
+        // (no CPU-side filter). buildGpuFilterData builds a transient Fuse-8 filter from the open
+        // LMDB purely for VRAM upload; the CPU lookup stays LMDB-only (no double filtering).
         new LMDBPlatformAssume().assumeLMDBExecution();
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(false);
@@ -186,8 +189,31 @@ public class ConsumerJavaTest {
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
         try {
             consumerJava.initLMDB();
-            // a non-Fuse8 backend has no GPU filter payload
-            assertThat(consumerJava.getGpuFilterData().isPresent(), is(false));
+            assertThat(consumerJava.buildGpuFilterData().isPresent(), is(true));
+            assertThat(consumerJava.buildGpuFilterData().get().fingerprints().length > 0, is(true));
+        } finally {
+            consumerJava.interrupt();
+        }
+    }
+
+    @Test
+    public void buildGpuFilterData_selfContainedBackend_returnsEmptyBecauseLmdbClosed() throws Exception {
+        // A self-contained snapshot (HASHSET) closes LMDB after population, so there is no open
+        // env to build the GPU filter from -> empty (the caller falls back to full transfer).
+        new LMDBPlatformAssume().assumeLMDBExecution();
+        TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
+        TestAddressesFiles testAddresses = new TestAddressesFiles(false);
+        File lmdbFolderPath = testAddressesLMDB.createTestLMDB(folder, testAddresses, true, true);
+
+        CConsumerJava cConsumerJava = new CConsumerJava();
+        cConsumerJava.lmdbConfigurationReadOnly = new CLMDBConfigurationReadOnly();
+        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = lmdbFolderPath.getAbsolutePath();
+        cConsumerJava.lmdbConfigurationReadOnly.addressLookupBackend =
+                net.ladenthin.bitcoinaddressfinder.configuration.AddressLookupBackend.HASHSET;
+        ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
+        try {
+            consumerJava.initLMDB();
+            assertThat(consumerJava.buildGpuFilterData().isPresent(), is(false));
         } finally {
             consumerJava.interrupt();
         }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
@@ -147,9 +147,9 @@ public class ConsumerJavaTest {
         }
     }
 
-    // <editor-fold defaultstate="collapsed" desc="buildGpuFilterData (GPU pre-filter, decoupled from CPU lookup)">
+    // <editor-fold defaultstate="collapsed" desc="GPU pre-filter payload (built in initLMDB, decoupled from CPU lookup)">
     @Test
-    public void buildGpuFilterData_binaryFuse8Backend_reusesCpuFilter() throws Exception {
+    public void gpuFilter_binaryFuse8Backend_reusesCpuFilter() throws Exception {
         new LMDBPlatformAssume().assumeLMDBExecution();
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(false);
@@ -162,20 +162,21 @@ public class ConsumerJavaTest {
                 net.ladenthin.bitcoinaddressfinder.configuration.AddressLookupBackend.BINARY_FUSE_8;
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
         try {
+            consumerJava.setGpuFilterRequested(true);
             consumerJava.initLMDB();
             // the Binary Fuse 8 backend already built a filter, so it is reused for GPU upload
-            assertThat(consumerJava.buildGpuFilterData().isPresent(), is(true));
-            assertThat(consumerJava.buildGpuFilterData().get().fingerprints().length > 0, is(true));
+            assertThat(consumerJava.getGpuFilterData().isPresent(), is(true));
+            assertThat(consumerJava.getGpuFilterData().get().fingerprints().length > 0, is(true));
         } finally {
             consumerJava.interrupt();
         }
     }
 
     @Test
-    public void buildGpuFilterData_lmdbOnlyBackend_buildsFilterFromOpenLmdb() throws Exception {
+    public void gpuFilter_lmdbOnlyBackend_buildsFilterFromOpenLmdb() throws Exception {
         // Decoupling: the GPU pre-filter must be available even when the CPU lookup is LMDB_ONLY
-        // (no CPU-side filter). buildGpuFilterData builds a transient Fuse-8 filter from the open
-        // LMDB purely for VRAM upload; the CPU lookup stays LMDB-only (no double filtering).
+        // (no CPU-side filter). initLMDB builds a transient Fuse-8 filter from the open LMDB purely
+        // for VRAM upload; the CPU lookup stays LMDB-only (no double filtering).
         new LMDBPlatformAssume().assumeLMDBExecution();
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(false);
@@ -188,18 +189,21 @@ public class ConsumerJavaTest {
                 net.ladenthin.bitcoinaddressfinder.configuration.AddressLookupBackend.LMDB_ONLY;
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
         try {
+            consumerJava.setGpuFilterRequested(true);
             consumerJava.initLMDB();
-            assertThat(consumerJava.buildGpuFilterData().isPresent(), is(true));
-            assertThat(consumerJava.buildGpuFilterData().get().fingerprints().length > 0, is(true));
+            assertThat(consumerJava.getGpuFilterData().isPresent(), is(true));
+            assertThat(consumerJava.getGpuFilterData().get().fingerprints().length > 0, is(true));
         } finally {
             consumerJava.interrupt();
         }
     }
 
     @Test
-    public void buildGpuFilterData_selfContainedBackend_returnsEmptyBecauseLmdbClosed() throws Exception {
-        // A self-contained snapshot (HASHSET) closes LMDB after population, so there is no open
-        // env to build the GPU filter from -> empty (the caller falls back to full transfer).
+    public void gpuFilter_selfContainedBackend_builtBeforeLmdbClosed() throws Exception {
+        // Regression: a self-contained snapshot (HASHSET) closes LMDB at the end of initLMDB().
+        // Because the GPU filter is requested up-front, initLMDB builds it from the open LMDB
+        // BEFORE the close -> the payload is present even though the env is afterwards released.
+        // (Previously the build happened after the close, so the data was already gone.)
         new LMDBPlatformAssume().assumeLMDBExecution();
         TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
         TestAddressesFiles testAddresses = new TestAddressesFiles(false);
@@ -212,8 +216,39 @@ public class ConsumerJavaTest {
                 net.ladenthin.bitcoinaddressfinder.configuration.AddressLookupBackend.HASHSET;
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
         try {
+            consumerJava.setGpuFilterRequested(true);
             consumerJava.initLMDB();
-            assertThat(consumerJava.buildGpuFilterData().isPresent(), is(false));
+            // payload built before the close
+            assertThat(consumerJava.getGpuFilterData().isPresent(), is(true));
+            assertThat(consumerJava.getGpuFilterData().get().fingerprints().length > 0, is(true));
+            // ...and the self-contained backend still released LMDB afterwards
+            assertThat(consumerJava.persistence, is(nullValue()));
+            // discarding frees the host copy
+            consumerJava.discardGpuFilterData();
+            assertThat(consumerJava.getGpuFilterData().isPresent(), is(false));
+        } finally {
+            consumerJava.interrupt();
+        }
+    }
+
+    @Test
+    public void gpuFilter_notRequested_returnsEmpty() throws Exception {
+        // When no producer needs the GPU filter, initLMDB does not build it.
+        new LMDBPlatformAssume().assumeLMDBExecution();
+        TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
+        TestAddressesFiles testAddresses = new TestAddressesFiles(false);
+        File lmdbFolderPath = testAddressesLMDB.createTestLMDB(folder, testAddresses, true, true);
+
+        CConsumerJava cConsumerJava = new CConsumerJava();
+        cConsumerJava.lmdbConfigurationReadOnly = new CLMDBConfigurationReadOnly();
+        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = lmdbFolderPath.getAbsolutePath();
+        cConsumerJava.lmdbConfigurationReadOnly.addressLookupBackend =
+                net.ladenthin.bitcoinaddressfinder.configuration.AddressLookupBackend.LMDB_ONLY;
+        ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
+        try {
+            // gpuFilterRequested defaults to false
+            consumerJava.initLMDB();
+            assertThat(consumerJava.getGpuFilterData().isPresent(), is(false));
         } finally {
             consumerJava.interrupt();
         }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/AbstractFilterAcceleratorTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/AbstractFilterAcceleratorTest.java
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the shared {@link AbstractFilterAccelerator} contract directly, independently of the Bloom
+ * and Binary Fuse concrete subclasses: a filter miss short-circuits without consulting the
+ * delegate, a filter hit is verified against the delegate, and {@link
+ * AbstractFilterAccelerator#requiresBackend()} is always {@code true}.
+ */
+class AbstractFilterAcceleratorTest {
+
+    /** Recording delegate: counts calls and reports a fixed contents set. */
+    private static final class RecordingPresence implements AddressPresence {
+        final Set<ByteBuffer> contains = new HashSet<>();
+        final AtomicInteger containsCalls = new AtomicInteger();
+
+        @Override
+        public boolean containsAddress(ByteBuffer hash160) {
+            containsCalls.incrementAndGet();
+            return contains.contains(hash160);
+        }
+
+        @Override
+        public boolean requiresBackend() {
+            return false;
+        }
+    }
+
+    /** Minimal accelerator whose filter probe is driven by a fixed set, for contract testing. */
+    private static final class FixedFilterAccelerator extends AbstractFilterAccelerator<AddressPresence> {
+        private final Set<ByteBuffer> filterHits;
+        private final AtomicInteger mightContainCalls = new AtomicInteger();
+
+        FixedFilterAccelerator(Set<ByteBuffer> filterHits, AddressPresence delegate) {
+            super(delegate);
+            this.filterHits = filterHits;
+        }
+
+        @Override
+        protected boolean mightContain(ByteBuffer hash160) {
+            mightContainCalls.incrementAndGet();
+            return filterHits.contains(hash160);
+        }
+    }
+
+    private static ByteBuffer hash(int v) {
+        ByteBuffer b = ByteBuffer.allocate(20);
+        b.putInt(0, v);
+        return b;
+    }
+
+    @Test
+    void containsAddress_filterMiss_shortCircuitsWithoutDelegate() {
+        RecordingPresence delegate = new RecordingPresence();
+        FixedFilterAccelerator accelerator = new FixedFilterAccelerator(new HashSet<>(), delegate);
+
+        boolean result = accelerator.containsAddress(hash(1));
+
+        assertThat(result, is(false));
+        assertThat("a filter miss must not consult the delegate", delegate.containsCalls.get(), is(equalTo(0)));
+    }
+
+    @Test
+    void containsAddress_filterHit_delegateConfirms_returnsTrue() {
+        RecordingPresence delegate = new RecordingPresence();
+        delegate.contains.add(hash(1));
+        Set<ByteBuffer> filterHits = new HashSet<>();
+        filterHits.add(hash(1));
+        FixedFilterAccelerator accelerator = new FixedFilterAccelerator(filterHits, delegate);
+
+        boolean result = accelerator.containsAddress(hash(1));
+
+        assertThat(result, is(true));
+        assertThat("a filter hit must be verified against the delegate", delegate.containsCalls.get(), is(equalTo(1)));
+    }
+
+    @Test
+    void containsAddress_filterHit_delegateRejects_returnsFalse() {
+        RecordingPresence delegate = new RecordingPresence(); // empty -> rejects
+        Set<ByteBuffer> filterHits = new HashSet<>();
+        filterHits.add(hash(1));
+        FixedFilterAccelerator accelerator = new FixedFilterAccelerator(filterHits, delegate);
+
+        boolean result = accelerator.containsAddress(hash(1));
+
+        assertThat("the delegate rejects the false positive", result, is(false));
+        assertThat(delegate.containsCalls.get(), is(equalTo(1)));
+    }
+
+    @Test
+    void requiresBackend_isAlwaysTrue() {
+        FixedFilterAccelerator accelerator = new FixedFilterAccelerator(new HashSet<>(), new RecordingPresence());
+        assertThat(accelerator.requiresBackend(), is(true));
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuseAcceleratorTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuseAcceleratorTest.java
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence.inmemory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import net.ladenthin.bitcoinaddressfinder.persistence.AddressIterable;
+import net.ladenthin.bitcoinaddressfinder.persistence.AddressPresence;
+import org.junit.jupiter.api.Test;
+
+class BinaryFuseAcceleratorTest {
+
+    /** Recording {@link AddressPresence} stub: counts calls and reports a fixed contents set. */
+    private static final class RecordingPresence implements AddressPresence {
+        final Set<ByteBuffer> contains = new HashSet<>();
+        final AtomicInteger containsCalls = new AtomicInteger();
+
+        @Override
+        public boolean containsAddress(ByteBuffer hash160) {
+            containsCalls.incrementAndGet();
+            return contains.contains(hash160);
+        }
+
+        @Override
+        public boolean requiresBackend() {
+            return false;
+        }
+    }
+
+    private static ByteBuffer hash(int v) {
+        ByteBuffer b = ByteBuffer.allocate(20);
+        b.putInt(0, v);
+        return b;
+    }
+
+    @Test
+    void containsAddress_filterSaysAbsent_returnsFalseAndDoesNotConsultDelegate() {
+        RecordingPresence filter = new RecordingPresence(); // empty -> miss
+        RecordingPresence delegate = new RecordingPresence();
+        BinaryFuseAccelerator accelerator = new BinaryFuseAccelerator(filter, delegate);
+
+        boolean result = accelerator.containsAddress(hash(999));
+
+        assertThat(result, is(false));
+        assertThat("filter 'no' must short-circuit", delegate.containsCalls.get(), is(equalTo(0)));
+    }
+
+    @Test
+    void containsAddress_filterHit_delegateConfirms_returnsTrue() {
+        RecordingPresence filter = new RecordingPresence();
+        filter.contains.add(hash(42));
+        RecordingPresence delegate = new RecordingPresence();
+        delegate.contains.add(hash(42));
+        BinaryFuseAccelerator accelerator = new BinaryFuseAccelerator(filter, delegate);
+
+        boolean result = accelerator.containsAddress(hash(42));
+
+        assertThat(result, is(true));
+        assertThat("filter hit must consult the delegate", delegate.containsCalls.get(), is(equalTo(1)));
+    }
+
+    @Test
+    void containsAddress_filterHit_delegateDenies_returnsFalse() {
+        // A filter false positive: the filter reports present, but the exact delegate does not.
+        RecordingPresence filter = new RecordingPresence();
+        filter.contains.add(hash(42));
+        RecordingPresence delegate = new RecordingPresence(); // intentionally empty
+        BinaryFuseAccelerator accelerator = new BinaryFuseAccelerator(filter, delegate);
+
+        boolean result = accelerator.containsAddress(hash(42));
+
+        assertThat(result, is(false));
+        assertThat(
+                "delegate must be consulted to reject the false positive",
+                delegate.containsCalls.get(),
+                is(equalTo(1)));
+    }
+
+    @Test
+    void requiresBackend_isTrue_becauseFuseIsProbabilistic() {
+        BinaryFuseAccelerator accelerator =
+                new BinaryFuseAccelerator(new RecordingPresence(), new RecordingPresence());
+        assertThat(accelerator.requiresBackend(), is(true));
+    }
+
+    @Test
+    void getGpuFilterData_fuse8Wrapped_returnsPayload() {
+        ListIterable source = new ListIterable().add(7).add(8).add(9);
+        BinaryFuse8AddressPresence filter = BinaryFuse8AddressPresence.populateFrom(source);
+        BinaryFuseAccelerator accelerator = new BinaryFuseAccelerator(filter, new RecordingPresence());
+
+        assertThat(accelerator.getGpuFilterData().isPresent(), is(true));
+        assertThat(accelerator.getGpuFilterData().get().fingerprints().length > 0, is(true));
+    }
+
+    @Test
+    void getGpuFilterData_fuse16Wrapped_returnsEmpty() {
+        ListIterable source = new ListIterable().add(7).add(8).add(9);
+        BinaryFuse16AddressPresence filter = BinaryFuse16AddressPresence.populateFrom(source);
+        BinaryFuseAccelerator accelerator = new BinaryFuseAccelerator(filter, new RecordingPresence());
+
+        assertThat("Fuse-16 has no GPU path", accelerator.getGpuFilterData().isPresent(), is(false));
+    }
+
+    @Test
+    void containsAddress_wrappingRealFuse8_rejectsAbsentAndConfirmsPresent() {
+        // End-to-end through a real Fuse-8 filter: present keys flow filter->delegate->true;
+        // a key the delegate does not hold is rejected even if the filter false-positives.
+        ListIterable source = new ListIterable().add(7).add(8).add(9);
+        BinaryFuse8AddressPresence filter = BinaryFuse8AddressPresence.populateFrom(source);
+        RecordingPresence delegate = new RecordingPresence();
+        delegate.contains.add(hash(7));
+        delegate.contains.add(hash(8));
+        delegate.contains.add(hash(9));
+        BinaryFuseAccelerator accelerator = new BinaryFuseAccelerator(filter, delegate);
+
+        // No false negatives: every inserted key passes the filter and is confirmed by the delegate.
+        assertThat(accelerator.containsAddress(hash(7)), is(true));
+        assertThat(accelerator.containsAddress(hash(8)), is(true));
+        assertThat(accelerator.containsAddress(hash(9)), is(true));
+        // An absent key: filter miss -> false, or (rarely) filter hit -> delegate rejects -> false.
+        assertThat(accelerator.containsAddress(hash(123_456)), is(false));
+    }
+
+    /** Minimal {@link AddressIterable} of 20-byte addresses for building real filters. */
+    private static final class ListIterable implements AddressIterable {
+        final List<byte[]> entries = new ArrayList<>();
+
+        ListIterable add(int seed) {
+            byte[] bytes = new byte[20];
+            ByteBuffer.wrap(bytes).putInt(0, seed);
+            entries.add(bytes);
+            return this;
+        }
+
+        @Override
+        public Stream<ByteBuffer> addresses() {
+            return entries.stream().map(ByteBuffer::wrap);
+        }
+
+        @Override
+        public long count() {
+            return entries.size();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Introduce `AbstractFilterAccelerator`**: A base class that enforces the probabilistic filter contract — filter misses short-circuit without consulting the delegate, filter hits are verified against an exact delegate, and `requiresBackend()` always returns `true`. This prevents false positives from being reported as final hits.

- **Refactor `BloomFilterAccelerator` to extend `AbstractFilterAccelerator`**: Simplifies the Bloom filter implementation by inheriting the shared verification logic.

- **Add `BinaryFuseAccelerator`**: A new decorator that wraps Binary Fuse filters (8-bit or 16-bit) in front of LMDB, with the same verify-on-hit contract. Exposes `getGpuFilterData()` for the 8-bit variant to feed the GPU pre-filter.

- **Decouple GPU pre-filter from CPU lookup**: The GPU pre-filter is now built independently of the CPU lookup backend. `ConsumerJava.setGpuFilterRequested()` allows the engine to request the filter up-front (before `initLMDB()`), and `ConsumerJava.getGpuFilterData()` / `discardGpuFilterData()` manage its lifecycle. This allows:
  - `LMDB_ONLY` CPU lookup to still use a Binary Fuse 8 GPU pre-filter for VRAM upload
  - `BINARY_FUSE_8` CPU lookup to reuse its filter for GPU upload (no double build)
  - Self-contained backends (`HASHSET`, `TRUNCATED_LONG_64`) to build a transient GPU filter while LMDB is open, then close the env

- **Change default `addressLookupBackend` to `LMDB_ONLY`**: The safest baseline — exact, no false positives, simplest base for GPU pre-filtering. In-RAM filters (`BLOOM`, `BINARY_FUSE_8`, etc.) are now opt-in optimizations.

- **Update documentation and examples**: Clarify the role of each backend, the independence of GPU pre-filtering, and the false-positive verification flow.

## Test plan

- [x] Added `AbstractFilterAcceleratorTest` — contract tests for the base class (filter miss short-circuits, filter hit verified, `requiresBackend() == true`)
- [x] Added `BinaryFuseAcceleratorTest` — end-to-end tests with real Fuse-8 filters, GPU payload extraction, false-positive rejection
- [x] Updated `ConsumerJavaTest` — new tests for GPU pre-filter lifecycle (`initLMDB_binaryFuse8Backend_keepsEnvOpenToVerifyFilterHits`, `gpuFilter_*` variants) and regression coverage for self-contained backends
- [x] Existing unit/integration tests pass locally
- [x] CI is green on this branch

## Related issues / PRs

Decouples the GPU pre-filter (VRAM upload) from the CPU lookup backend, enabling flexible combinations (e.g., exact CPU lookup with GPU pre-filter, or self-contained CPU snapshot with transient GPU filter).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01F3Mttz7ZHcL1ThyH7nkP7d