### PR TITLE
Apply spotless formatting to Java source files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,6 +565,11 @@ See [`../workspace/policies/javadoc-conventions.md`](../workspace/policies/javad
 
 See [`../workspace/policies/spotbugs-suppressions.md`](../workspace/policies/spotbugs-suppressions.md).
 
+## Spotless Formatting
+
+See [`../workspace/policies/spotless-formatting.md`](../workspace/policies/spotless-formatting.md).
+Run `mvn spotless:apply` before every commit that touches `.java` files.
+
 ## jqwik Policy
 
 See [`../workspace/policies/jqwik-prompt-injection.md`](../workspace/policies/jqwik-prompt-injection.md).

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/Finder.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/Finder.java
@@ -339,7 +339,8 @@ public class Finder implements Interruptable {
      * @param producer the producer to stage the filter on
      * @param data     the GPU-upload payload built once by {@link #uploadGpuFilterToProducers()}
      */
-    private void stageGpuFilterOnProducer(CProducerOpenCL config, ProducerOpenCL producer, BinaryFuse8GpuFilterData data) {
+    private void stageGpuFilterOnProducer(
+            CProducerOpenCL config, ProducerOpenCL producer, BinaryFuse8GpuFilterData data) {
         if (!config.enableGpuFilter || config.transferAll) {
             return;
         }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBBase.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/LMDBBase.java
@@ -74,8 +74,10 @@ public class LMDBBase {
                         BloomFilterAccelerator.populateFrom(lmdb, lmdb, lmdbConfigurationReadOnly.bloomFilterFpp);
                     case HASHSET -> HashSetAddressPresence.populateFrom(lmdb);
                     case TRUNCATED_LONG_64 -> TruncatedLong64SortedArrayPresence.populateFrom(lmdb);
-                    case BINARY_FUSE_8 -> new BinaryFuseAccelerator(BinaryFuse8AddressPresence.populateFrom(lmdb), lmdb);
-                    case BINARY_FUSE_16 -> new BinaryFuseAccelerator(BinaryFuse16AddressPresence.populateFrom(lmdb), lmdb);
+                    case BINARY_FUSE_8 ->
+                        new BinaryFuseAccelerator(BinaryFuse8AddressPresence.populateFrom(lmdb), lmdb);
+                    case BINARY_FUSE_16 ->
+                        new BinaryFuseAccelerator(BinaryFuse16AddressPresence.populateFrom(lmdb), lmdb);
                 };
 
         return new LMDBHandle(lmdb, lookup);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
@@ -147,7 +147,8 @@ public class ConsumerJavaTest {
         }
     }
 
-    // <editor-fold defaultstate="collapsed" desc="GPU pre-filter payload (built in initLMDB, decoupled from CPU lookup)">
+    // <editor-fold defaultstate="collapsed" desc="GPU pre-filter payload (built in initLMDB, decoupled from CPU
+    // lookup)">
     @Test
     public void gpuFilter_binaryFuse8Backend_reusesCpuFilter() throws Exception {
         new LMDBPlatformAssume().assumeLMDBExecution();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuseAcceleratorTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuseAcceleratorTest.java
@@ -88,8 +88,7 @@ class BinaryFuseAcceleratorTest {
 
     @Test
     void requiresBackend_isTrue_becauseFuseIsProbabilistic() {
-        BinaryFuseAccelerator accelerator =
-                new BinaryFuseAccelerator(new RecordingPresence(), new RecordingPresence());
+        BinaryFuseAccelerator accelerator = new BinaryFuseAccelerator(new RecordingPresence(), new RecordingPresence());
         assertThat(accelerator.requiresBackend(), is(true));
     }
 


### PR DESCRIPTION
## Summary

- Applied spotless code formatting to multiple Java files to comply with project formatting standards
- Reformatted long lines in switch expressions and method signatures for improved readability
- Added documentation reference to spotless formatting policy in CLAUDE.md

## Test plan

- [x] Affected unit / integration tests pass locally
- [x] CI is green on this branch
- [x] Docs updated (CLAUDE.md)

## Related issues / PRs

None

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01Au4VSkHrWmx3FJDYcLSNJo