### PR TITLE
Upgrade spotless and central-publishing-maven-plugin dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ SPDX-License-Identifier: Apache-2.0
         <mockito.version>5.23.0</mockito.version>
         <logcaptor.version>2.12.6</logcaptor.version>
         <jmh.version>1.37</jmh.version>
-        <spotless.version>3.6.0</spotless.version>
+        <spotless.version>3.7.0</spotless.version>
         <palantir-java-format.version>2.92.0</palantir-java-format.version>
     </properties>
 
@@ -247,7 +247,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.10.0</version>
+                    <version>0.11.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Summary

- Upgrade `spotless` from 3.6.0 to 3.7.0
- Upgrade `central-publishing-maven-plugin` from 0.10.0 to 0.11.0

These are routine dependency updates to pull in the latest bug fixes and improvements from upstream.

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01HfEmuuUiRwnciLxNAKw2Sf