### PR TITLE
Docs: add BitCrack and KeyHunt-Cuda to the similar-projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1542,6 +1542,8 @@ BitcoinAddressFinder can simulate this type of scenario by generating keys using
 * https://allprivatekeys.com/vanity-address
 * https://github.com/treyyoder/bitcoin-wallet-finder
 * https://github.com/albertobsd/keyhunt
+* https://github.com/brichard19/BitCrack — CUDA/OpenCL secp256k1 brute-forcer
+* https://github.com/kanhavishva/KeyHunt-Cuda — CUDA key/puzzle hunter (a modified version of [VanitySearch](https://github.com/JeanLucPons/VanitySearch))
 * https://github.com/mvrc42/bitp0wn
 * https://github.com/JeanLucPons/BTCCollider
 * https://github.com/JeanLucPons/VanitySearch

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -668,6 +668,7 @@ hot path; correctness is paramount.
 | — | suggested starting config | run `OpenCLInfo` (or grep init log) for `SUGGESTED START CONFIG` (§6); pure helper `OpenClConfigSuggestion` | `OpenClConfigSuggestionTest`, `OpenCLDeviceTest` |
 | — | `KEYS_BATCH_INV` sweep | edit the `#define`, `GpuFuse8FilterBenchmark` (§3) | `ProbeAddressesOpenCLTest` |
 | — | reduced-radix 2²⁶ field multiply (isolated; §8) | `FieldMulBenchmark -p useReducedRadix=true,false` | `OpenCLFe10x26ParityTest` (`test_fe10x26`, 8192 pairs, byte-identical to radix-2³²) |
+| 5 | reduced-radix 2²⁶ scalar-walker (end-to-end; §8) | `GpuFuse8FilterBenchmark -p gpuFilter=true -p batchSizeInBits=20 -p keysPerWorkItem=128 -p useReducedRadixField=false,true` | `ProbeAddressesManySeedsOpenCLTest` (flag on+off, 16 seeds × 256 keys vs bitcoinj) + `ProbeAddressesOpenCLTest` |
 
 **Honest caveat on A/B reproducibility:** only Stage 4 has a build-time toggle
 (`useSafeGcdInverse`), so its A/B is a single JMH run. Stages 2b and 3 are unconditional (no flag, per
@@ -752,34 +753,64 @@ is forbidden — both address types are mandatory).
   branch/addressing overhead, so it loses. Reverted. Could be revisited on a *multiply-bound* device
   (or paired with a reduced-radix representation that shortens the add chain).
 
-### Implemented & measured building block — reduced-radix 2²⁶ field (not yet in the hot path)
+### Stage 5 (opt-in) — reduced-radix 2²⁶ field in the scalar-walker (≈ +22% end-to-end, flag-gated)
 
-The #1 EC lever (below) is no longer purely theoretical: the reduced-radix field arithmetic is
-**implemented, parity-proven, and benchmarked in isolation**. What is *not* yet done is wiring it into
-the production scalar-multiply / point-addition walk — that is the remaining (large) step.
+The #1 EC lever is **implemented, parity-proven, integrated into the hot loop behind a flag, and
+benchmarked both in isolation and end-to-end**. It is **off by default** (`useReducedRadixField =
+false`) pending per-device confirmation; flipping the default is a one-line change now that it is
+proven. The comb anchor and the `copyfromhashcat` files are unchanged either way.
 
 - **What was built.** `src/main/resources/inc_ecc_secp256k1_fe10x26.cl` — a self-contained OpenCL port
   of libsecp256k1's `field_10x26_impl.h` (Pieter Wuille, MIT): `fe10x26_mul`, `fe10x26_sqr`,
-  `fe10x26_normalize`, `fe10x26_add`, `fe10x26_negate`, plus a **compatibility layer**
+  `fe10x26_normalize`, `fe10x26_add`, `fe10x26_negate`, `fe10x26_sub`, plus a **compatibility layer**
   (`fe10x26_from_u32x8` / `fe10x26_to_u32x8`) that converts between the 2²⁶ form and the radix-2³²
   `u32[8]` form used everywhere else (and by hashcat: limb 0 = least-significant 32 bits). The vendored
   `copyfromhashcat/inc_ecc_secp256k1.cl` is **untouched** and the new file is written in the same
   hashcat dialect (`DECLSPEC`, `u32`/`u64`, `PRIVATE_AS`), so it could be dropped into a hashcat tree.
-- **Correctness (gated).** `test_fe10x26` kernel + `OpenCLFe10x26ParityTest` run **8192** deterministic
-  pseudo-random operand pairs and assert the 2²⁶ path is **byte-identical** to the radix-2³² reference
-  for roundtrip, multiply, square, add, and subtract. Passes on the RTX 3070 (and under pocl in CI).
-- **Measured speed (RTX 3070 Laptop, isolated).** `FieldMulBenchmark` → `bench_fe_mul` kernel chains
-  `iterations` field multiplies per work-item over a full grid (`gridSizeInBits=18`, `iterations=4096`),
-  keeping coordinates in their native form for the whole chain (the 2²⁶ arm converts in/out only once):
+- **Integration.** With `useReducedRadixField = true` (build define `-D USE_REDUCED_RADIX_FIELD`) the
+  affine batched-addition walk in `generateKeysKernel_grid` holds coordinates in 2²⁶: the comb anchor
+  `x0/y0` is converted once, the increment-table reads and the two emitted coordinates convert at their
+  boundaries, and the single per-sub-batch inverse is done in radix-2³² via the conversion layer
+  (reusing the build-selected safegcd `inv_mod`). The slope law follows libsecp's magnitude discipline
+  (intermediate magnitudes ≤ 7, so only the two emitted coordinates are normalized). The radix-2³²
+  walk is retained verbatim as the `#else` branch and remains the default.
+- **Correctness (gated, two layers).**
+  (1) `test_fe10x26` kernel + `OpenCLFe10x26ParityTest` run **8192** deterministic pseudo-random
+  operand pairs and assert the 2²⁶ field ops are **byte-identical** to the radix-2³² reference for
+  roundtrip, multiply, square, add, subtract.
+  (2) `ProbeAddressesManySeedsOpenCLTest` builds the kernel with the flag **off and on** and derives
+  **16 seeds × 256 keys** each (varied bit sizes), verifying every key against **bitcoinj**
+  (`runtimePublicKeyCalculationCheck` — both pubkeys + both hash160 chains). Both arms pass on the RTX
+  3070; `ProbeAddressesOpenCLTest` (43 cases, default path) still 43/0. bitcoinj is an independent
+  oracle, so this catches any representation-specific (e.g. rare magnitude/carry) bug — important
+  because a wrong result here is a *silently missed key*, not a crash.
+- **Measured speed.** Two benchmarks, both on the RTX 3070 Laptop, both A/B-bracketed against the
+  laptop's thermal noise.
+
+  *Isolated field multiply* — `FieldMulBenchmark` → `bench_fe_mul` kernel chains `iterations` multiplies
+  per work-item over a full grid (`gridSizeInBits=18`, `iterations=4096`), coordinates kept native for
+  the whole chain (2²⁶ arm converts in/out only once):
 
   | field multiply         | throughput (ops/s) | relative |
   |------------------------|--------------------|----------|
   | reduced-radix 2²⁶      | **10.20**          | **1.56×** |
   | radix-2³² `mul_mod`    | 6.53               | 1.00×    |
 
-  ~**1.56× faster** field multiply, confirming the carry-bound diagnosis (the `sqr_mod` finding above).
-  Not a thermal artifact: the radix-2³² arm measured **6.57** when run *cold* in its own fresh JVM
-  (vs 6.53 when run second/hot), and per-iteration variance was tiny (6.52–6.57). Reproduce:
+  *End-to-end kernel* — `GpuFuse8FilterBenchmark -p gpuFilter=true -p batchSizeInBits=20 -p
+  keysPerWorkItem=128 -p useReducedRadixField=false,true` (compact mode, the §4 sweet spot):
+
+  | scalar-walker field | throughput (ops/s) | relative |
+  |---------------------|--------------------|----------|
+  | reduced-radix 2²⁶   | **188.6**          | **1.22×** |
+  | radix-2³²           | 155.2              | 1.00×    |
+
+  ~**+22% end-to-end** (consistent across both A/B orderings: 189.3/152.1 = 1.24× and, reversed/cold,
+  188.6/155.2 = 1.22×; tight ±1–2 ops/s error). The end-to-end gain is smaller than the isolated 1.56×
+  because hashing is ~43% of the kernel (§6) and the per-key boundary conversions (increment-table
+  reads, coordinate outputs) cost a little — storing the `iG_table` in 2²⁶ form would remove those reads
+  and is the obvious next refinement. The isolated multiply confirms the carry-bound diagnosis (the
+  `sqr_mod` finding above): not a thermal artifact — the radix-2³² multiply measured **6.57** cold in a
+  fresh JVM (vs 6.53 hot). Reproduce the isolated multiply:
 
   ```bash
   # after: mvn -q dependency:build-classpath -Dmdep.outputFile=target/cp-test.txt -DincludeScope=test
@@ -787,16 +818,16 @@ the production scalar-multiply / point-addition walk — that is the remaining (
        org.openjdk.jmh.Main FieldMulBenchmark -p gridSizeInBits=18 -p iterations=4096 -f 1 -wi 1 -w 20 -i 3 -r 50
   ```
 
-- **What remains (the actual Stage).** Convert the hot path (the comb anchor, the affine
-  batched-addition walk, `point_add`/`point_double`/`point_to_affine`, and the Montgomery
-  simultaneous-inversion chain) to hold coordinates in 2²⁶ form, converting only at kernel
-  input/output, and reuse the existing `inv_mod` via the conversion layer (or port `modinv32`'s 2²⁶
-  path). The **1.56× is the multiply in isolation**; end-to-end it will be diluted by hashing (~43%,
-  §6) and the non-multiply EC work, and *helped* by lower register pressure (fewer live wide
-  temporaries → better occupancy, §6). Net end-to-end gain **must be measured** with a fresh
-  `keysPerWorkItem` sweep. This is gated and low-risk to *add* (the module is proven); the risk is all
-  in the hot-path rewrite, which changes address-derivation correctness and so needs the full
-  `ProbeAddressesOpenCLTest` 43/0 gate plus the parity kernel.
+- **What remains (refinements, all optional).**
+  (a) **Flip the default** to `useReducedRadixField = true` once the +22% is confirmed on more than
+  this one RTX 3070 (the safegcd precedent: made default after a cross-device win). One-line change.
+  (b) **Store `iG_table` in 2²⁶ form** (host build or a post-process kernel) to drop the per-key
+  increment-read conversions — the main remaining overhead diluting the gain.
+  (c) **Convert the comb anchor** to 2²⁶ too (needs a 2²⁶ Jacobian `point_add` in our own file, since
+  `copyfromhashcat` is untouched). Low payoff — the comb runs once per work-item vs the walk's
+  `keysPerWorkItem` iterations — so only worth it after (b).
+  (d) **Re-sweep `keysPerWorkItem`** with the flag on: the per-key cost balance shifted, so the §4
+  sweet spot may move.
 
 ### Candidates for a future stage
 
@@ -812,10 +843,10 @@ cost balance shifts):
   micro-optimisation, or sharing more work between the uncompressed and compressed chains (they share
   the X coordinate; the compressed SEC prefix transform is already reused via `REUSE_FOR_COMPRESSED`),
   is the lever here — without ever dropping a chain. Both chains always run.
-- **Reduced-radix field representation — the #1 lever; the field module is now built & measured
-  (see "Implemented & measured building block" above), hot-path integration is what remains.** The EC
-  side is ~57% (§6) and the field multiply is carry/add-bound (the `sqr_mod` result, now also confirmed
-  the other way: the 2²⁶ multiply measured ~1.56× faster in isolation). A reduced-radix
+- **Reduced-radix field representation — DONE for the scalar-walker (see "Stage 5" above:
+  ≈ +22% end-to-end, flag-gated, proven vs bitcoinj). The notes below remain for the comb anchor and
+  for context.** The EC side is ~57% (§6) and the field multiply is carry/add-bound (the `sqr_mod`
+  result, now confirmed the other way: the 2²⁶ multiply measured ~1.56× faster in isolation). A reduced-radix
   layout stores 256 bits in limbs narrower than the word (e.g. **10×26-bit** for a 32-bit GPU, or
   5×52-bit for 64-bit), so additive overflow lands in the spare bits and **carries are deferred**
   instead of propagated every limb; reconciliation happens only inside `mul`/`sqr` or at an explicit

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -191,16 +191,25 @@ dominated EC cost once the walk amortized it.
 
 ### Stage 0 — kernel build flags + `#pragma unroll` (no measurable gain; kept as hygiene)
 
-`clBuildProgram` passes `-cl-std=CL2.0 -cl-mad-enable` (constant `CL_BUILD_OPTIONS` in
+`clBuildProgram` passes `-cl-std=CL1.2 -cl-mad-enable` (constant `CL_BUILD_OPTIONS` in
 `OpenCLContext.java`), and `#pragma unroll` was added to the fixed 8-limb `mul_mod` / fast-reduction
 loops in `copyfromhashcat/inc_ecc_secp256k1.cl`.
 
 Parity: ✅ 5/5 byte-identical. Throughput: **no reliable gain** — every arm's JMH error bar overlaps
 the baseline (e.g. kpwi=64: 18.4 ± 1.4 vs 17.7 ± 1.8 ops/s). Expected for an integer-only kernel:
-`-cl-mad-enable` affects only floating-point math, the NVIDIA PTX compiler already unrolls these
-small fixed-trip loops, and `-cl-std=CL2.0` only pins the OpenCL-2.0 semantics compact mode's
-`atomic_add` already required. Kept because harmless, verified byte-identical, and it makes the
-2.0 requirement explicit — but it is setup/hygiene, not a speed-up.
+`-cl-mad-enable` affects only floating-point math, and the NVIDIA PTX compiler already unrolls these
+small fixed-trip loops. Kept because harmless and verified byte-identical — setup/hygiene, not a
+speed-up.
+
+> **`-cl-std` note (was `CL2.0`, now `CL1.2`).** An earlier revision pinned `-cl-std=CL2.0` on the
+> belief that compact mode's global `atomic_add` was an OpenCL-2.0 feature. It is not — `atomic_add`
+> on global `int` is core since OpenCL C 1.1 (`cl_khr_global_int32_base_atomics`, advertised by every
+> target), and the hashcat `IS_OPENCL` path uses the same 1.1 atomics (the C11 `atomic_*_explicit`
+> forms are `IS_METAL`-only). `CL2.0` was rejected by pocl's CPU device (which advertises only OpenCL
+> C 1.2 even on an OpenCL 3.0 platform) with `CL_BUILD_PROGRAM_FAILURE`, breaking the `test-opencl`
+> (pocl) CI job. `CL1.2` is accepted everywhere (pocl CPU + NVIDIA GPU) and the kernel needs nothing
+> newer. The compact-mode *device*-version gate (≥ 2.0, on `CL_DEVICE_VERSION`) is a separate check
+> and is unchanged.
 
 ### Stage 1 — single-anchor affine batched-addition walk (+~10% at the sweet spot)
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -637,7 +637,7 @@ Every kernel change is gated **before** any throughput is reported. These run un
 `test-opencl` job) or a real GPU; `@OpenCLTest` classes self-skip when no device is present.
 
 ```bash
-mvn test -Dtest='ProbeAddressesOpenCLTest,OpenCLCompactOutputIntegrationTest,OpenCLContextTest,Fuse8GpuHashParityTest,ProducerOpenCLTest,OpenCLPrecomputeKernelTest'
+mvn test -Dtest='ProbeAddressesOpenCLTest,ProbeAddressesManySeedsOpenCLTest,OpenCLCompactOutputIntegrationTest,OpenCLContextTest,OpenCLKernelModeMatrixTest,OpenCLFe10x26ParityTest,Fuse8GpuHashParityTest,ProducerOpenCLTest,OpenCLPrecomputeKernelTest'
 ```
 
 - **`ProbeAddressesOpenCLTest#createKeys_acrossKeysPerWorkItem_allResultsMatchReference`** — the
@@ -656,9 +656,44 @@ mvn test -Dtest='ProbeAddressesOpenCLTest,OpenCLCompactOutputIntegrationTest,Ope
   cross-checks safegcd vs. the binary GCD **and** `x·x⁻¹ ≡ 1 (mod p)` over 4096 random inputs (built
   with `useSafeGcdInverse=false` so both inverses are present and genuinely compared).
 - **`Fuse8GpuHashParityTest`** — the pure-Java filter-hash contract the kernel filter must match.
+- **`ProbeAddressesManySeedsOpenCLTest`** — the hardened many-seed gate: builds the kernel with
+  `useReducedRadixField` **off and on** and derives 16 random bases × 256 keys each (varied bit sizes),
+  verifying every key against bitcoinj. Widens the input space beyond the single fixed seed so a
+  representation-specific carry/magnitude bug (a *silently missed* key, not a crash) is caught.
+- **`OpenCLKernelModeMatrixTest`** — builds+runs the reduced-radix *interactions* not covered above
+  (the 2²⁶ walk feeding the legacy inverse, verified vs bitcoinj; the 2²⁶ walk under each profiling
+  stage, build+run only).
 
 **Never report a speedup from a build whose parity tests have not passed.** This is the cryptographic
 hot path; correctness is paramount.
+
+### Compile-time kernel modes — what selects them and how each is gated
+
+The kernel has exactly **three** externally toggleable compile-time switches (each a `CProducerOpenCL`
+field → a `-D` define in `OpenCLContext.buildOptions()`), plus the legacy-inverse switch in the
+vendored field file. **Both states of every switch are built and run on a device by some test.**
+"Correctness" means byte-compared against bitcoinj; the profiling modes deliberately emit wrong hashes
+(timing only), so for them the test can only assert the branch *compiles and runs*.
+
+| Build define | Config field | Default | OFF gated by | ON gated by | Correctness checkable? |
+|---|---|---|---|---|---|
+| *(none)* / `-D USE_LEGACY_BINARY_GCD_INV_MOD` | `useSafeGcdInverse` | safegcd | every `@OpenCLTest` (safegcd) | `OpenCLPrecomputeKernelTest#invModSafegcd_…` (built legacy) + `OpenCLKernelModeMatrixTest` | yes (both, vs bitcoinj / `x·x⁻¹≡1`) |
+| `-D USE_REDUCED_RADIX_FIELD` | `useReducedRadixField` | radix-2³² | every `@OpenCLTest` + `ProbeAddressesManySeedsOpenCLTest` | `ProbeAddressesManySeedsOpenCLTest` + `OpenCLKernelModeMatrixTest` | yes (both, vs bitcoinj) |
+| `-D PROFILE_SKIP_SECOND_HASH160` | `kernelProfileStage=ONE_HASH160` | `FULL` | every FULL test | `OpenCLContextTest#kernelProfileStage_buildsAndRuns` + `OpenCLKernelModeMatrixTest` | build+run only (mode emits wrong hashes by design) |
+| `-D PROFILE_SKIP_HASH160` | `kernelProfileStage=NO_HASH160` | `FULL` | every FULL test | `OpenCLContextTest#kernelProfileStage_buildsAndRuns` + `OpenCLKernelModeMatrixTest` | build+run only (mode emits wrong hashes by design) |
+
+Non-toggles in `inc_ecc_secp256k1custom.cl` (for completeness, not config-driven):
+`REUSE_FOR_COMPRESSED` is unconditionally `#define`d, so only its active branch ever compiles (its
+`#else` is dead code); `#if defined(__builtin_bswap32)` is platform autodetect, so only the branch the
+build platform selects is compiled. Both active branches run in every test.
+
+Honest scope: the **full cross-product** of all switches (3×2×3 = 18 distinct builds) is **not**
+exhaustively tested — every distinct `-D` set is a fresh kernel build, and a class that built all of
+them would exceed the Surefire per-fork timeout. Each switch is covered in both states, and the
+reduced-radix interactions (the genuinely new code) are covered explicitly; the remaining
+combinations are orthogonal `#ifdef` regions (inverse selection in the field file, profiling in the
+hashing tail, radix in the walk). As with the rest of this section, these are `@OpenCLTest` classes:
+they run in CI's `test-opencl` (pocl) job and on a local GPU, and self-skip on the no-device matrix.
 
 ### Reproducibility map (every stage → how to re-measure → how it's gated)
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -667,6 +667,7 @@ hot path; correctness is paramount.
 | — | occupancy / register pressure | grep init log for `Kernel resource usage:` (§6); `logGpuDiagnostics=true` for the verbose build log | — |
 | — | suggested starting config | run `OpenCLInfo` (or grep init log) for `SUGGESTED START CONFIG` (§6); pure helper `OpenClConfigSuggestion` | `OpenClConfigSuggestionTest`, `OpenCLDeviceTest` |
 | — | `KEYS_BATCH_INV` sweep | edit the `#define`, `GpuFuse8FilterBenchmark` (§3) | `ProbeAddressesOpenCLTest` |
+| — | reduced-radix 2²⁶ field multiply (isolated; §8) | `FieldMulBenchmark -p useReducedRadix=true,false` | `OpenCLFe10x26ParityTest` (`test_fe10x26`, 8192 pairs, byte-identical to radix-2³²) |
 
 **Honest caveat on A/B reproducibility:** only Stage 4 has a build-time toggle
 (`useSafeGcdInverse`), so its A/B is a single JMH run. Stages 2b and 3 are unconditional (no flag, per
@@ -751,6 +752,52 @@ is forbidden — both address types are mandatory).
   branch/addressing overhead, so it loses. Reverted. Could be revisited on a *multiply-bound* device
   (or paired with a reduced-radix representation that shortens the add chain).
 
+### Implemented & measured building block — reduced-radix 2²⁶ field (not yet in the hot path)
+
+The #1 EC lever (below) is no longer purely theoretical: the reduced-radix field arithmetic is
+**implemented, parity-proven, and benchmarked in isolation**. What is *not* yet done is wiring it into
+the production scalar-multiply / point-addition walk — that is the remaining (large) step.
+
+- **What was built.** `src/main/resources/inc_ecc_secp256k1_fe10x26.cl` — a self-contained OpenCL port
+  of libsecp256k1's `field_10x26_impl.h` (Pieter Wuille, MIT): `fe10x26_mul`, `fe10x26_sqr`,
+  `fe10x26_normalize`, `fe10x26_add`, `fe10x26_negate`, plus a **compatibility layer**
+  (`fe10x26_from_u32x8` / `fe10x26_to_u32x8`) that converts between the 2²⁶ form and the radix-2³²
+  `u32[8]` form used everywhere else (and by hashcat: limb 0 = least-significant 32 bits). The vendored
+  `copyfromhashcat/inc_ecc_secp256k1.cl` is **untouched** and the new file is written in the same
+  hashcat dialect (`DECLSPEC`, `u32`/`u64`, `PRIVATE_AS`), so it could be dropped into a hashcat tree.
+- **Correctness (gated).** `test_fe10x26` kernel + `OpenCLFe10x26ParityTest` run **8192** deterministic
+  pseudo-random operand pairs and assert the 2²⁶ path is **byte-identical** to the radix-2³² reference
+  for roundtrip, multiply, square, add, and subtract. Passes on the RTX 3070 (and under pocl in CI).
+- **Measured speed (RTX 3070 Laptop, isolated).** `FieldMulBenchmark` → `bench_fe_mul` kernel chains
+  `iterations` field multiplies per work-item over a full grid (`gridSizeInBits=18`, `iterations=4096`),
+  keeping coordinates in their native form for the whole chain (the 2²⁶ arm converts in/out only once):
+
+  | field multiply         | throughput (ops/s) | relative |
+  |------------------------|--------------------|----------|
+  | reduced-radix 2²⁶      | **10.20**          | **1.56×** |
+  | radix-2³² `mul_mod`    | 6.53               | 1.00×    |
+
+  ~**1.56× faster** field multiply, confirming the carry-bound diagnosis (the `sqr_mod` finding above).
+  Not a thermal artifact: the radix-2³² arm measured **6.57** when run *cold* in its own fresh JVM
+  (vs 6.53 when run second/hot), and per-iteration variance was tiny (6.52–6.57). Reproduce:
+
+  ```bash
+  # after: mvn -q dependency:build-classpath -Dmdep.outputFile=target/cp-test.txt -DincludeScope=test
+  java <add-opens from §5/pom.xml> -cp "target/test-classes;target/classes;$(cat target/cp-test.txt)" \
+       org.openjdk.jmh.Main FieldMulBenchmark -p gridSizeInBits=18 -p iterations=4096 -f 1 -wi 1 -w 20 -i 3 -r 50
+  ```
+
+- **What remains (the actual Stage).** Convert the hot path (the comb anchor, the affine
+  batched-addition walk, `point_add`/`point_double`/`point_to_affine`, and the Montgomery
+  simultaneous-inversion chain) to hold coordinates in 2²⁶ form, converting only at kernel
+  input/output, and reuse the existing `inv_mod` via the conversion layer (or port `modinv32`'s 2²⁶
+  path). The **1.56× is the multiply in isolation**; end-to-end it will be diluted by hashing (~43%,
+  §6) and the non-multiply EC work, and *helped* by lower register pressure (fewer live wide
+  temporaries → better occupancy, §6). Net end-to-end gain **must be measured** with a fresh
+  `keysPerWorkItem` sweep. This is gated and low-risk to *add* (the module is proven); the risk is all
+  in the hot-path rewrite, which changes address-derivation correctness and so needs the full
+  `ProbeAddressesOpenCLTest` 43/0 gate plus the parity kernel.
+
 ### Candidates for a future stage
 
 Evaluated during the investigation (re-sweep `keysPerWorkItem` after any of these, since the per-key
@@ -765,8 +812,10 @@ cost balance shifts):
   micro-optimisation, or sharing more work between the uncompressed and compressed chains (they share
   the X coordinate; the compressed SEC prefix transform is already reused via `REUSE_FOR_COMPRESSED`),
   is the lever here — without ever dropping a chain. Both chains always run.
-- **Reduced-radix field representation — the #1 lever, corroborated by an external review.** The EC
-  side is ~57% (§6) and the field multiply is carry/add-bound (the `sqr_mod` result). A reduced-radix
+- **Reduced-radix field representation — the #1 lever; the field module is now built & measured
+  (see "Implemented & measured building block" above), hot-path integration is what remains.** The EC
+  side is ~57% (§6) and the field multiply is carry/add-bound (the `sqr_mod` result, now also confirmed
+  the other way: the 2²⁶ multiply measured ~1.56× faster in isolation). A reduced-radix
   layout stores 256 bits in limbs narrower than the word (e.g. **10×26-bit** for a 32-bit GPU, or
   5×52-bit for 64-bit), so additive overflow lands in the spare bits and **carries are deferred**
   instead of propagated every limb; reconciliation happens only inside `mul`/`sqr` or at an explicit
@@ -829,9 +878,6 @@ cost balance shifts):
   memory (64 KB fits, but competes with `g_precomputed`). The current `T[pos][digit]` read is
   secret-keyed (data-dependent, not a warp broadcast) — cache-resident and occupancy-hidden, but
   benchmark alternatives per device.
-- **Optional single-hash (compressed-only) mode:** skip one of the two hash160 chains (~+15% if
-  hashing ~30% of runtime) — but it is a coverage/semantics change (would miss uncompressed P2PKH
-  hits), so it must be opt-in and clearly documented.
 - **±P symmetry** (one addition yields `P` and `−P`): random-search mode only — for sequential range
   scanning the `−P` keys fall outside the scanned range.
 - **Rejected:** GLV endomorphism (subsumed by the fixed-base comb, which already removes almost all

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
@@ -142,4 +142,22 @@ public class CProducerOpenCL extends CProducer {
      * pressure").
      */
     public boolean logGpuDiagnostics = false;
+
+    /**
+     * Selects the field-arithmetic representation used in the scalar-walker hot loop.
+     * <p>
+     * When {@code false} (default), the affine batched-addition walk computes coordinates in the
+     * vendored radix-2³² field ({@code copyfromhashcat/inc_ecc_secp256k1.cl}). When {@code true}, the
+     * kernel is built with {@code -D USE_REDUCED_RADIX_FIELD} and the walk holds coordinates in the
+     * reduced-radix 2²⁶ field ({@code inc_ecc_secp256k1_fe10x26.cl}), converting to radix-2³² only at
+     * the increment-table reads, the single per-sub-batch inverse, and the coordinate outputs.
+     * <p>
+     * Motivation: the radix-2³² field multiply is carry-bound; the isolated {@code FieldMulBenchmark}
+     * measured the 2²⁶ multiply ≈ 1.56× faster on an RTX 3070. The comb anchor and the
+     * {@code copyfromhashcat} files are unchanged either way. Off by default until the end-to-end gain
+     * is confirmed per device; correctness is identical (gated against bitcoinj by
+     * {@code ProbeAddressesOpenCLTest} / {@code ProbeAddressesManySeedsOpenCLTest} with the flag on).
+     * See {@code docs/performance.md} ("reduced-radix 2²⁶ field").
+     */
+    public boolean useReducedRadixField = false;
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -123,9 +123,18 @@ public class OpenCLContext implements ReleaseCLObject {
      * trivial to A/B and revert.
      *
      * <ul>
-     *   <li>{@code -cl-std=CL2.0} — the kernel's compact mode already relies on OpenCL 2.0
-     *       {@code atomic_add} on global memory; pinning the language standard makes that explicit
-     *       rather than depending on the driver's default (CL1.2).</li>
+     *   <li>{@code -cl-std=CL1.2} — pins the OpenCL C language version. The kernel only uses features
+     *       available in OpenCL C 1.1/1.2: the compact-mode counter is the <b>extension</b>
+     *       {@code atomic_add} on global {@code int} (core since OpenCL C 1.1, advertised by every
+     *       target via {@code cl_khr_global_int32_base_atomics}); the hashcat {@code IS_OPENCL} path
+     *       likewise uses the 1.1 {@code atomic_add}/{@code atomic_sub}/{@code atomic_or} (the C11
+     *       {@code atomic_*_explicit} forms are {@code IS_METAL}-only). It deliberately does <b>not</b>
+     *       force {@code CL2.0}: pocl's CPU device advertises only OpenCL C 1.2 (even on an OpenCL 3.0
+     *       platform) and rejects {@code -cl-std=CL2.0} with {@code CL_BUILD_PROGRAM_FAILURE}
+     *       ("device cpu doesn't support that OpenCL C version"), which broke the {@code test-opencl}
+     *       (pocl) CI job. {@code CL1.2} is accepted by every OpenCL 1.2+ device (pocl CPU and the
+     *       NVIDIA GPU alike). The compact-mode <em>device</em> version gate is separate and unchanged
+     *       (see {@link #REQUIRED_COMPACT_MODE_VERSION} / {@link #assertCompactModeDeviceVersionSupported}).</li>
      *   <li>{@code -cl-mad-enable} — permits fused multiply-add contraction. This kernel is
      *       integer-only so the effect is expected to be marginal, but it is harmless and part of
      *       the documented quick-win set (see docs/performance.md, "Stage 0").</li>
@@ -134,7 +143,7 @@ public class OpenCLContext implements ReleaseCLObject {
      * <p>Deliberately omits {@code -cl-fast-relaxed-math}: it only affects floating-point math, of
      * which this kernel has none.
      */
-    private static final String CL_BUILD_OPTIONS = "-cl-std=CL2.0 -cl-mad-enable";
+    private static final String CL_BUILD_OPTIONS = "-cl-std=CL1.2 -cl-mad-enable";
 
     /**
      * Build define that makes {@code inv_mod} fall back to the legacy binary-GCD modular inverse.

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -106,6 +106,11 @@ public class OpenCLContext implements ReleaseCLObject {
 
         resourceNames.add("copyfromhashcat/inc_ecc_secp256k1.h");
         resourceNames.add("copyfromhashcat/inc_ecc_secp256k1.cl");
+        // Reduced-radix 2^26 field module (our own file; does not touch copyfromhashcat). Provides the
+        // 10x26 multiply/square plus the u32[8] <-> 2^26 compatibility layer used by test_fe10x26 and
+        // FieldMulBenchmark. Must come after inc_ecc_secp256k1.* (it reuses u32/u64/PRIVATE_AS) and
+        // before the custom kernel file that references its symbols.
+        resourceNames.add("inc_ecc_secp256k1_fe10x26.cl");
         resourceNames.add("inc_ecc_secp256k1custom.cl");
         return resourceNames;
     }
@@ -705,6 +710,40 @@ public class OpenCLContext implements ReleaseCLObject {
             clSetKernelArg(benchKernel, 0, Sizeof.cl_mem, Pointer.to(out));
             clSetKernelArg(benchKernel, 1, Sizeof.cl_uint, Pointer.to(new int[] {iterations}));
             clSetKernelArg(benchKernel, 2, Sizeof.cl_uint, Pointer.to(new int[] {inputHighLimbsZero ? 1 : 0}));
+            clEnqueueNDRangeKernel(localQueue, benchKernel, 1, null, new long[] {globalWorkSize}, null, 0, null, null);
+            clFinish(localQueue);
+        } finally {
+            clReleaseMemObject(out);
+            clReleaseKernel(benchKernel);
+        }
+    }
+
+    /**
+     * Benchmark hook: launches the {@code bench_fe_mul} microbenchmark kernel (see
+     * {@code inc_ecc_secp256k1custom.cl}) over {@code globalWorkSize} work-items, each performing
+     * {@code iterations} chained field multiplies, and blocks until it finishes. Used by
+     * {@code FieldMulBenchmark} to compare the reduced-radix 2^26 field multiply against the vendored
+     * radix-2^32 {@code mul_mod}. The work is fully on the device (no result is read back). The output
+     * buffer and kernel are created and released per call.
+     *
+     * @param globalWorkSize  number of work-items (e.g. {@code 1 << gridSizeInBits})
+     * @param iterations      chained multiplies performed per work-item
+     * @param useReducedRadix {@code true} for the 2^26 field path, {@code false} for radix-2^32
+     *     {@code mul_mod}
+     */
+    @VisibleForTesting
+    public void runBenchFeMul(int globalWorkSize, int iterations, boolean useReducedRadix) {
+        final cl_context localContext = Objects.requireNonNull(context);
+        final cl_program localProgram = Objects.requireNonNull(program);
+        final cl_command_queue localQueue = Objects.requireNonNull(commandQueue);
+
+        final cl_kernel benchKernel = clCreateKernel(localProgram, "bench_fe_mul", null);
+        final cl_mem out =
+                clCreateBuffer(localContext, CL_MEM_WRITE_ONLY, (long) globalWorkSize * Sizeof.cl_uint, null, null);
+        try {
+            clSetKernelArg(benchKernel, 0, Sizeof.cl_mem, Pointer.to(out));
+            clSetKernelArg(benchKernel, 1, Sizeof.cl_uint, Pointer.to(new int[] {iterations}));
+            clSetKernelArg(benchKernel, 2, Sizeof.cl_uint, Pointer.to(new int[] {useReducedRadix ? 1 : 0}));
             clEnqueueNDRangeKernel(localQueue, benchKernel, 1, null, new long[] {globalWorkSize}, null, 0, null, null);
             clFinish(localQueue);
         } finally {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -157,11 +157,21 @@ public class OpenCLContext implements ReleaseCLObject {
     static final String NV_VERBOSE_BUILD_OPTION = "-cl-nv-verbose";
 
     /**
+     * Build define that switches the scalar-walker hot loop to the reduced-radix 2²⁶ field
+     * ({@code inc_ecc_secp256k1_fe10x26.cl}). Appended only when
+     * {@link CProducerOpenCL#useReducedRadixField} is {@code true}; the default walk uses the vendored
+     * radix-2³² field.
+     */
+    @VisibleForTesting
+    static final String REDUCED_RADIX_FIELD_BUILD_OPTION = "-D USE_REDUCED_RADIX_FIELD";
+
+    /**
      * Assembles the {@code clBuildProgram} options string: the constant {@link #CL_BUILD_OPTIONS},
      * plus {@link #LEGACY_BINARY_GCD_INV_MOD_BUILD_OPTION} when {@link CProducerOpenCL#useSafeGcdInverse}
      * is {@code false}, the profiling define for a non-{@code FULL}
-     * {@link CProducerOpenCL#kernelProfileStage}, and {@link #NV_VERBOSE_BUILD_OPTION} when
-     * {@link CProducerOpenCL#logGpuDiagnostics} is set.
+     * {@link CProducerOpenCL#kernelProfileStage}, {@link #NV_VERBOSE_BUILD_OPTION} when
+     * {@link CProducerOpenCL#logGpuDiagnostics} is set, and {@link #REDUCED_RADIX_FIELD_BUILD_OPTION}
+     * when {@link CProducerOpenCL#useReducedRadixField} is set.
      *
      * @return the build options string for this context's producer configuration
      */
@@ -184,6 +194,9 @@ public class OpenCLContext implements ReleaseCLObject {
         }
         if (producerOpenCL.logGpuDiagnostics) {
             options.append(' ').append(NV_VERBOSE_BUILD_OPTION);
+        }
+        if (producerOpenCL.useReducedRadixField) {
+            options.append(' ').append(REDUCED_RADIX_FIELD_BUILD_OPTION);
         }
         return options.toString();
     }

--- a/src/main/resources/inc_ecc_secp256k1_fe10x26.cl
+++ b/src/main/resources/inc_ecc_secp256k1_fe10x26.cl
@@ -191,6 +191,19 @@ DECLSPEC void fe10x26_negate(PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, const i
 }
 
 /*
+ * r = a - b (mod p), congruent only - NOT normalized. Computes a + (-b) via fe10x26_negate, so the
+ * caller must pass b's magnitude `mb` (b's limbs <= 2*mb*(2^26-1), n[9] <= 2*mb*(2^22-1)). The result
+ * has magnitude a.magnitude + mb + 1; normalize before lowering with fe10x26_to_u32x8, and keep that
+ * magnitude <= 8 if the result feeds straight into fe10x26_mul/fe10x26_sqr. r may alias a or b.
+ */
+DECLSPEC void fe10x26_sub(PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, PRIVATE_AS const u32 *b, const int mb)
+{
+  u32 neg[SECP256K1_FE10X26_NUM_LIMBS];
+  fe10x26_negate(neg, b, mb);
+  fe10x26_add(r, a, neg);
+}
+
+/*
  * r = a * b mod p. Port of secp256k1_fe_mul_inner. Inputs must have limbs
  * a[0..8],b[0..8] < 2^30 and a[9],b[9] < 2^26 (magnitude <= 8). Output is
  * magnitude 1 but only weakly normalized.

--- a/src/main/resources/inc_ecc_secp256k1_fe10x26.cl
+++ b/src/main/resources/inc_ecc_secp256k1_fe10x26.cl
@@ -1,0 +1,461 @@
+// @formatter:off
+// SPDX-FileCopyrightText: 2013-2014 Pieter Wuille (original field_10x26 implementation, libsecp256k1, MIT)
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com> (OpenCL port + compatibility layer)
+//
+// SPDX-License-Identifier: MIT
+// @formatter:on
+
+/*
+ * Reduced-radix secp256k1 field arithmetic in base 2^26 (10 limbs of 26 bits),
+ * an OpenCL C port of libsecp256k1's src/field_10x26_impl.h (Pieter Wuille, MIT).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The vendored copyfromhashcat/inc_ecc_secp256k1.cl field is radix-2^32 (8 fully
+ * packed u32 limbs). Its schoolbook multiply is carry-bound: every 32x32->64
+ * partial product immediately propagates a carry, so the field multiply is
+ * dominated by long add-with-carry dependency chains rather than by the
+ * multiplies themselves (this is why a dedicated sqr_mod measured *slower* on
+ * this kernel - see docs/performance.md). The reduced-radix 2^26 form leaves
+ * 6 spare bits in every 32-bit limb, so up to ~64 partial products can be
+ * accumulated in a 64-bit register before a single carry pass is needed. That
+ * defers carry propagation and is the representation libsecp256k1 itself uses
+ * for the 32-bit field. It is the #1 field-arithmetic lever identified in
+ * docs/performance.md.
+ *
+ * SCOPE / NON-GOALS
+ * -----------------
+ * This is a self-contained, drop-in field module. It deliberately does NOT
+ * modify copyfromhashcat/inc_ecc_secp256k1.cl: that file stays byte-for-byte
+ * hashcat-compatible. This file is written in the same hashcat dialect (DECLSPEC,
+ * u32/u64, PRIVATE_AS) so it could equally be dropped into a hashcat tree.
+ *
+ * COMPATIBILITY LAYER
+ * -------------------
+ * fe10x26_from_u32x8 / fe10x26_to_u32x8 convert between this 2^26 form and the
+ * radix-2^32 u32[8] form used everywhere else in the kernel (and by hashcat:
+ * limb 0 = least-significant 32 bits). They make the two representations
+ * interchangeable, so a caller can lift an existing u32[8] coordinate into 2^26
+ * form, run a chain of mul/sqr/add/negate cheaply, and lower the result back.
+ * This bridge is what the parity kernel (test_fe10x26) and FieldMulBenchmark
+ * exercise; it is proven byte-identical to the radix-2^32 path before any
+ * production hot path relies on it.
+ *
+ * REPRESENTATION
+ * --------------
+ * A field element is u32 n[10]; the value is sum(i=0..9, n[i] << (i*26)) mod p,
+ * p = 2^256 - 2^32 - 977. "Normalized" means n[i] < 2^26 for i=0..8,
+ * n[9] < 2^22, and the whole value is < p. Multiply/square inputs may carry a
+ * small "magnitude" (limbs up to ~2^30); their outputs are magnitude-1 but only
+ * weakly normalized (value may be >= p), so fe10x26_normalize must be called
+ * before fe10x26_to_u32x8. See the libsecp256k1 source for the full magnitude
+ * analysis; the VERIFY_BITS/VERIFY_CHECK assertions from the original are
+ * intentionally dropped here (they were debug-only bounds proofs).
+ */
+
+#define SECP256K1_FE10X26_NUM_LIMBS 10
+
+/*
+ * Lift a radix-2^32 field element (u32 w[8], limb 0 = least significant) into
+ * 2^26 form. Pure radix repack (no byte-endianness involved): both forms are
+ * little-endian numeric. The result limbs are < 2^26 (n[9] < 2^22) whenever the
+ * input value is < 2^256, i.e. the output is in normalized limb form.
+ */
+DECLSPEC void fe10x26_from_u32x8(PRIVATE_AS u32 *n, PRIVATE_AS const u32 *w)
+{
+  u64 acc = 0;
+  int bits = 0;
+  int wi = 0;
+
+  #pragma unroll
+  for (int i = 0; i < SECP256K1_FE10X26_NUM_LIMBS; i++)
+  {
+    // 32 > 26, so at most one source word is needed to top up each 26-bit limb.
+    if (bits < 26 && wi < 8)
+    {
+      acc |= ((u64) w[wi]) << bits;
+      bits += 32;
+      wi++;
+    }
+    n[i] = (u32) (acc & 0x3FFFFFF);
+    acc >>= 26;
+    bits -= 26;
+  }
+}
+
+/*
+ * Lower a NORMALIZED 2^26 field element back to radix-2^32 (u32 w[8], limb 0 =
+ * least significant). Requires each n[i] < 2^26 (i.e. the result of
+ * fe10x26_normalize); a weakly-normalized multiply/square output must be
+ * normalized first.
+ */
+DECLSPEC void fe10x26_to_u32x8(PRIVATE_AS u32 *w, PRIVATE_AS const u32 *n)
+{
+  u64 acc = 0;
+  int bits = 0;
+  int ni = 0;
+
+  #pragma unroll
+  for (int j = 0; j < 8; j++)
+  {
+    // 26 < 32, so up to two source limbs may be needed to fill a 32-bit word.
+    while (bits < 32 && ni < SECP256K1_FE10X26_NUM_LIMBS)
+    {
+      acc |= ((u64) n[ni]) << bits;
+      bits += 26;
+      ni++;
+    }
+    w[j] = (u32) (acc & 0xFFFFFFFF);
+    acc >>= 32;
+    bits -= 32;
+  }
+}
+
+/*
+ * Fully normalize r in place: reduce to magnitude 1 and into [0, p). Constant-time
+ * port of secp256k1_fe_impl_normalize (the final reduction is always applied).
+ */
+DECLSPEC void fe10x26_normalize(PRIVATE_AS u32 *r)
+{
+  u32 t0 = r[0], t1 = r[1], t2 = r[2], t3 = r[3], t4 = r[4],
+      t5 = r[5], t6 = r[6], t7 = r[7], t8 = r[8], t9 = r[9];
+
+  u32 m;
+  u32 x = t9 >> 22; t9 &= 0x03FFFFF;
+
+  t0 += x * 0x3D1; t1 += (x << 6);
+  t1 += (t0 >> 26); t0 &= 0x3FFFFFF;
+  t2 += (t1 >> 26); t1 &= 0x3FFFFFF;
+  t3 += (t2 >> 26); t2 &= 0x3FFFFFF; m = t2;
+  t4 += (t3 >> 26); t3 &= 0x3FFFFFF; m &= t3;
+  t5 += (t4 >> 26); t4 &= 0x3FFFFFF; m &= t4;
+  t6 += (t5 >> 26); t5 &= 0x3FFFFFF; m &= t5;
+  t7 += (t6 >> 26); t6 &= 0x3FFFFFF; m &= t6;
+  t8 += (t7 >> 26); t7 &= 0x3FFFFFF; m &= t7;
+  t9 += (t8 >> 26); t8 &= 0x3FFFFFF; m &= t8;
+
+  // At most a single final reduction is needed; check if value >= p.
+  x = (t9 >> 22) | ((t9 == 0x03FFFFF) & (m == 0x3FFFFFF)
+      & ((t1 + 0x40 + ((t0 + 0x3D1) >> 26)) > 0x3FFFFFF));
+
+  t0 += x * 0x3D1; t1 += (x << 6);
+  t1 += (t0 >> 26); t0 &= 0x3FFFFFF;
+  t2 += (t1 >> 26); t1 &= 0x3FFFFFF;
+  t3 += (t2 >> 26); t2 &= 0x3FFFFFF;
+  t4 += (t3 >> 26); t3 &= 0x3FFFFFF;
+  t5 += (t4 >> 26); t4 &= 0x3FFFFFF;
+  t6 += (t5 >> 26); t5 &= 0x3FFFFFF;
+  t7 += (t6 >> 26); t6 &= 0x3FFFFFF;
+  t8 += (t7 >> 26); t7 &= 0x3FFFFFF;
+  t9 += (t8 >> 26); t8 &= 0x3FFFFFF;
+
+  // Mask off the possible multiple of 2^256 from the final reduction.
+  t9 &= 0x03FFFFF;
+
+  r[0] = t0; r[1] = t1; r[2] = t2; r[3] = t3; r[4] = t4;
+  r[5] = t5; r[6] = t6; r[7] = t7; r[8] = t8; r[9] = t9;
+}
+
+/* r = a + b, limb-wise (no reduction). Magnitudes add; normalize before lowering. */
+DECLSPEC void fe10x26_add(PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, PRIVATE_AS const u32 *b)
+{
+  r[0] = a[0] + b[0];
+  r[1] = a[1] + b[1];
+  r[2] = a[2] + b[2];
+  r[3] = a[3] + b[3];
+  r[4] = a[4] + b[4];
+  r[5] = a[5] + b[5];
+  r[6] = a[6] + b[6];
+  r[7] = a[7] + b[7];
+  r[8] = a[8] + b[8];
+  r[9] = a[9] + b[9];
+}
+
+/*
+ * r = -a, valid when a has magnitude <= m (limbs <= 2*m*(2^26-1), n[9] <= 2*m*(2^22-1)).
+ * The result has magnitude m+1 and is congruent to -a mod p. Port of
+ * secp256k1_fe_impl_negate_unchecked.
+ */
+DECLSPEC void fe10x26_negate(PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, const int m)
+{
+  r[0] = 0x3FFFC2F * 2 * (m + 1) - a[0];
+  r[1] = 0x3FFFFBF * 2 * (m + 1) - a[1];
+  r[2] = 0x3FFFFFF * 2 * (m + 1) - a[2];
+  r[3] = 0x3FFFFFF * 2 * (m + 1) - a[3];
+  r[4] = 0x3FFFFFF * 2 * (m + 1) - a[4];
+  r[5] = 0x3FFFFFF * 2 * (m + 1) - a[5];
+  r[6] = 0x3FFFFFF * 2 * (m + 1) - a[6];
+  r[7] = 0x3FFFFFF * 2 * (m + 1) - a[7];
+  r[8] = 0x3FFFFFF * 2 * (m + 1) - a[8];
+  r[9] = 0x03FFFFF * 2 * (m + 1) - a[9];
+}
+
+/*
+ * r = a * b mod p. Port of secp256k1_fe_mul_inner. Inputs must have limbs
+ * a[0..8],b[0..8] < 2^30 and a[9],b[9] < 2^26 (magnitude <= 8). Output is
+ * magnitude 1 but only weakly normalized.
+ */
+DECLSPEC void fe10x26_mul(PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, PRIVATE_AS const u32 *b)
+{
+  u64 c, d;
+  u64 u0, u1, u2, u3, u4, u5, u6, u7, u8;
+  u32 t9, t1, t0, t2, t3, t4, t5, t6, t7;
+  const u32 M = 0x3FFFFFF, R0 = 0x3D10, R1 = 0x400;
+
+  d  = (u64) a[0] * b[9]
+     + (u64) a[1] * b[8]
+     + (u64) a[2] * b[7]
+     + (u64) a[3] * b[6]
+     + (u64) a[4] * b[5]
+     + (u64) a[5] * b[4]
+     + (u64) a[6] * b[3]
+     + (u64) a[7] * b[2]
+     + (u64) a[8] * b[1]
+     + (u64) a[9] * b[0];
+  t9 = (u32) (d & M); d >>= 26;
+
+  c  = (u64) a[0] * b[0];
+  d += (u64) a[1] * b[9]
+     + (u64) a[2] * b[8]
+     + (u64) a[3] * b[7]
+     + (u64) a[4] * b[6]
+     + (u64) a[5] * b[5]
+     + (u64) a[6] * b[4]
+     + (u64) a[7] * b[3]
+     + (u64) a[8] * b[2]
+     + (u64) a[9] * b[1];
+  u0 = d & M; d >>= 26; c += u0 * R0;
+  t0 = (u32) (c & M); c >>= 26; c += u0 * R1;
+
+  c += (u64) a[0] * b[1]
+     + (u64) a[1] * b[0];
+  d += (u64) a[2] * b[9]
+     + (u64) a[3] * b[8]
+     + (u64) a[4] * b[7]
+     + (u64) a[5] * b[6]
+     + (u64) a[6] * b[5]
+     + (u64) a[7] * b[4]
+     + (u64) a[8] * b[3]
+     + (u64) a[9] * b[2];
+  u1 = d & M; d >>= 26; c += u1 * R0;
+  t1 = (u32) (c & M); c >>= 26; c += u1 * R1;
+
+  c += (u64) a[0] * b[2]
+     + (u64) a[1] * b[1]
+     + (u64) a[2] * b[0];
+  d += (u64) a[3] * b[9]
+     + (u64) a[4] * b[8]
+     + (u64) a[5] * b[7]
+     + (u64) a[6] * b[6]
+     + (u64) a[7] * b[5]
+     + (u64) a[8] * b[4]
+     + (u64) a[9] * b[3];
+  u2 = d & M; d >>= 26; c += u2 * R0;
+  t2 = (u32) (c & M); c >>= 26; c += u2 * R1;
+
+  c += (u64) a[0] * b[3]
+     + (u64) a[1] * b[2]
+     + (u64) a[2] * b[1]
+     + (u64) a[3] * b[0];
+  d += (u64) a[4] * b[9]
+     + (u64) a[5] * b[8]
+     + (u64) a[6] * b[7]
+     + (u64) a[7] * b[6]
+     + (u64) a[8] * b[5]
+     + (u64) a[9] * b[4];
+  u3 = d & M; d >>= 26; c += u3 * R0;
+  t3 = (u32) (c & M); c >>= 26; c += u3 * R1;
+
+  c += (u64) a[0] * b[4]
+     + (u64) a[1] * b[3]
+     + (u64) a[2] * b[2]
+     + (u64) a[3] * b[1]
+     + (u64) a[4] * b[0];
+  d += (u64) a[5] * b[9]
+     + (u64) a[6] * b[8]
+     + (u64) a[7] * b[7]
+     + (u64) a[8] * b[6]
+     + (u64) a[9] * b[5];
+  u4 = d & M; d >>= 26; c += u4 * R0;
+  t4 = (u32) (c & M); c >>= 26; c += u4 * R1;
+
+  c += (u64) a[0] * b[5]
+     + (u64) a[1] * b[4]
+     + (u64) a[2] * b[3]
+     + (u64) a[3] * b[2]
+     + (u64) a[4] * b[1]
+     + (u64) a[5] * b[0];
+  d += (u64) a[6] * b[9]
+     + (u64) a[7] * b[8]
+     + (u64) a[8] * b[7]
+     + (u64) a[9] * b[6];
+  u5 = d & M; d >>= 26; c += u5 * R0;
+  t5 = (u32) (c & M); c >>= 26; c += u5 * R1;
+
+  c += (u64) a[0] * b[6]
+     + (u64) a[1] * b[5]
+     + (u64) a[2] * b[4]
+     + (u64) a[3] * b[3]
+     + (u64) a[4] * b[2]
+     + (u64) a[5] * b[1]
+     + (u64) a[6] * b[0];
+  d += (u64) a[7] * b[9]
+     + (u64) a[8] * b[8]
+     + (u64) a[9] * b[7];
+  u6 = d & M; d >>= 26; c += u6 * R0;
+  t6 = (u32) (c & M); c >>= 26; c += u6 * R1;
+
+  c += (u64) a[0] * b[7]
+     + (u64) a[1] * b[6]
+     + (u64) a[2] * b[5]
+     + (u64) a[3] * b[4]
+     + (u64) a[4] * b[3]
+     + (u64) a[5] * b[2]
+     + (u64) a[6] * b[1]
+     + (u64) a[7] * b[0];
+  d += (u64) a[8] * b[9]
+     + (u64) a[9] * b[8];
+  u7 = d & M; d >>= 26; c += u7 * R0;
+  t7 = (u32) (c & M); c >>= 26; c += u7 * R1;
+
+  c += (u64) a[0] * b[8]
+     + (u64) a[1] * b[7]
+     + (u64) a[2] * b[6]
+     + (u64) a[3] * b[5]
+     + (u64) a[4] * b[4]
+     + (u64) a[5] * b[3]
+     + (u64) a[6] * b[2]
+     + (u64) a[7] * b[1]
+     + (u64) a[8] * b[0];
+  d += (u64) a[9] * b[9];
+  u8 = d & M; d >>= 26; c += u8 * R0;
+
+  r[3] = t3;
+  r[4] = t4;
+  r[5] = t5;
+  r[6] = t6;
+  r[7] = t7;
+
+  r[8] = (u32) (c & M); c >>= 26; c += u8 * R1;
+  c   += d * R0 + t9;
+  r[9] = (u32) (c & (M >> 4)); c >>= 22; c += d * (R1 << 4);
+
+  d    = c * (R0 >> 4) + t0;
+  r[0] = (u32) (d & M); d >>= 26;
+  d   += c * (R1 >> 4) + t1;
+  r[1] = (u32) (d & M); d >>= 26;
+  d   += t2;
+  r[2] = (u32) d;
+}
+
+/*
+ * r = a^2 mod p. Port of secp256k1_fe_sqr_inner (same input/output magnitude
+ * contract as fe10x26_mul).
+ */
+DECLSPEC void fe10x26_sqr(PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a)
+{
+  u64 c, d;
+  u64 u0, u1, u2, u3, u4, u5, u6, u7, u8;
+  u32 t9, t0, t1, t2, t3, t4, t5, t6, t7;
+  const u32 M = 0x3FFFFFF, R0 = 0x3D10, R1 = 0x400;
+
+  d  = (u64) (a[0] * 2) * a[9]
+     + (u64) (a[1] * 2) * a[8]
+     + (u64) (a[2] * 2) * a[7]
+     + (u64) (a[3] * 2) * a[6]
+     + (u64) (a[4] * 2) * a[5];
+  t9 = (u32) (d & M); d >>= 26;
+
+  c  = (u64) a[0] * a[0];
+  d += (u64) (a[1] * 2) * a[9]
+     + (u64) (a[2] * 2) * a[8]
+     + (u64) (a[3] * 2) * a[7]
+     + (u64) (a[4] * 2) * a[6]
+     + (u64) a[5] * a[5];
+  u0 = d & M; d >>= 26; c += u0 * R0;
+  t0 = (u32) (c & M); c >>= 26; c += u0 * R1;
+
+  c += (u64) (a[0] * 2) * a[1];
+  d += (u64) (a[2] * 2) * a[9]
+     + (u64) (a[3] * 2) * a[8]
+     + (u64) (a[4] * 2) * a[7]
+     + (u64) (a[5] * 2) * a[6];
+  u1 = d & M; d >>= 26; c += u1 * R0;
+  t1 = (u32) (c & M); c >>= 26; c += u1 * R1;
+
+  c += (u64) (a[0] * 2) * a[2]
+     + (u64) a[1] * a[1];
+  d += (u64) (a[3] * 2) * a[9]
+     + (u64) (a[4] * 2) * a[8]
+     + (u64) (a[5] * 2) * a[7]
+     + (u64) a[6] * a[6];
+  u2 = d & M; d >>= 26; c += u2 * R0;
+  t2 = (u32) (c & M); c >>= 26; c += u2 * R1;
+
+  c += (u64) (a[0] * 2) * a[3]
+     + (u64) (a[1] * 2) * a[2];
+  d += (u64) (a[4] * 2) * a[9]
+     + (u64) (a[5] * 2) * a[8]
+     + (u64) (a[6] * 2) * a[7];
+  u3 = d & M; d >>= 26; c += u3 * R0;
+  t3 = (u32) (c & M); c >>= 26; c += u3 * R1;
+
+  c += (u64) (a[0] * 2) * a[4]
+     + (u64) (a[1] * 2) * a[3]
+     + (u64) a[2] * a[2];
+  d += (u64) (a[5] * 2) * a[9]
+     + (u64) (a[6] * 2) * a[8]
+     + (u64) a[7] * a[7];
+  u4 = d & M; d >>= 26; c += u4 * R0;
+  t4 = (u32) (c & M); c >>= 26; c += u4 * R1;
+
+  c += (u64) (a[0] * 2) * a[5]
+     + (u64) (a[1] * 2) * a[4]
+     + (u64) (a[2] * 2) * a[3];
+  d += (u64) (a[6] * 2) * a[9]
+     + (u64) (a[7] * 2) * a[8];
+  u5 = d & M; d >>= 26; c += u5 * R0;
+  t5 = (u32) (c & M); c >>= 26; c += u5 * R1;
+
+  c += (u64) (a[0] * 2) * a[6]
+     + (u64) (a[1] * 2) * a[5]
+     + (u64) (a[2] * 2) * a[4]
+     + (u64) a[3] * a[3];
+  d += (u64) (a[7] * 2) * a[9]
+     + (u64) a[8] * a[8];
+  u6 = d & M; d >>= 26; c += u6 * R0;
+  t6 = (u32) (c & M); c >>= 26; c += u6 * R1;
+
+  c += (u64) (a[0] * 2) * a[7]
+     + (u64) (a[1] * 2) * a[6]
+     + (u64) (a[2] * 2) * a[5]
+     + (u64) (a[3] * 2) * a[4];
+  d += (u64) (a[8] * 2) * a[9];
+  u7 = d & M; d >>= 26; c += u7 * R0;
+  t7 = (u32) (c & M); c >>= 26; c += u7 * R1;
+
+  c += (u64) (a[0] * 2) * a[8]
+     + (u64) (a[1] * 2) * a[7]
+     + (u64) (a[2] * 2) * a[6]
+     + (u64) (a[3] * 2) * a[5]
+     + (u64) a[4] * a[4];
+  d += (u64) a[9] * a[9];
+  u8 = d & M; d >>= 26; c += u8 * R0;
+
+  r[3] = t3;
+  r[4] = t4;
+  r[5] = t5;
+  r[6] = t6;
+  r[7] = t7;
+
+  r[8] = (u32) (c & M); c >>= 26; c += u8 * R1;
+  c   += d * R0 + t9;
+  r[9] = (u32) (c & (M >> 4)); c >>= 22; c += d * (R1 << 4);
+
+  d    = c * (R0 >> 4) + t0;
+  r[0] = (u32) (d & M); d >>= 26;
+  d   += c * (R1 >> 4) + t1;
+  r[1] = (u32) (d & M); d >>= 26;
+  d   += t2;
+  r[2] = (u32) d;
+}

--- a/src/main/resources/inc_ecc_secp256k1custom.cl
+++ b/src/main/resources/inc_ecc_secp256k1custom.cl
@@ -907,9 +907,25 @@ __kernel void generateKeysKernel_grid(
     k_littleEndian_local[0] = (baseK0 | base_offset);
     point_mul_xy_comb(x0, y0, k_littleEndian_local, comb_table);
 
+#ifdef USE_REDUCED_RADIX_FIELD
+    // Reduced-radix 2^26 walk (inc_ecc_secp256k1_fe10x26.cl): the comb anchor x0/y0 stays radix-2^32
+    // (it is computed once), but the per-key slope arithmetic runs in 2^26. Convert the anchor once;
+    // the increment-table reads, the single per-sub-batch inverse, and the coordinate outputs convert
+    // at their boundaries. All field elements stay within libsecp's magnitude bounds (<= 8 for mul
+    // inputs), so the only normalizes are immediately before lowering a coordinate to radix-2^32.
+    u32 nx0[SECP256K1_FE10X26_NUM_LIMBS];
+    u32 ny0[SECP256K1_FE10X26_NUM_LIMBS];
+    fe10x26_from_u32x8(nx0, x0);
+    fe10x26_from_u32x8(ny0, y0);
+
+    // Per-sub-batch scratch: dx_m denominators and their Montgomery prefix products (2^26 limbs).
+    u32 dx[KEYS_BATCH_INV][SECP256K1_FE10X26_NUM_LIMBS];
+    u32 prefix[KEYS_BATCH_INV][SECP256K1_FE10X26_NUM_LIMBS];
+#else
     // Per-sub-batch scratch: dx_m denominators and their Montgomery prefix products.
     u32 dx[KEYS_BATCH_INV][ONE_COORDINATE_NUM_WORDS];
     u32 prefix[KEYS_BATCH_INV][ONE_COORDINATE_NUM_WORDS];
+#endif
 
     for (u32 done = 0; done < keysPerWorkItem; done += KEYS_BATCH_INV) {
         u32 count = keysPerWorkItem - done;
@@ -918,6 +934,38 @@ __kernel void generateKeysKernel_grid(
         }
 
         // ---- Pass A: dx_m = x_{mG} - x0 and Montgomery prefix products of dx ----
+#ifdef USE_REDUCED_RADIX_FIELD
+        u32 acc[SECP256K1_FE10X26_NUM_LIMBS] = { 0 };
+        acc[0] = 1; // field element 1, normalized
+        for (u32 j = 0; j < count; j++) {
+            u32 m = done + j;
+            copy_private_u32_array_private_u32(prefix[j], acc, SECP256K1_FE10X26_NUM_LIMBS);
+            if (m == 0) {
+                // P0 itself has no slope; contribute the multiplicative identity to the product.
+                dx[j][0] = 1;
+                #pragma unroll
+                for (int w = 1; w < SECP256K1_FE10X26_NUM_LIMBS; w++) {
+                    dx[j][w] = 0;
+                }
+            } else {
+                u32 gx[ONE_COORDINATE_NUM_WORDS];
+                u32 ig_base = (m - 1) * TWO_COORDINATE_NUM_WORDS; // 16 words per table entry
+                copy_global_u32_array_private_u32(gx, &iG_table[ig_base], ONE_COORDINATE_NUM_WORDS);
+                u32 ngx[SECP256K1_FE10X26_NUM_LIMBS];
+                fe10x26_from_u32x8(ngx, gx);
+                fe10x26_sub(dx[j], ngx, nx0, 1); // dx_m = x_{mG} - x0 (magnitude 3)
+            }
+            fe10x26_mul(acc, acc, dx[j]); // acc = dx_0 * ... * dx_j (magnitude 1)
+        }
+
+        // ---- one modular inverse for the whole sub-batch (done in radix-2^32 via the conversion
+        //      layer; reuses the build-selected safegcd/legacy inv_mod) ----
+        u32 accU[ONE_COORDINATE_NUM_WORDS];
+        fe10x26_normalize(acc);
+        fe10x26_to_u32x8(accU, acc);
+        inv_mod(accU); // accU = 1 / (dx_0 * ... * dx_{count-1})
+        fe10x26_from_u32x8(acc, accU);
+#else
         u32 acc[ONE_COORDINATE_NUM_WORDS] = { 0 };
         acc[0] = 1;
         for (u32 j = 0; j < count; j++) {
@@ -941,11 +989,57 @@ __kernel void generateKeysKernel_grid(
 
         // ---- one modular inverse for the whole sub-batch ----
         inv_mod(acc); // acc = 1 / (dx_0 * ... * dx_{count-1})
+#endif
 
         // ---- Pass B (reverse): recover each 1/dx_m, apply the affine slope formula, emit ----
         for (int j = (int) count - 1; j >= 0; j--) {
             u32 m = done + (u32) j;
 
+#ifdef USE_REDUCED_RADIX_FIELD
+            u32 inv_dx[SECP256K1_FE10X26_NUM_LIMBS];
+            fe10x26_mul(inv_dx, acc, prefix[j]); // 1/dx_m = (1/product) * (dx_0..dx_{j-1})
+            fe10x26_mul(acc, acc, dx[j]);        // strip dx_m: acc = 1 / (dx_0..dx_{j-1})
+
+            if (m == 0) {
+                // Emit the anchor P0 directly (inv_dx unused for this single key); x0/y0 are still in
+                // radix-2^32 from the comb, so no conversion is needed.
+                copy_private_u32_array_private_u32(x_littleEndian_local, x0, ONE_COORDINATE_NUM_WORDS);
+                copy_private_u32_array_private_u32(y_littleEndian_local, y0, ONE_COORDINATE_NUM_WORDS);
+            } else {
+                u32 gx[ONE_COORDINATE_NUM_WORDS];
+                u32 gy[ONE_COORDINATE_NUM_WORDS];
+                u32 ig_base = (m - 1) * TWO_COORDINATE_NUM_WORDS;
+                copy_global_u32_array_private_u32(gx, &iG_table[ig_base], ONE_COORDINATE_NUM_WORDS);
+                copy_global_u32_array_private_u32(gy, &iG_table[ig_base + ONE_COORDINATE_NUM_WORDS], ONE_COORDINATE_NUM_WORDS);
+                u32 ngx[SECP256K1_FE10X26_NUM_LIMBS];
+                u32 ngy[SECP256K1_FE10X26_NUM_LIMBS];
+                fe10x26_from_u32x8(ngx, gx);
+                fe10x26_from_u32x8(ngy, gy);
+
+                // Affine slope law in 2^26. Magnitudes (mul/sqr inputs must stay <= 8): num=3,
+                // lambda/lam2=1, xr=3 then 5, t=7 then 1, ynew=3. Only the two emitted coordinates
+                // are normalized + lowered to radix-2^32.
+                u32 num[SECP256K1_FE10X26_NUM_LIMBS];
+                u32 lambda[SECP256K1_FE10X26_NUM_LIMBS];
+                u32 lam2[SECP256K1_FE10X26_NUM_LIMBS];
+                u32 t[SECP256K1_FE10X26_NUM_LIMBS];
+                u32 xr[SECP256K1_FE10X26_NUM_LIMBS];
+                u32 ynew[SECP256K1_FE10X26_NUM_LIMBS];
+                fe10x26_sub(num, ngy, ny0, 1);   // y_{mG} - y0           (mag 3)
+                fe10x26_mul(lambda, num, inv_dx);// λ = (y_{mG} - y0)/dx_m (mag 1)
+                fe10x26_sqr(lam2, lambda);       // λ^2                    (mag 1)
+                fe10x26_sub(xr, lam2, ngx, 1);   // λ^2 - x_{mG}           (mag 3)
+                fe10x26_sub(xr, xr, nx0, 1);     // x_m = λ^2 - x_{mG} - x0 (mag 5)
+                fe10x26_sub(t, nx0, xr, 5);      // x0 - x_m               (mag 7)
+                fe10x26_mul(t, lambda, t);       // λ(x0 - x_m)            (mag 1)
+                fe10x26_sub(ynew, t, ny0, 1);    // y_m = λ(x0 - x_m) - y0 (mag 3)
+
+                fe10x26_normalize(xr);
+                fe10x26_to_u32x8(x_littleEndian_local, xr);
+                fe10x26_normalize(ynew);
+                fe10x26_to_u32x8(y_littleEndian_local, ynew);
+            }
+#else
             u32 inv_dx[ONE_COORDINATE_NUM_WORDS];
             mul_mod(inv_dx, acc, prefix[j]); // 1/dx_m = (1/product) * (dx_0..dx_{j-1})
             mul_mod(acc, acc, dx[j]);        // strip dx_m: acc = 1 / (dx_0..dx_{j-1})
@@ -974,6 +1068,7 @@ __kernel void generateKeysKernel_grid(
                 mul_mod(t, lambda, t);                                   // λ(x0 - x_m)
                 sub_mod(y_littleEndian_local, t, y0);                    // y_m = λ(x0 - x_m) - y0
             }
+#endif
 
             u32 loop_index = base_offset + m;
 

--- a/src/main/resources/inc_ecc_secp256k1custom.cl
+++ b/src/main/resources/inc_ecc_secp256k1custom.cl
@@ -1169,3 +1169,166 @@ __kernel void bench_inv_mod(__global u32 *out, const u32 iterations, const u32 i
 
     out[gid] = checksum;
 }
+
+/*
+ * Validation kernel (test scaffolding, not used in production): proves the reduced-radix 2^26 field
+ * module (inc_ecc_secp256k1_fe10x26.cl) is byte-identical to the vendored radix-2^32 field, so it can
+ * be trusted as a drop-in. Single work-item, loops over `count` deterministic pseudo-random operand
+ * pairs (x, y), each fully reduced into [0, p) via mul_mod(., ., 1). out[i] is a failure bitmask,
+ * 0 == pass:
+ *   bit 0 (1):  roundtrip   to_u32x8(from_u32x8(x)) != x
+ *   bit 1 (2):  multiply    fe10x26_mul(x, y) != mul_mod(x, y)
+ *   bit 2 (4):  square      fe10x26_sqr(x)    != mul_mod(x, x)
+ *   bit 3 (8):  add         fe10x26_add(x, y) != add_mod(x, y)
+ *   bit 4 (16): subtract    fe10x26 (x + (-y)) != sub_mod(x, y)
+ */
+__kernel void test_fe10x26(__global u32 *out, const u32 count)
+{
+    u32 one[ONE_COORDINATE_NUM_WORDS] = { 0 };
+    one[0] = 1;
+
+    for (u32 i = 0; i < count; i++) {
+        // Two independent xorshift streams -> x and y, then reduce each into [0, p).
+        u32 x[ONE_COORDINATE_NUM_WORDS];
+        u32 y[ONE_COORDINATE_NUM_WORDS];
+        u32 sx = i * 2654435761u + 0x9e3779b9u;
+        u32 sy = i * 40503u + 0x85ebca6bu;
+        for (int j = 0; j < ONE_COORDINATE_NUM_WORDS; j++) {
+            sx ^= sx << 13; sx ^= sx >> 17; sx ^= sx << 5; x[j] = sx;
+            sy ^= sy << 13; sy ^= sy >> 17; sy ^= sy << 5; y[j] = sy;
+        }
+        mul_mod(x, x, one); // x = x mod p
+        mul_mod(y, y, one); // y = y mod p
+
+        u32 status = 0;
+
+        u32 nx[10];
+        u32 ny[10];
+        fe10x26_from_u32x8(nx, x);
+        fe10x26_from_u32x8(ny, y);
+
+        // (1) roundtrip
+        {
+            u32 n[10];
+            for (int j = 0; j < 10; j++) n[j] = nx[j];
+            fe10x26_normalize(n);
+            u32 w[ONE_COORDINATE_NUM_WORDS];
+            fe10x26_to_u32x8(w, n);
+            u32 diff = 0;
+            for (int j = 0; j < ONE_COORDINATE_NUM_WORDS; j++) diff |= (w[j] ^ x[j]);
+            if (diff != 0) status |= 1u;
+        }
+
+        // (2) multiply
+        {
+            u32 n[10];
+            fe10x26_mul(n, nx, ny);
+            fe10x26_normalize(n);
+            u32 w[ONE_COORDINATE_NUM_WORDS];
+            fe10x26_to_u32x8(w, n);
+            u32 ref[ONE_COORDINATE_NUM_WORDS];
+            mul_mod(ref, x, y);
+            u32 diff = 0;
+            for (int j = 0; j < ONE_COORDINATE_NUM_WORDS; j++) diff |= (w[j] ^ ref[j]);
+            if (diff != 0) status |= 2u;
+        }
+
+        // (3) square
+        {
+            u32 n[10];
+            fe10x26_sqr(n, nx);
+            fe10x26_normalize(n);
+            u32 w[ONE_COORDINATE_NUM_WORDS];
+            fe10x26_to_u32x8(w, n);
+            u32 ref[ONE_COORDINATE_NUM_WORDS];
+            mul_mod(ref, x, x);
+            u32 diff = 0;
+            for (int j = 0; j < ONE_COORDINATE_NUM_WORDS; j++) diff |= (w[j] ^ ref[j]);
+            if (diff != 0) status |= 4u;
+        }
+
+        // (4) add
+        {
+            u32 n[10];
+            fe10x26_add(n, nx, ny);
+            fe10x26_normalize(n);
+            u32 w[ONE_COORDINATE_NUM_WORDS];
+            fe10x26_to_u32x8(w, n);
+            u32 ref[ONE_COORDINATE_NUM_WORDS];
+            add_mod(ref, x, y);
+            u32 diff = 0;
+            for (int j = 0; j < ONE_COORDINATE_NUM_WORDS; j++) diff |= (w[j] ^ ref[j]);
+            if (diff != 0) status |= 8u;
+        }
+
+        // (5) subtract via negate + add (ny is normalized, magnitude 1)
+        {
+            u32 neg[10];
+            fe10x26_negate(neg, ny, 1);
+            u32 n[10];
+            fe10x26_add(n, nx, neg);
+            fe10x26_normalize(n);
+            u32 w[ONE_COORDINATE_NUM_WORDS];
+            fe10x26_to_u32x8(w, n);
+            u32 ref[ONE_COORDINATE_NUM_WORDS];
+            sub_mod(ref, x, y);
+            u32 diff = 0;
+            for (int j = 0; j < ONE_COORDINATE_NUM_WORDS; j++) diff |= (w[j] ^ ref[j]);
+            if (diff != 0) status |= 16u;
+        }
+
+        out[i] = status;
+    }
+}
+
+/*
+ * Microbenchmark kernel (test scaffolding, not used in production): each work-item performs
+ * `iterations` chained field multiplies and XOR-accumulates a checksum so the compiler cannot elide
+ * the work. `useReducedRadix != 0` runs the chain in the reduced-radix 2^26 field
+ * (inc_ecc_secp256k1_fe10x26.cl), converting in/out only once (mirroring a real EC walk that keeps
+ * coordinates in 2^26 form); 0 runs the chain in the vendored radix-2^32 mul_mod. Launched over a full
+ * grid for realistic occupancy. Timing only - correctness is gated by test_fe10x26. See FieldMulBenchmark.
+ */
+__kernel void bench_fe_mul(__global u32 *out, const u32 iterations, const u32 useReducedRadix)
+{
+    const u32 gid = get_global_id(0);
+    u32 one[ONE_COORDINATE_NUM_WORDS] = { 0 };
+    one[0] = 1;
+
+    u32 a[ONE_COORDINATE_NUM_WORDS];
+    u32 b[ONE_COORDINATE_NUM_WORDS];
+    u32 s = gid * 2654435761u + 0x9e3779b9u;
+    for (int j = 0; j < ONE_COORDINATE_NUM_WORDS; j++) {
+        s ^= s << 13; s ^= s >> 17; s ^= s << 5; a[j] = s;
+    }
+    for (int j = 0; j < ONE_COORDINATE_NUM_WORDS; j++) {
+        s ^= s << 13; s ^= s >> 17; s ^= s << 5; b[j] = s;
+    }
+    a[0] |= 1u;
+    b[0] |= 1u;
+    mul_mod(a, a, one); // reduce into [0, p)
+    mul_mod(b, b, one);
+
+    u32 checksum = 0;
+
+    if (useReducedRadix != 0) {
+        u32 na[10];
+        u32 nb[10];
+        fe10x26_from_u32x8(na, a);
+        fe10x26_from_u32x8(nb, b);
+        for (u32 i = 0; i < iterations; i++) {
+            fe10x26_mul(na, na, nb); // na = na * nb (alias-safe: all reads precede writes)
+        }
+        fe10x26_normalize(na);
+        u32 w[ONE_COORDINATE_NUM_WORDS];
+        fe10x26_to_u32x8(w, na);
+        checksum = w[0];
+    } else {
+        for (u32 i = 0; i < iterations; i++) {
+            mul_mod(a, a, b); // a = a * b mod p
+        }
+        checksum = a[0];
+    }
+
+    out[gid] = checksum;
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesManySeedsOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesManySeedsOpenCLTest.java
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Random;
+import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
+import net.ladenthin.bitcoinaddressfinder.constants.Secp256k1Constants;
+import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
+import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLContext;
+import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLGridResult;
+import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
+import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
+import net.ladenthin.bitcoinaddressfinder.util.KeyUtility;
+import net.ladenthin.bitcoinaddressfinder.util.NetworkParameterFactory;
+import org.bitcoinj.base.Network;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Hardened end-to-end correctness gate for the scalar-walker field arithmetic, run for <b>both</b>
+ * field representations ({@link CProducerOpenCL#useReducedRadixField} {@code false} = radix-2³²,
+ * {@code true} = reduced-radix 2²⁶).
+ *
+ * <p>The existing {@code ProbeAddressesOpenCLTest} pins correctness against bitcoinj but uses a single
+ * fixed seed ({@code new Random(1337)}). The reduced-radix port is sensitive to magnitude/carry
+ * handling that could (in theory) only misbehave for rare limb patterns, and a wrong result here is a
+ * <em>silently missed key</em>, not a crash — so this test widens the input space: it derives a full
+ * batch from <b>many</b> independent random bases (different seeds and bit sizes) and verifies
+ * <b>every</b> derived key against bitcoinj via {@link PublicKeyBytes#runtimePublicKeyCalculationCheck()},
+ * which recomputes both the compressed and uncompressed public key and both hash160 chains from the
+ * secret with {@code ECKey.fromPrivate} and compares. Thousands of keys per representation across
+ * varied ranges make a representation-specific arithmetic bug overwhelmingly likely to surface.
+ *
+ * <p>{@code @OpenCLTest}: self-skips when no OpenCL 2.0+ device is present (runs under pocl in CI or a
+ * real GPU). {@code keysPerWorkItem} is set to the {@code KEYS_BATCH_INV} sub-batch size so the walk's
+ * Montgomery sub-batch boundaries (and the {@code m == 0} anchor-emit path) are exercised every batch.
+ */
+public class ProbeAddressesManySeedsOpenCLTest {
+
+    private final Network network = new NetworkParameterFactory().getNetwork();
+    private final ByteBufferUtility byteBufferUtility = new ByteBufferUtility(true);
+    private final BitHelper bitHelper = new BitHelper();
+
+    /** 2^8 = 256 keys per batch. */
+    private static final int BITS_FOR_BATCH = 8;
+
+    /** Walk sub-batch size (matches the kernel's KEYS_BATCH_INV) so the batched-inversion path runs. */
+    private static final int KEYS_PER_WORK_ITEM = 16;
+
+    /** Number of independent random bases (seeds) per representation. */
+    private static final int NUMBER_OF_SEEDS = 16;
+
+    @ParameterizedTest
+    @OpenCLTest
+    @ValueSource(booleans = {false, true})
+    public void createKeys_manySeeds_allMatchBitcoinjReference(boolean useReducedRadixField) throws IOException {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+
+        final KeyUtility keyUtility = new KeyUtility(network, byteBufferUtility);
+
+        final CProducerOpenCL producerOpenCL = new CProducerOpenCL();
+        producerOpenCL.batchSizeInBits = BITS_FOR_BATCH;
+        producerOpenCL.keysPerWorkItem = KEYS_PER_WORK_ITEM;
+        producerOpenCL.useReducedRadixField = useReducedRadixField;
+
+        try (OpenCLContext openCLContext = new OpenCLContext(producerOpenCL, bitHelper)) {
+            openCLContext.init();
+
+            for (int seed = 0; seed < NUMBER_OF_SEEDS; seed++) {
+                final Random random = new Random(0x5DEECE66DL ^ (0x9E3779B97F4A7C15L * (seed + 1)));
+                // Vary the bit size across seeds so both small and full-width 256-bit bases are covered.
+                final int bitSize = Secp256k1Constants.PRIVATE_KEY_MAX_NUM_BITS - (seed % 64);
+                final BigInteger secretKeyBase = keyUtility.createSecret(bitSize, random);
+                final BigInteger secretBase =
+                        keyUtility.alignDown(secretKeyBase, bitHelper.getLowBitMask(producerOpenCL.batchSizeInBits));
+
+                final OpenCLGridResult createKeys = openCLContext.createKeys(secretBase);
+                try {
+                    final PublicKeyBytes[] publicKeys = createKeys.getPublicKeyBytes();
+                    for (int i = 0; i < publicKeys.length; i++) {
+                        final PublicKeyBytes publicKeyBytes = publicKeys[i];
+                        assertTrue(
+                                publicKeyBytes.runtimePublicKeyCalculationCheck(),
+                                "useReducedRadixField=" + useReducedRadixField
+                                        + " seed=" + seed
+                                        + " index=" + i
+                                        + " secretKey=" + publicKeyBytes.getSecretKey());
+                    }
+                } finally {
+                    createKeys.close();
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/FieldMulBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/FieldMulBenchmark.java
@@ -1,0 +1,147 @@
+// @formatter:off
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+// @formatter:on
+package net.ladenthin.bitcoinaddressfinder.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.OpenCLPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
+import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLContext;
+import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Isolated microbenchmark for the secp256k1 field multiply, comparing the reduced-radix 2^26
+ * implementation ({@code inc_ecc_secp256k1_fe10x26.cl}) against the vendored radix-2^32
+ * {@code mul_mod} ({@code copyfromhashcat/inc_ecc_secp256k1.cl}).
+ *
+ * <p>Motivation: docs/performance.md identifies the field multiply as carry-bound in the radix-2^32
+ * representation (every 32x32-&gt;64 partial product propagates a carry immediately; a dedicated
+ * {@code sqr_mod} measured <em>slower</em> for this reason). The reduced-radix 2^26 form leaves 6
+ * spare bits per limb so partial products accumulate in a 64-bit register before a single carry pass,
+ * which is the representation libsecp256k1 uses for its 32-bit field. This benchmark drives the
+ * {@code bench_fe_mul} kernel (each work-item chains {@code iterations} multiplies over a full grid)
+ * to measure that lever in isolation, before any production hot path adopts it.</p>
+ *
+ * <p>The two arms keep coordinates in their native form for the whole chain (the 2^26 arm converts
+ * in/out only once), mirroring a real EC walk that never round-trips between representations
+ * per-multiply. Self-skips when no OpenCL 2.0+ device is present. Reads §6 of docs/performance.md
+ * first - the laptop GPU is thermally noisy; compare matched arms (ON-OFF-ON bracketing).</p>
+ *
+ * <p>One JMH op = one {@link OpenCLContext#runBenchFeMul} launch =
+ * {@code (1 << gridSizeInBits) × iterations} field multiplies, so multiplies/sec = ops/sec × that
+ * product.</p>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 10)
+@Measurement(iterations = 3, time = 10)
+@Fork(
+        value = 1,
+        // Master JVM-flag list — keep identical (same set + same order) to the pom.xml
+        // <argLine>, .mvn/jvm.config and examples/*.bat so the JMH fork matches the JVM
+        // Surefire uses (lmdbjava reflects into sun.nio.ch / jdk.internal.ref).
+        jvmArgsAppend = {
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.io=ALL-UNNAMED",
+            "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED",
+            "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+            "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            "--add-exports=java.base/java.lang=ALL-UNNAMED",
+            "--add-exports=java.base/java.io=ALL-UNNAMED",
+            "--add-exports=java.base/java.nio=ALL-UNNAMED",
+            "--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED",
+            "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+            "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+            "--add-exports=jdk.management/com.sun.management.internal=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        })
+public class FieldMulBenchmark {
+
+    /** {@code true} = reduced-radix 2^26 field multiply; {@code false} = vendored radix-2^32 mul_mod. */
+    @Param({"true", "false"})
+    public boolean useReducedRadix;
+
+    /** Log2 of the number of work-items launched (the grid size; fills the GPU for realistic occupancy). */
+    @Param({"18"})
+    public int gridSizeInBits;
+
+    /** Number of chained multiplies each work-item performs per launch (amortises launch/alloc overhead). */
+    @Param({"4096"})
+    public int iterations;
+
+    private OpenCLContext ctx;
+    private int globalWorkSize;
+
+    /** Creates a new {@link FieldMulBenchmark} (no-arg constructor for JMH). */
+    public FieldMulBenchmark() {
+        // no-op
+    }
+
+    /**
+     * Builds an OpenCL context. Skips the trial cleanly (JMH reports {@code ERROR}) if no OpenCL 2.0+
+     * device is present.
+     *
+     * @throws Exception if {@link OpenCLContext#init()} fails (e.g. kernel build error)
+     */
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+
+        final CProducerOpenCL p = new CProducerOpenCL();
+        // batchSizeInBits only sizes the production result buffer; bench_fe_mul ignores it, but keep
+        // it consistent with the grid we launch so init()'s buffers are sane.
+        p.batchSizeInBits = gridSizeInBits;
+        p.keysPerWorkItem = 1;
+
+        ctx = new OpenCLContext(p, new BitHelper());
+        ctx.init();
+
+        globalWorkSize = 1 << gridSizeInBits;
+    }
+
+    /**
+     * One launch of {@code bench_fe_mul}: {@code globalWorkSize × iterations} field multiplies in the
+     * selected representation.
+     */
+    @Benchmark
+    public void multiplyGrid() {
+        ctx.runBenchFeMul(globalWorkSize, iterations, useReducedRadix);
+    }
+
+    /**
+     * Releases the OpenCL context. Guarded against a setUp that threw before assigning {@code ctx}.
+     */
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (ctx != null && !ctx.isClosed()) {
+            ctx.close();
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
@@ -207,6 +207,17 @@ public class GpuFuse8FilterBenchmark {
     @Param({"FULL"})
     public KernelProfileStage kernelProfileStage;
 
+    /**
+     * Selects the scalar-walker field representation ({@link CProducerOpenCL#useReducedRadixField}).
+     * {@code false} = radix-2³² (default); {@code true} = reduced-radix 2²⁶. Sweep both
+     * (e.g. {@code -p useReducedRadixField=false,true}) to measure the end-to-end effect of the 2²⁶
+     * walk (the isolated multiply was ≈ 1.56× faster — see {@code FieldMulBenchmark} and §8 of
+     * {@code docs/performance.md}). Best paired with a realistic {@code keysPerWorkItem} (e.g. 128),
+     * since the win lives in the per-key walk, not the one-time comb anchor.
+     */
+    @Param({"false"})
+    public boolean useReducedRadixField;
+
     private OpenCLContext ctx;
     private BigInteger privateKeyBase;
 
@@ -241,6 +252,7 @@ public class GpuFuse8FilterBenchmark {
         p.enableProfiling = profiling;
         p.useSafeGcdInverse = useSafeGcdInverse;
         p.kernelProfileStage = kernelProfileStage;
+        p.useReducedRadixField = useReducedRadixField;
 
         ctx = new OpenCLContext(p, new BitHelper());
         ctx.init();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCLTest.java
@@ -214,4 +214,41 @@ public class CProducerOpenCLTest {
         // assert
         assertThat(parsed.logGpuDiagnostics, is(true));
     }
+
+    @Test
+    public void defaults_useReducedRadixField_isFalse() {
+        // arrange + act
+        CProducerOpenCL config = new CProducerOpenCL();
+
+        // assert
+        assertThat(config.useReducedRadixField, is(false));
+    }
+
+    @Test
+    public void jsonRoundTrip_useReducedRadixFieldTrue_survivesSerialiseDeserialise() throws Exception {
+        // arrange
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        CProducerOpenCL original = new CProducerOpenCL();
+        original.useReducedRadixField = true;
+
+        // act
+        String json = mapper.writeValueAsString(original);
+        CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
+
+        // assert
+        assertThat(parsed.useReducedRadixField, is(true));
+    }
+
+    @Test
+    public void jsonDeserialise_useReducedRadixFieldAbsent_defaultsToFalse() throws Exception {
+        // arrange
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        String json = "{}";
+
+        // act
+        CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
+
+        // assert
+        assertThat(parsed.useReducedRadixField, is(false));
+    }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContextTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContextTest.java
@@ -197,6 +197,34 @@ public class OpenCLContextTest {
         // assert
         assertThat(options, containsString(OpenCLContext.NV_VERBOSE_BUILD_OPTION));
     }
+
+    @Test
+    public void buildOptions_useReducedRadixFieldFalse_omitsReducedRadixDefine() {
+        // arrange
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.useReducedRadixField = false;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        // act
+        String options = openCLContext.buildOptions();
+
+        // assert
+        assertThat(options, not(containsString(OpenCLContext.REDUCED_RADIX_FIELD_BUILD_OPTION)));
+    }
+
+    @Test
+    public void buildOptions_useReducedRadixFieldTrue_appendsReducedRadixDefine() {
+        // arrange
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.useReducedRadixField = true;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        // act
+        String options = openCLContext.buildOptions();
+
+        // assert
+        assertThat(options, containsString(OpenCLContext.REDUCED_RADIX_FIELD_BUILD_OPTION));
+    }
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="kernelProfileStage builds and runs">

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLFe10x26ParityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLFe10x26ParityTest.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import net.ladenthin.bitcoinaddressfinder.OpenCLPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.OpenCLTest;
+import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
+import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates the reduced-radix 2^26 field module ({@code inc_ecc_secp256k1_fe10x26.cl}) against the
+ * vendored radix-2^32 field ({@code copyfromhashcat/inc_ecc_secp256k1.cl}) by running the
+ * {@code test_fe10x26} self-check kernel on the GPU.
+ *
+ * <p>The kernel takes deterministic pseudo-random operand pairs {@code (x, y)}, each fully reduced
+ * into {@code [0, p)}, and for each cross-checks the 2^26 implementation against the radix-2^32
+ * reference for: limb-representation roundtrip, modular multiply, square, add, and subtract. Every
+ * output word must be {@code 0}; a non-zero word is a per-input failure bitmask (see the kernel
+ * comment for the bit assignments). This is the proof that the 2^26 field is a byte-identical drop-in
+ * before any production hot path relies on it.
+ *
+ * <p>{@code @OpenCLTest}: self-skips when no OpenCL 2.0+ device is present (runs under pocl in CI or a
+ * real GPU).
+ */
+class OpenCLFe10x26ParityTest {
+
+    private final BitHelper bitHelper = new BitHelper();
+
+    private static CProducerOpenCL minimalProducer() {
+        final CProducerOpenCL p = new CProducerOpenCL();
+        p.batchSizeInBits = 8;
+        p.keysPerWorkItem = 1; // irrelevant here: the test drives the self-check kernel directly
+        return p;
+    }
+
+    @Test
+    @OpenCLTest
+    void fe10x26_matchesRadix32Field() throws IOException {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+        final int count = 8192;
+        try (OpenCLContext ctx = new OpenCLContext(minimalProducer(), bitHelper)) {
+            ctx.init();
+            final byte[] status = ctx.runPrecomputeKernelForTesting("test_fe10x26", count * Integer.BYTES, count);
+            for (int i = 0; i < status.length; i++) {
+                assertEquals(0, status[i], "fe10x26 parity failure at status byte " + i);
+            }
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLKernelModeMatrixTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLKernelModeMatrixTest.java
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import net.ladenthin.bitcoinaddressfinder.OpenCLPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.OpenCLTest;
+import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
+import net.ladenthin.bitcoinaddressfinder.configuration.KernelProfileStage;
+import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
+import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Regression guard that every compile-time kernel mode <b>and the meaningful combinations of them</b>
+ * actually build and run. The production kernel has three independent build-time switches, each driven
+ * by a {@link CProducerOpenCL} field and toggled with a {@code -D} define in {@link OpenCLContext#buildOptions()}:
+ *
+ * <ul>
+ *   <li>{@code useSafeGcdInverse} — safegcd (default) vs {@code -D USE_LEGACY_BINARY_GCD_INV_MOD};</li>
+ *   <li>{@code useReducedRadixField} — radix-2³² (default) vs {@code -D USE_REDUCED_RADIX_FIELD} (2²⁶ walk);</li>
+ *   <li>{@code kernelProfileStage} — {@code FULL} vs {@code -D PROFILE_SKIP_SECOND_HASH160} / {@code -D PROFILE_SKIP_HASH160}.</li>
+ * </ul>
+ *
+ * <p><b>Each individual switch is already exercised elsewhere</b> — {@code kernelProfileStage_buildsAndRuns}
+ * (the three stages, radix-2³²), {@code OpenCLPrecomputeKernelTest#invModSafegcd_…} (legacy inverse,
+ * radix-2³²), and {@code ProbeAddressesManySeedsOpenCLTest} (reduced-radix and radix-2³², FULL, vs
+ * bitcoinj). What none of them covers is the <b>interaction</b> of {@code useReducedRadixField=true}
+ * with the other two switches: the 2²⁶ walk feeding the legacy binary-GCD inverse, and the 2²⁶ walk
+ * under the profiling stages. Those are the combinations selected here (kept small on purpose: every
+ * row is a distinct {@code -D} set, so each is a fresh kernel build, and the whole class must finish
+ * within the Surefire per-fork timeout). For each it builds the full program
+ * ({@link OpenCLContext#init()}), launches it ({@link OpenCLContext#createKeys(BigInteger)}), and:
+ *
+ * <ul>
+ *   <li>for {@code FULL} stages (correct hashing) verifies every derived key against bitcoinj via
+ *       {@link PublicKeyBytes#runtimePublicKeyCalculationCheck()};</li>
+ *   <li>for the {@code PROFILE_SKIP_*} stages (timing-only — hashes are intentionally wrong) only
+ *       asserts the launch produced a non-empty result buffer, i.e. the branch compiled and ran.</li>
+ * </ul>
+ *
+ * <p>{@code @OpenCLTest}: self-skips when no OpenCL 2.0+ device is present (runs under pocl in CI or a
+ * real GPU). All combinations build in one forked JVM; the first {@code init()} pays the cold
+ * OpenCL-compiler cost, the rest reuse the warm driver, keeping the class within the Surefire fork
+ * timeout. The grid is intentionally tiny ({@code batchSizeInBits=8}) — this guards compilation and
+ * basic execution of each branch, not throughput.
+ */
+public class OpenCLKernelModeMatrixTest {
+
+    private final BitHelper bitHelper = new BitHelper();
+
+    @ParameterizedTest(name = "[{index}] safegcd={0} reducedRadix={1} stage={2}")
+    @OpenCLTest
+    @CsvSource({
+        // useSafeGcdInverse, useReducedRadixField, kernelProfileStage
+        // Only the reduced-radix interactions not covered elsewhere (each row = one fresh kernel build;
+        // kept to 3 to stay within the Surefire fork timeout).
+        "false, true,  FULL", // reduced-radix 2^26 walk + legacy binary-GCD inverse (asserts vs bitcoinj)
+        "true,  true,  ONE_HASH160", // reduced-radix 2^26 walk + skip-second-hash160 profiling
+        "true,  true,  NO_HASH160", // reduced-radix 2^26 walk + EC-only profiling
+    })
+    public void kernelMode_buildsRunsAndIsCorrectWhenFull(
+            boolean useSafeGcdInverse, boolean useReducedRadixField, KernelProfileStage kernelProfileStage)
+            throws IOException {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+
+        final CProducerOpenCL producerOpenCL = new CProducerOpenCL();
+        producerOpenCL.batchSizeInBits = 8;
+        producerOpenCL.keysPerWorkItem = 8; // > 1 so the scalar-walker path (and its #ifdef) is exercised
+        producerOpenCL.useSafeGcdInverse = useSafeGcdInverse;
+        producerOpenCL.useReducedRadixField = useReducedRadixField;
+        producerOpenCL.kernelProfileStage = kernelProfileStage;
+
+        try (OpenCLContext openCLContext = new OpenCLContext(producerOpenCL, bitHelper)) {
+            openCLContext.init(); // builds the full program with this mode's -D defines
+
+            // The base must be aligned to batchSizeInBits (low bits zero): the producer labels each
+            // result secret as base | index, and the runtime check compares the kernel's pubkey to
+            // bitcoinj for that secret. With low bits zero, base | index == base + index, so the grid
+            // covers a clean contiguous range. (0x...00 has its low 8 bits zero for batchSizeInBits=8.)
+            final BigInteger secretBase = BigInteger.valueOf(0x1234_5600L);
+            try (OpenCLGridResult result = openCLContext.createKeys(secretBase)) {
+                // The launch completed and produced a readable result buffer (the branch compiled + ran).
+                assertThat(result.getResult().capacity(), is(greaterThan(0)));
+
+                if (kernelProfileStage == KernelProfileStage.FULL) {
+                    // FULL hashing is correct -> every key must match bitcoinj for both representations
+                    // and both inverse implementations.
+                    final PublicKeyBytes[] publicKeys = result.getPublicKeyBytes();
+                    for (int i = 0; i < publicKeys.length; i++) {
+                        assertTrue(
+                                publicKeys[i].runtimePublicKeyCalculationCheck(),
+                                "safegcd=" + useSafeGcdInverse
+                                        + " reducedRadix=" + useReducedRadixField
+                                        + " index=" + i
+                                        + " secretKey=" + publicKeys[i].getSecretKey());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
BitCrack (brichard19) has both CUDA and OpenCL secp256k1 backends.
KeyHunt-Cuda (kanhavishva) is a modified version of VanitySearch
(JeanLucPons), already listed; link it explicitly as upstream.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>