### PR TITLE
ECC GPU: reduced-radix 2^26 default + AMD noinline compile fix (vendor auto-detect)

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -169,6 +169,47 @@ Notes:
 Use `{"command":"OpenCLInfo"}` to confirm a device is present and pick `platformIndex` /
 `deviceIndex` before benchmarking.
 
+### Cross-device: AMD RX 7900 XTX (RDNA3) vs RTX 3070 Laptop (Ampere)
+
+The same kernel was swept on a second GPU — an **AMD Radeon RX 7900 XTX** (`gfx1100`, RDNA3, 48 CU,
+wave32, OpenCL 2.0 AMD-APP, Adrenalin 25.12.1). Two things differ from the RTX 3070 and both are
+expected from the architecture:
+
+**(1) The `keysPerWorkItem` sweet spot is different.** Compact mode, `batchSizeInBits = 20`, full
+kernel + safegcd, candidates/s = JMH ops/s × `2^20`:
+
+| `keysPerWorkItem` | 8 | 16 | **32** | 64 | 128 | 256 |
+|---|--:|--:|--:|--:|--:|--:|
+| RX 7900 XTX — M keys/s (compact) | 32.7 | 48.3 | **80.4 (peak)** | 69.1 | 50.5 | 28.2 |
+| RTX 3070 — M keys/s (compact) | 47 | 69 | 96 | 124 | **138 (peak)** | 93 |
+
+The RX 7900 XTX peaks at **`keysPerWorkItem = 32`** (≈ 32 768 work-items to fill its 48 CUs), whereas
+the RTX 3070 peaks at **128** (8 192 work-items for its 40 SMs). This is the same "match the work-item
+count to the device" rule from §4 — the optimum is genuinely per-device, so **sweep on your own
+hardware**. The RX 7900 XTX wants ~4× more work-items (smaller `keysPerWorkItem`) than the RTX 3070.
+
+**(2) Reduced-radix 2²⁶ (Stage 5) is also a win on AMD — but smaller (≈ +8% vs +22%).** Matched A/B at
+each device's own context (compact, `batchSizeInBits = 20`; RX 7900 XTX at its `keysPerWorkItem = 32`
+sweet spot), both orderings to defeat thermal bias (§6):
+
+| device | radix-2³² | reduced-radix 2²⁶ | delta |
+|---|--:|--:|--:|
+| RX 7900 XTX (avg of both orderings) | 75.3 ops/s | 81.4 ops/s | **≈ +8.1%** |
+| RTX 3070 (§5 Stage 5) | 155.2 ops/s | 188.6 ops/s | **≈ +22%** |
+
+On the RX 7900 XTX the two orderings gave +9.8% (false→true) and +6.4% (true→false); reduced-radix won
+in **both** (error bars disjoint), including when it ran second/warmer, so the gain is real, not
+ordering. It is smaller than on the RTX 3070 — plausibly because RDNA3's field throughput is less
+carry-bound, or because the per-key boundary conversions (§5 Stage 5) weigh more here — but it is a
+**positive cross-device confirmation**, which is what open point #4 was gated on (see §8 Stage 5).
+
+> **Methodology caveat — the AMD numbers are measured with `noinline` (§9).** The RX 7900 XTX build
+> uses `-D AMD_NOINLINE_HELPERS` because the inlined kernel takes 8–16+ min to compile on AMD (§9).
+> Out-of-line calls can cost runtime throughput, so the **absolute** AMD M keys/s above are likely
+> *understated* relative to a hypothetical inlined AMD build, and are **not** directly comparable to
+> the inlined RTX 3070 absolutes. What *is* comparable: the **sweet-spot location** (architectural)
+> and the **reduced-radix relative delta** (`noinline` is present in both A/B arms, so it cancels).
+
 ---
 
 ## 5. Optimization history (measured)
@@ -678,7 +719,7 @@ vendored field file. **Both states of every switch are built and run on a device
 | Build define | Config field | Default | OFF gated by | ON gated by | Correctness checkable? |
 |---|---|---|---|---|---|
 | *(none)* / `-D USE_LEGACY_BINARY_GCD_INV_MOD` | `useSafeGcdInverse` | safegcd | every `@OpenCLTest` (safegcd) | `OpenCLPrecomputeKernelTest#invModSafegcd_…` (built legacy) + `OpenCLKernelModeMatrixTest` | yes (both, vs bitcoinj / `x·x⁻¹≡1`) |
-| `-D USE_REDUCED_RADIX_FIELD` | `useReducedRadixField` | radix-2³² | every `@OpenCLTest` + `ProbeAddressesManySeedsOpenCLTest` | `ProbeAddressesManySeedsOpenCLTest` + `OpenCLKernelModeMatrixTest` | yes (both, vs bitcoinj) |
+| `-D USE_REDUCED_RADIX_FIELD` | `useReducedRadixField` | **2²⁶ (define on by default)** | `ProbeAddressesManySeedsOpenCLTest` + `OpenCLKernelModeMatrixTest` | every `@OpenCLTest` + `ProbeAddressesManySeedsOpenCLTest` | yes (both, vs bitcoinj) |
 | `-D PROFILE_SKIP_SECOND_HASH160` | `kernelProfileStage=ONE_HASH160` | `FULL` | every FULL test | `OpenCLContextTest#kernelProfileStage_buildsAndRuns` + `OpenCLKernelModeMatrixTest` | build+run only (mode emits wrong hashes by design) |
 | `-D PROFILE_SKIP_HASH160` | `kernelProfileStage=NO_HASH160` | `FULL` | every FULL test | `OpenCLContextTest#kernelProfileStage_buildsAndRuns` + `OpenCLKernelModeMatrixTest` | build+run only (mode emits wrong hashes by design) |
 
@@ -797,12 +838,14 @@ is forbidden — both address types are mandatory).
   branch/addressing overhead, so it loses. Reverted. Could be revisited on a *multiply-bound* device
   (or paired with a reduced-radix representation that shortens the add chain).
 
-### Stage 5 (opt-in) — reduced-radix 2²⁶ field in the scalar-walker (≈ +22% end-to-end, flag-gated)
+### Stage 5 — reduced-radix 2²⁶ field in the scalar-walker (≈ +22% end-to-end; now the default)
 
-The #1 EC lever is **implemented, parity-proven, integrated into the hot loop behind a flag, and
-benchmarked both in isolation and end-to-end**. It is **off by default** (`useReducedRadixField =
-false`) pending per-device confirmation; flipping the default is a one-line change now that it is
-proven. The comb anchor and the `copyfromhashcat` files are unchanged either way.
+The #1 EC lever is **implemented, parity-proven, integrated into the hot loop, and benchmarked both
+in isolation and end-to-end**. It is **now on by default** (`useReducedRadixField = true`) after the
+end-to-end gain was confirmed **cross-device** — ≈ +22% on the RTX 3070 and ≈ +8% on an AMD RX 7900
+XTX, never a regression on either (the bar open point #4 set; see §4 "Cross-device"). Set
+`useReducedRadixField = false` to force the legacy radix-2³² walk for A/B comparison. The comb anchor
+and the `copyfromhashcat` files are unchanged either way.
 
 - **What was built.** `src/main/resources/inc_ecc_secp256k1_fe10x26.cl` — a self-contained OpenCL port
   of libsecp256k1's `field_10x26_impl.h` (Pieter Wuille, MIT): `fe10x26_mul`, `fe10x26_sqr`,
@@ -863,8 +906,11 @@ proven. The comb anchor and the `copyfromhashcat` files are unchanged either way
   ```
 
 - **What remains (refinements, all optional).**
-  (a) **Flip the default** to `useReducedRadixField = true` once the +22% is confirmed on more than
-  this one RTX 3070 (the safegcd precedent: made default after a cross-device win). One-line change.
+  (a) **Flip the default — ✅ DONE.** `useReducedRadixField` now defaults to `true`. The cross-device
+  bar this item set is met: confirmed positive on a second architecture — **AMD RX 7900 XTX** (RDNA3)
+  ≈ **+8%** (both A/B orderings, error bars disjoint; see §4 "Cross-device") alongside the RTX 3070's
+  ≈ +22%, never a regression on either. Correctness is identical (gated against bitcoinj with the flag
+  on and off); set `false` to force the legacy radix-2³² walk for A/B.
   (b) **Store `iG_table` in 2²⁶ form** (host build or a post-process kernel) to drop the per-key
   increment-read conversions — the main remaining overhead diluting the gain.
   (c) **Convert the comb anchor** to 2²⁶ too (needs a 2²⁶ Jacobian `point_add` in our own file, since
@@ -962,7 +1008,105 @@ cost balance shifts):
 
 ---
 
-## 9. File map
+## 9. AMD GPUs — fixing the multi-minute kernel compile (`noinline`)
+
+**Symptom.** On AMD GPUs (measured: Radeon RX 7900 XTX, `gfx1100`, RDNA3, Adrenalin 25.12.1,
+OpenCL 2.0 AMD-APP) the **first** `clBuildProgram` of the full kernel took **8–16+ minutes** —
+single-threaded, one core pinned, multi-GB RAM — and routinely blew past the 180 s Surefire fork
+budget, so the OpenCL parity tests could not even run. A trivial `add` kernel compiles in **0.2 s** on
+the same device, so the OpenCL stack itself is healthy; the cost is specific to this one large kernel.
+NVIDIA (RTX 3070) builds the identical source in seconds.
+
+**Root cause — one giant inlined function.** AMD's OpenCL compiler is LLVM-based (the "LC" /
+`comgr` + `ld.lld` stack). At `-O3` it **inlines every `DECLSPEC` helper** (the comb's ~64
+`point_add`s, field `mul_mod`, the 600-divstep safegcd inverse, both 64-round SHA-256 → RIPEMD-160
+chains) into the single `generateKeysKernel_grid` function. Several LLVM back-end passes — greedy
+register allocation and SelectionDAG scheduling — scale **~super-linearly (≈ quadratically) per
+function**, so one enormous function explodes in time and memory. NVIDIA's separate ptxas back-end
+does not share LLVM's per-function scaling, which is why CUDA was always fast.
+
+**What does *not* work (measured, so you don't repeat it):**
+- **`-cl-opt-disable`** — fails to link: `ld.lld: undefined hidden symbol` for the `static`/`DECLSPEC`
+  helpers (the documented C99-`inline` trap; same failure as hashcat/darktable/CL2QCD).
+- **Removing `#pragma unroll` hints** — no effect (8m02s vs 8m04s). Those loops have compile-time
+  bounds, so LLVM unrolls them regardless of the hint. (To *reduce* straight-line size you would force
+  `#pragma unroll 1`, not delete the hint.)
+- **The `comgr` disk cache helps but is not a compile-time fix** — it caches a *successful* build
+  (`llvmcache-*` under `%LOCALAPPDATA%\comgr`; controlled by `AMD_COMGR_CACHE` / `AMD_COMGR_CACHE_DIR`),
+  giving a ~680× warm speedup (8 min → ~0.7 s), but only **after** one full slow compile completes
+  uninterrupted. Every earlier attempt was killed before it could populate the cache.
+
+**The fix — force the helpers out-of-line (`noinline`).** Build the kernel with
+`-D AMD_NOINLINE_HELPERS`, which makes the vendored `DECLSPEC` expand to
+`__attribute__((noinline))` (`copyfromhashcat/inc_vendor.h`). The kernel is then **partitioned into
+many small functions**, each compiling in roughly linear time, instead of one quadratic-cost giant.
+Note removing the `inline` *keyword* alone does nothing — LLVM still inlines at `-O3`; only the hard
+`noinline` attribute stops it.
+
+| Cold compile (fresh `comgr` cache), RX 7900 XTX | default (inlined) | `-D AMD_NOINLINE_HELPERS` |
+|---|--:|--:|
+| Stripped (no hash160, legacy inverse) | 8m 02s | **2.99 s** |
+| **Full (both hash160 chains + safegcd)** | **>16 min (never finished)** | **3.09 s** |
+
+**> 300× faster, byte-identical output.** Parity confirmed on the AMD GPU with the flag on:
+`ProbeAddressesOpenCLTest` 43 run / 0 fail in 21.6 s (byte-compared to bitcoinj across
+`keysPerWorkItem` 1…16). `noinline` is a compile directive only; it cannot change numerical results.
+
+**How to enable.** Runtime config flag `producerOpenCL.noInlineHelpers` (`CProducerOpenCL`,
+default `false`) → `OpenCLContext.buildOptions()` appends the define. Unit-gated by
+`OpenCLContextTest#buildOptions_noInlineHelpers{True,False}` and `CProducerOpenCLTest`.
+
+**Why it is opt-in / off by default.** Out-of-line calls can cost *runtime* throughput (call
+overhead, lost cross-function optimisation, possible extra VGPR pressure at call sites). The
+compile-time win on AMD is decisive, but enabling it as a default — or auto-enabling it for AMD
+devices — should be gated on an NVIDIA throughput A/B first. Tuning lever for later: apply `noinline`
+selectively (heaviest helpers first — SHA-256, RIPEMD-160, safegcd) rather than to every helper, to
+trade the smallest runtime cost for most of the compile-time win.
+
+---
+
+## 10. Device / vendor compatibility
+
+Devices the kernel has been built and run on (byte-identical to the bitcoinj reference unless noted):
+
+| Device | Architecture | OpenCL | Role | Notes |
+|---|---|---|---|---|
+| NVIDIA RTX 3070 Laptop | Ampere (40 SM) | 3.0 CUDA | primary perf / tuning | fast compile (ptxas); `keysPerWorkItem` sweet spot **128** |
+| AMD RX 7900 XTX | RDNA3 (`gfx1100`, 48 CU) | 2.0 AMD-APP | cross-device confirmation | **needs `noInlineHelpers`** for a practical compile (§9); sweet spot **32** |
+| pocl (CPU) | CPU | 3.0 platform / CL C 1.2 | CI `test-opencl` job | conformant; small grids only (per-fork timeout) |
+
+**Feature compatibility / requirements:**
+
+| Feature | Config (default) | Requirement | Status |
+|---|---|---|---|
+| Reduced-radix 2²⁶ field | `useReducedRadixField` (**`true`**) | none beyond base OpenCL | byte-identical on NVIDIA / AMD / pocl; ≈ +22% / +8% |
+| safegcd modular inverse | `useSafeGcdInverse` (`true`) | arithmetic (sign-extending) `>>` | NVIDIA / AMD / pocl comply; `false` → legacy binary-GCD fallback |
+| GPU Binary-Fuse-8 filter (compact) | `enableGpuFilter` (`false`) | OpenCL **≥ 2.0** device (global `atomic_add`) | gated by `assertCompactModeDeviceVersionSupported`; otherwise full transfer |
+| Out-of-line helpers | `noInlineHelpers` (`false`) | none | AMD compile fix (§9); opt-in pending the NVIDIA A/B below |
+| Device endianness | — (implicit) | **little-endian** device | big-endian rejected at init (`assertDeviceByteOrderSupported`) |
+
+**Compile-time, by vendor:** NVIDIA — seconds. AMD — 8–16+ min inlined, **≈ 3 s with `noInlineHelpers`** (§9); the `comgr` disk cache (`%LOCALAPPDATA%\comgr`) persists successful builds. pocl — fast; note `-cl-std=CL2.0` is rejected (CL C 1.2 only), so the kernel pins `-cl-std=CL1.2` (§5 Stage 0).
+
+### TODO — Track B (handoff): NVIDIA `noinline` throughput A/B
+
+**Owner: NVIDIA-side agent (this needs an NVIDIA GPU; not runnable on the AMD box).**
+
+**Question to answer:** can `noInlineHelpers` be enabled more broadly — auto-enabled for AMD devices, or even made the global default — or must it stay opt-in? It is already proven **correctness-neutral** (byte-identical, gated by `ProbeAddressesOpenCLTest#createKeys_noInlineHelpers_resultsMatchReference`); the open question is purely its **runtime throughput** cost (out-of-line calls can cost H/s).
+
+**What's left to do, concretely:**
+1. **Expose `noInlineHelpers` as a benchmark `@Param`** in `GpuFuse8FilterBenchmark` (mirror the existing `useReducedRadixField` `@Param` wiring) so the A/B is a single clean JMH run with no source edits.
+2. **Measure on NVIDIA** (e.g. RTX 3070): compact mode, `batchSizeInBits=20`, at the device sweet spot (`keysPerWorkItem=128`), `-p noInlineHelpers=false,true`, **both orderings** to defeat thermal bias (§6). Record the relative throughput delta.
+3. **Measure on AMD too** (quantify what AMD pays): warm the inlined `comgr` cache once (one uninterrupted ~16 min inlined build), then A/B inlined vs `noinline` at the AMD sweet spot (`keysPerWorkItem=32`).
+4. **Decide enablement policy:**
+   - If `noinline` costs **≲ a few %** on NVIDIA → consider making it the global default (simplest).
+   - If it costs **meaningful** NVIDIA throughput → keep it off for NVIDIA but **auto-enable for AMD devices** via vendor detection in `OpenCLContext.buildOptions()` (enable when `CL_DEVICE_VENDOR` / platform is AMD), leaving the config flag as an override.
+   - Either way, evaluate **selective `noinline`** (apply only to the heaviest helpers — SHA-256, RIPEMD-160, safegcd — instead of all `DECLSPEC`) as a way to keep most of the AMD compile-time win at a smaller runtime cost; re-run the parity gate after any change.
+
+**Inputs already available:** AMD compile/throughput numbers and the sweet-spot sweep are in §4 "Cross-device"; the `noinline` mechanism and the `comgr` cache controls are in §9.
+
+---
+
+## 11. File map
 
 | File | Role |
 |---|---|

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1043,7 +1043,7 @@ many small functions**, each compiling in roughly linear time, instead of one qu
 Note removing the `inline` *keyword* alone does nothing — LLVM still inlines at `-O3`; only the hard
 `noinline` attribute stops it.
 
-| Cold compile (fresh `comgr` cache), RX 7900 XTX | default (inlined) | `-D AMD_NOINLINE_HELPERS` |
+| Cold compile (fresh `comgr` cache), RX 7900 XTX | inlined (`noInlineHelpers=false`) | `-D AMD_NOINLINE_HELPERS` (AMD auto-default) |
 |---|--:|--:|
 | Stripped (no hash160, legacy inverse) | 8m 02s | **2.99 s** |
 | **Full (both hash160 chains + safegcd)** | **>16 min (never finished)** | **3.09 s** |
@@ -1052,16 +1052,33 @@ Note removing the `inline` *keyword* alone does nothing — LLVM still inlines a
 `ProbeAddressesOpenCLTest` 43 run / 0 fail in 21.6 s (byte-compared to bitcoinj across
 `keysPerWorkItem` 1…16). `noinline` is a compile directive only; it cannot change numerical results.
 
-**How to enable.** Runtime config flag `producerOpenCL.noInlineHelpers` (`CProducerOpenCL`,
-default `false`) → `OpenCLContext.buildOptions()` appends the define. Unit-gated by
-`OpenCLContextTest#buildOptions_noInlineHelpers{True,False}` and `CProducerOpenCLTest`.
+**How to enable — tri-state, AMD auto-detected.** Runtime config flag
+`producerOpenCL.noInlineHelpers` (`CProducerOpenCL`) is a **nullable `Boolean`**:
 
-**Why it is opt-in / off by default.** Out-of-line calls can cost *runtime* throughput (call
-overhead, lost cross-function optimisation, possible extra VGPR pressure at call sites). The
-compile-time win on AMD is decisive, but enabling it as a default — or auto-enabling it for AMD
-devices — should be gated on an NVIDIA throughput A/B first. Tuning lever for later: apply `noinline`
-selectively (heaviest helpers first — SHA-256, RIPEMD-160, safegcd) rather than to every helper, to
-trade the smallest runtime cost for most of the compile-time win.
+| value | behaviour |
+|---|---|
+| `null` (**default**) | **auto / vendor-detect**: the define is added **only when the selected device is AMD** (`CL_DEVICE_VENDOR` matches `"amd"` / `"advanced micro devices"`), off on every other vendor. |
+| `true` | force on (any vendor). |
+| `false` | force off (any vendor) — needed to A/B inlined vs out-of-line on an AMD device. |
+
+The decision is resolved against the device at `init()` by
+`OpenCLContext.resolveEffectiveNoInlineHelpers(name, vendor)` and **logged with its reason** (INFO for
+auto/explicit, WARN when explicitly `false` on AMD — which keeps the slow inlined compile). The vendor
+predicate is `OpenCLContext.isAmdVendor(...)`. Unit-gated by `OpenCLContextTest`
+(`isAmdVendor_*`, `resolveEffectiveNoInlineHelpers_*` with `LogCaptor` assertions on the log lines,
+`buildOptions*`) and `CProducerOpenCLTest` (tri-state default-`null` + JSON round-trips); parity by
+`ProbeAddressesOpenCLTest#createKeys_noInlineHelpers_resultsMatchReference`.
+
+**Why AMD-only and not a global default — answered by the NVIDIA A/B (RTX 3070).** Out-of-line calls
+cost *runtime* throughput (call overhead, lost cross-function optimisation, extra VGPR pressure at call
+sites). Track B (below) measured exactly how much: at the NVIDIA sweet spot (compact,
+`batchSizeInBits=20`, `keysPerWorkItem=128`, reduced-radix on) the out-of-line kernel ran
+**≈ 4.5× slower — ~45 vs ~200 ops/s, a ~77% throughput loss** — consistent across both A/B orderings
+and on AC power. That is far past any "few %" bar for a global default, so `noinline` is **auto-enabled
+for AMD only** (where the inlined kernel cannot compile in a practical time at all) and left off on
+NVIDIA (which compiles inlined in seconds and wants the throughput). Tuning lever still open: apply
+`noinline` *selectively* (heaviest helpers first — SHA-256, RIPEMD-160, safegcd) to keep most of the
+AMD compile-time win at a smaller runtime cost; re-run the parity gate after any change.
 
 ---
 
@@ -1072,7 +1089,7 @@ Devices the kernel has been built and run on (byte-identical to the bitcoinj ref
 | Device | Architecture | OpenCL | Role | Notes |
 |---|---|---|---|---|
 | NVIDIA RTX 3070 Laptop | Ampere (40 SM) | 3.0 CUDA | primary perf / tuning | fast compile (ptxas); `keysPerWorkItem` sweet spot **128** |
-| AMD RX 7900 XTX | RDNA3 (`gfx1100`, 48 CU) | 2.0 AMD-APP | cross-device confirmation | **needs `noInlineHelpers`** for a practical compile (§9); sweet spot **32** |
+| AMD RX 7900 XTX | RDNA3 (`gfx1100`, 48 CU) | 2.0 AMD-APP | cross-device confirmation | `noInlineHelpers` **auto-enabled** (vendor-detect) for a practical compile (§9); sweet spot **32** |
 | pocl (CPU) | CPU | 3.0 platform / CL C 1.2 | CI `test-opencl` job | conformant; small grids only (per-fork timeout) |
 
 **Feature compatibility / requirements:**
@@ -1082,27 +1099,48 @@ Devices the kernel has been built and run on (byte-identical to the bitcoinj ref
 | Reduced-radix 2²⁶ field | `useReducedRadixField` (**`true`**) | none beyond base OpenCL | byte-identical on NVIDIA / AMD / pocl; ≈ +22% / +8% |
 | safegcd modular inverse | `useSafeGcdInverse` (`true`) | arithmetic (sign-extending) `>>` | NVIDIA / AMD / pocl comply; `false` → legacy binary-GCD fallback |
 | GPU Binary-Fuse-8 filter (compact) | `enableGpuFilter` (`false`) | OpenCL **≥ 2.0** device (global `atomic_add`) | gated by `assertCompactModeDeviceVersionSupported`; otherwise full transfer |
-| Out-of-line helpers | `noInlineHelpers` (`false`) | none | AMD compile fix (§9); opt-in pending the NVIDIA A/B below |
+| Out-of-line helpers | `noInlineHelpers` (`null` = **auto**) | none | AMD compile fix (§9); auto-enabled for AMD only (vendor-detect), off on NVIDIA (≈4.5× slower there); `true`/`false` force |
 | Device endianness | — (implicit) | **little-endian** device | big-endian rejected at init (`assertDeviceByteOrderSupported`) |
 
 **Compile-time, by vendor:** NVIDIA — seconds. AMD — 8–16+ min inlined, **≈ 3 s with `noInlineHelpers`** (§9); the `comgr` disk cache (`%LOCALAPPDATA%\comgr`) persists successful builds. pocl — fast; note `-cl-std=CL2.0` is rejected (CL C 1.2 only), so the kernel pins `-cl-std=CL1.2` (§5 Stage 0).
 
-### TODO — Track B (handoff): NVIDIA `noinline` throughput A/B
+### Track B (handoff) — NVIDIA `noinline` throughput A/B — ✅ RESOLVED
 
-**Owner: NVIDIA-side agent (this needs an NVIDIA GPU; not runnable on the AMD box).**
+**Question (closed):** could `noInlineHelpers` be enabled more broadly — auto-enabled for AMD, or made
+the global default — or must it stay opt-in? It was already **correctness-neutral** (byte-identical,
+gated by `ProbeAddressesOpenCLTest#createKeys_noInlineHelpers_resultsMatchReference`); the only open
+question was its **runtime throughput** cost.
 
-**Question to answer:** can `noInlineHelpers` be enabled more broadly — auto-enabled for AMD devices, or even made the global default — or must it stay opt-in? It is already proven **correctness-neutral** (byte-identical, gated by `ProbeAddressesOpenCLTest#createKeys_noInlineHelpers_resultsMatchReference`); the open question is purely its **runtime throughput** cost (out-of-line calls can cost H/s).
+**Result (RTX 3070, Ampere).** `noInlineHelpers` was exposed as a `GpuFuse8FilterBenchmark` `@Param`
+(mirroring `useReducedRadixField`) and A/B-measured at the device sweet spot (compact,
+`batchSizeInBits=20`, `keysPerWorkItem=128`, reduced-radix on):
 
-**What's left to do, concretely:**
-1. **Expose `noInlineHelpers` as a benchmark `@Param`** in `GpuFuse8FilterBenchmark` (mirror the existing `useReducedRadixField` `@Param` wiring) so the A/B is a single clean JMH run with no source edits.
-2. **Measure on NVIDIA** (e.g. RTX 3070): compact mode, `batchSizeInBits=20`, at the device sweet spot (`keysPerWorkItem=128`), `-p noInlineHelpers=false,true`, **both orderings** to defeat thermal bias (§6). Record the relative throughput delta.
-3. **Measure on AMD too** (quantify what AMD pays): warm the inlined `comgr` cache once (one uninterrupted ~16 min inlined build), then A/B inlined vs `noinline` at the AMD sweet spot (`keysPerWorkItem=32`).
-4. **Decide enablement policy:**
-   - If `noinline` costs **≲ a few %** on NVIDIA → consider making it the global default (simplest).
-   - If it costs **meaningful** NVIDIA throughput → keep it off for NVIDIA but **auto-enable for AMD devices** via vendor detection in `OpenCLContext.buildOptions()` (enable when `CL_DEVICE_VENDOR` / platform is AMD), leaving the config flag as an override.
-   - Either way, evaluate **selective `noinline`** (apply only to the heaviest helpers — SHA-256, RIPEMD-160, safegcd — instead of all `DECLSPEC`) as a way to keep most of the AMD compile-time win at a smaller runtime cost; re-run the parity gate after any change.
+| `noInlineHelpers` | throughput | relative |
+|---|--:|--:|
+| `false` (inlined) | **≈ 201 ops/s** (AC; 193/191 on battery) | 1.00× |
+| `true` (out-of-line) | **≈ 45 ops/s** | **≈ 0.23× (~4.5× slower)** |
 
-**Inputs already available:** AMD compile/throughput numbers and the sweet-spot sweep are in §4 "Cross-device"; the `noinline` mechanism and the `comgr` cache controls are in §9.
+Identical across both A/B orderings (`false→true` and cold `true→false`) and on AC power — not thermal
+ordering. A ~77% throughput loss, far past any "few %" bar for a global default.
+
+**Decision (implemented).** Keep `noinline` **off for NVIDIA**, **auto-enable for AMD only** via vendor
+detection — the Track-B branch-2 policy. Implemented as a tri-state `@Nullable Boolean noInlineHelpers`
+(`null`=auto → AMD-only; `true`/`false` force), resolved + **logged** in
+`OpenCLContext.resolveEffectiveNoInlineHelpers(...)` (predicate `isAmdVendor(...)`); the config flag
+remains a manual override. See §9 "How to enable". Steps 1 (benchmark `@Param`), 2 (NVIDIA measure) and
+4 (policy + code) are **done**.
+
+**Still open (AMD-side, optional):**
+- **Quantify what AMD pays** (step 3): warm the inlined `comgr` cache once (one uninterrupted ~16 min
+  inlined build), then A/B inlined vs `noinline` at the AMD sweet spot (`keysPerWorkItem=32`). Needs the
+  AMD box.
+- **Selective `noinline`** — apply only to the heaviest helpers (SHA-256, RIPEMD-160, safegcd) instead
+  of every `DECLSPEC`, to keep most of the AMD compile-time win at a smaller runtime cost; re-run the
+  parity gate after any change. The NVIDIA 4.5× figure shows the all-helpers hammer is expensive, so a
+  scalpel is worth trying on AMD.
+
+**Inputs:** AMD compile/throughput numbers + sweet-spot sweep in §4 "Cross-device"; the `noinline`
+mechanism + `comgr` cache controls in §9.
 
 ---
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1130,14 +1130,39 @@ detection — the Track-B branch-2 policy. Implemented as a tri-state `@Nullable
 remains a manual override. See §9 "How to enable". Steps 1 (benchmark `@Param`), 2 (NVIDIA measure) and
 4 (policy + code) are **done**.
 
-**Still open (AMD-side, optional):**
-- **Quantify what AMD pays** (step 3): warm the inlined `comgr` cache once (one uninterrupted ~16 min
-  inlined build), then A/B inlined vs `noinline` at the AMD sweet spot (`keysPerWorkItem=32`). Needs the
-  AMD box.
-- **Selective `noinline`** — apply only to the heaviest helpers (SHA-256, RIPEMD-160, safegcd) instead
-  of every `DECLSPEC`, to keep most of the AMD compile-time win at a smaller runtime cost; re-run the
-  parity gate after any change. The NVIDIA 4.5× figure shows the all-helpers hammer is expensive, so a
-  scalpel is worth trying on AMD.
+**Quantified — what AMD pays (step 3): ✅ DONE.** A/B on the **RX 7900 XTX** (compact,
+`batchSizeInBits=20`, `keysPerWorkItem=32`, reduced-radix on; `-f 1 -wi 1 -w 30 -i 1 -r 240`):
+
+| `noInlineHelpers` | throughput | M keys/s | relative |
+|---|--:|--:|--:|
+| `false` (inlined) | **265.98 ops/s** | ≈ 279 | 1.00× |
+| `true` (out-of-line, the AMD auto-default) | **79.63 ops/s** | ≈ 83 | **≈ 0.30× (~3.34× slower)** |
+
+So `noinline` costs AMD **~3.3×** runtime throughput — same order as NVIDIA's ~4.5×, **not** a cheap
+fix. Key consequence of the `comgr` cache: the inlined 8–16 min compile is a **one-time** cost (warm
+hits are ~0.7 s thereafter), so a **long-running AMD scan is ~3.3× faster with `noInlineHelpers=false`**
+once the cache is warm. The `null`=auto default (out-of-line on AMD) optimises **first-run / test /
+CI** convenience — it must never pay a 16 min compile — at the price of steady-state throughput.
+Practical guidance: for a sustained production scan on AMD, warm the cache once and set
+`noInlineHelpers=false` at `keysPerWorkItem ≈ 64`; leave it on auto everywhere else. (The §4 sweet-spot
+sweep used the `noinline` build, peak at 32; the *inline* peak is ≈ 64 — measured in the step-3
+follow-ups below.)
+
+**Investigated — step 3 AMD-side follow-ups: ✅ DONE (neither changes the policy).**
+- **Selective `noinline` — tried, not viable.** Tagging only the 6 heaviest *structural* helpers out-of-line
+  (comb `point_mul_xy_comb`, `point_add`, `point_add_xy`, `inv_mod_safegcd`, `sha256_transform`,
+  `ripemd160_transform`) via a `NOINLINE_HEAVY` marker — while keeping the field multiply
+  (`mul_mod`/`fe10x26_mul`) inline — compiled in **~5.3 min** (vs ~16 min fully inlined, ~3 s blanket).
+  Still far over the 180 s test-fork budget, so it cannot serve as the AMD default. Root cause: the
+  **field multiply is both the compile bottleneck** (inlined into `point_add`/`point_add_xy`/conversions
+  everywhere) **and the runtime-hottest function** — keep it inline and compile stays minutes;
+  out-of-line it and runtime collapses toward the blanket's 3.3×. No split wins both, so the blanket
+  out-of-line stays the AMD auto path and the experiment was reverted.
+- **Inline `keysPerWorkItem` sweet spot ≈ 64** (re-sweep done; RX 7900 XTX, compact, `batchSizeInBits=20`,
+  reduced-radix on, warm cache): 8 → 144.6, 16 → 205.9, 32 → 269.5, **64 → 274.7**, 128 → 244.3 ops/s
+  (≈ 288 M keys/s at the peak). The inline build prefers slightly fatter work-items than the `noinline`
+  build (sweet spot 32, §4), so for a sustained production scan on AMD use `noInlineHelpers=false` at
+  `keysPerWorkItem ≈ 64` (a broad 32–64 plateau).
 
 **Inputs:** AMD compile/throughput numbers + sweet-spot sweep in §4 "Cross-device"; the `noinline`
 mechanism + `comgr` cache controls in §9.

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
@@ -7,6 +7,7 @@ import static org.jocl.CL.CL_DEVICE_TYPE_ALL;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Configuration for the OpenCL (GPU) producer.
@@ -167,24 +168,34 @@ public class CProducerOpenCL extends CProducer {
 
     /**
      * Forces the kernel's helper functions out-of-line to fix pathological OpenCL compile times on
-     * AMD GPUs.
+     * AMD GPUs. <b>Tri-state</b> — {@code null}, {@link Boolean#TRUE}, {@link Boolean#FALSE}:
+     * <ul>
+     *   <li>{@code null} (<b>default</b>) — <b>auto / vendor-detect</b>: the build define is enabled
+     *       <em>only when the selected device is AMD</em> and disabled on every other vendor. The
+     *       decision and reason are logged at {@code INFO} by
+     *       {@code OpenCLContext.resolveEffectiveNoInlineHelpers(...)}. This is the recommended
+     *       setting: AMD gets the compile-time fix automatically, NVIDIA keeps full throughput.</li>
+     *   <li>{@link Boolean#TRUE} — <b>force on</b> regardless of vendor: the kernel is always built
+     *       with {@code -D AMD_NOINLINE_HELPERS}.</li>
+     *   <li>{@link Boolean#FALSE} — <b>force off</b> regardless of vendor: the define is never added,
+     *       even on AMD (a slow-compile warning is logged). Needed to A/B inlined vs. out-of-line on
+     *       an AMD device.</li>
+     * </ul>
      * <p>
-     * When {@code false} (default), the kernel is built normally: LLVM inlines the secp256k1, comb,
-     * safegcd and both hash160 helpers into one giant {@code generateKeysKernel_grid} function. On
-     * NVIDIA's (non-LLVM) back-end that compiles in seconds, but AMD's LLVM-based "LC"/comgr back-end
-     * (greedy register allocation + SelectionDAG scheduling) scales ~super-linearly per function, so
-     * that single huge function takes <b>8–16+ minutes</b> to build on AMD RDNA3 (measured: the full
-     * kernel did not finish within 16&nbsp;min on an RX&nbsp;7900&nbsp;XTX / gfx1100).
+     * <b>Background.</b> With the kernel inlined, AMD's LLVM-based "LC"/comgr back-end (greedy register
+     * allocation + SelectionDAG scheduling) scales ~super-linearly per function, so the single giant
+     * {@code generateKeysKernel_grid} takes <b>8–16+ minutes</b> to build on AMD RDNA3 (the full kernel
+     * did not finish within 16&nbsp;min on an RX&nbsp;7900&nbsp;XTX / gfx1100). The {@code -D
+     * AMD_NOINLINE_HELPERS} define makes the vendored {@code DECLSPEC} helpers
+     * {@code __attribute__((noinline))}, partitioning the back-end work into many small functions and
+     * cutting the cold compile to <b>≈3&nbsp;s</b>. (Removing the {@code inline} hint alone does nothing
+     * — LLVM still inlines at {@code -O3}; only a hard {@code noinline} stops it.)
      * <p>
-     * When {@code true}, the kernel is built with {@code -D AMD_NOINLINE_HELPERS}, which makes the
-     * vendored {@code DECLSPEC} helpers {@code __attribute__((noinline))}. This partitions the
-     * back-end work into many small functions and cut the cold compile from {@literal >}16&nbsp;min to
-     * <b>≈3&nbsp;s</b> on the RX&nbsp;7900&nbsp;XTX. (Removing the {@code inline} hint alone does
-     * nothing — LLVM still inlines at {@code -O3}; only a hard {@code noinline} stops it.)
-     * <p>
-     * Off by default and opt-in because out-of-line calls can cost runtime throughput: it must be
-     * validated with an NVIDIA throughput A/B before being enabled there. On AMD the compile-time win
-     * is decisive. See {@code docs/performance.md} ("slow AMD compile").
+     * <b>Why AMD-only.</b> Out-of-line calls cost runtime throughput: a matched NVIDIA A/B measured the
+     * out-of-line kernel <b>≈4.5× slower</b> on an RTX 3070 (≈ 45 vs ≈ 200 ops/s; see
+     * {@code docs/performance.md} §9–§10). On NVIDIA the inlined kernel compiles in seconds anyway, so
+     * there is no reason to pay that cost — hence the {@code null}-default auto-detect applies the fix
+     * to AMD alone. See {@code docs/performance.md} ("slow AMD compile").
      */
-    public boolean noInlineHelpers = false;
+    public @Nullable Boolean noInlineHelpers;
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
@@ -146,18 +146,45 @@ public class CProducerOpenCL extends CProducer {
     /**
      * Selects the field-arithmetic representation used in the scalar-walker hot loop.
      * <p>
-     * When {@code false} (default), the affine batched-addition walk computes coordinates in the
-     * vendored radix-2³² field ({@code copyfromhashcat/inc_ecc_secp256k1.cl}). When {@code true}, the
-     * kernel is built with {@code -D USE_REDUCED_RADIX_FIELD} and the walk holds coordinates in the
-     * reduced-radix 2²⁶ field ({@code inc_ecc_secp256k1_fe10x26.cl}), converting to radix-2³² only at
-     * the increment-table reads, the single per-sub-batch inverse, and the coordinate outputs.
+     * When {@code true} (default), the kernel is built with {@code -D USE_REDUCED_RADIX_FIELD} and the
+     * affine batched-addition walk holds coordinates in the reduced-radix 2²⁶ field
+     * ({@code inc_ecc_secp256k1_fe10x26.cl}), converting to radix-2³² only at the increment-table
+     * reads, the single per-sub-batch inverse, and the coordinate outputs. When {@code false}, the
+     * walk uses the vendored radix-2³² field ({@code copyfromhashcat/inc_ecc_secp256k1.cl}).
      * <p>
      * Motivation: the radix-2³² field multiply is carry-bound; the isolated {@code FieldMulBenchmark}
      * measured the 2²⁶ multiply ≈ 1.56× faster on an RTX 3070. The comb anchor and the
-     * {@code copyfromhashcat} files are unchanged either way. Off by default until the end-to-end gain
-     * is confirmed per device; correctness is identical (gated against bitcoinj by
-     * {@code ProbeAddressesOpenCLTest} / {@code ProbeAddressesManySeedsOpenCLTest} with the flag on).
-     * See {@code docs/performance.md} ("reduced-radix 2²⁶ field").
+     * {@code copyfromhashcat} files are unchanged either way.
+     * <p>
+     * <b>On by default</b> since the end-to-end gain was confirmed <b>cross-device</b>: ≈ +22% on an
+     * RTX 3070 (Ampere) and ≈ +8% on an AMD RX 7900 XTX (RDNA3), never a regression on either (see
+     * {@code docs/performance.md} §8 Stage 5 + §4 "Cross-device"). Set {@code false} to force the
+     * legacy radix-2³² walk for A/B comparison. Correctness is identical regardless of the setting —
+     * gated byte-for-byte against bitcoinj by {@code ProbeAddressesOpenCLTest} and
+     * {@code ProbeAddressesManySeedsOpenCLTest} (which builds the kernel with the flag both on and off).
      */
-    public boolean useReducedRadixField = false;
+    public boolean useReducedRadixField = true;
+
+    /**
+     * Forces the kernel's helper functions out-of-line to fix pathological OpenCL compile times on
+     * AMD GPUs.
+     * <p>
+     * When {@code false} (default), the kernel is built normally: LLVM inlines the secp256k1, comb,
+     * safegcd and both hash160 helpers into one giant {@code generateKeysKernel_grid} function. On
+     * NVIDIA's (non-LLVM) back-end that compiles in seconds, but AMD's LLVM-based "LC"/comgr back-end
+     * (greedy register allocation + SelectionDAG scheduling) scales ~super-linearly per function, so
+     * that single huge function takes <b>8–16+ minutes</b> to build on AMD RDNA3 (measured: the full
+     * kernel did not finish within 16&nbsp;min on an RX&nbsp;7900&nbsp;XTX / gfx1100).
+     * <p>
+     * When {@code true}, the kernel is built with {@code -D AMD_NOINLINE_HELPERS}, which makes the
+     * vendored {@code DECLSPEC} helpers {@code __attribute__((noinline))}. This partitions the
+     * back-end work into many small functions and cut the cold compile from {@literal >}16&nbsp;min to
+     * <b>≈3&nbsp;s</b> on the RX&nbsp;7900&nbsp;XTX. (Removing the {@code inline} hint alone does
+     * nothing — LLVM still inlines at {@code -O3}; only a hard {@code noinline} stops it.)
+     * <p>
+     * Off by default and opt-in because out-of-line calls can cost runtime throughput: it must be
+     * validated with an NVIDIA throughput A/B before being enabled there. On AMD the compile-time win
+     * is decisive. See {@code docs/performance.md} ("slow AMD compile").
+     */
+    public boolean noInlineHelpers = false;
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -175,6 +175,15 @@ public class OpenCLContext implements ReleaseCLObject {
     static final String REDUCED_RADIX_FIELD_BUILD_OPTION = "-D USE_REDUCED_RADIX_FIELD";
 
     /**
+     * Build define that forces the kernel's {@code DECLSPEC} helpers out-of-line
+     * ({@code __attribute__((noinline))}). Appended only when {@link CProducerOpenCL#noInlineHelpers}
+     * is {@code true}; it slashes the AMD LLVM/comgr cold compile time (≈ minutes → seconds) by
+     * partitioning the otherwise-megamerged kernel. See {@code docs/performance.md}.
+     */
+    @VisibleForTesting
+    static final String NO_INLINE_HELPERS_BUILD_OPTION = "-D AMD_NOINLINE_HELPERS";
+
+    /**
      * Assembles the {@code clBuildProgram} options string: the constant {@link #CL_BUILD_OPTIONS},
      * plus {@link #LEGACY_BINARY_GCD_INV_MOD_BUILD_OPTION} when {@link CProducerOpenCL#useSafeGcdInverse}
      * is {@code false}, the profiling define for a non-{@code FULL}
@@ -206,6 +215,9 @@ public class OpenCLContext implements ReleaseCLObject {
         }
         if (producerOpenCL.useReducedRadixField) {
             options.append(' ').append(REDUCED_RADIX_FIELD_BUILD_OPTION);
+        }
+        if (producerOpenCL.noInlineHelpers) {
+            options.append(' ').append(NO_INLINE_HELPERS_BUILD_OPTION);
         }
         return options.toString();
     }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.ToString;
@@ -176,25 +177,109 @@ public class OpenCLContext implements ReleaseCLObject {
 
     /**
      * Build define that forces the kernel's {@code DECLSPEC} helpers out-of-line
-     * ({@code __attribute__((noinline))}). Appended only when {@link CProducerOpenCL#noInlineHelpers}
-     * is {@code true}; it slashes the AMD LLVM/comgr cold compile time (≈ minutes → seconds) by
-     * partitioning the otherwise-megamerged kernel. See {@code docs/performance.md}.
+     * ({@code __attribute__((noinline))}). Appended when the <em>effective</em> noinline decision is
+     * {@code true} (see {@link #resolveEffectiveNoInlineHelpers}); it slashes the AMD LLVM/comgr cold
+     * compile time (≈ minutes → seconds) by partitioning the otherwise-megamerged kernel, at a heavy
+     * runtime cost on other vendors (≈4.5× slower on NVIDIA). See {@code docs/performance.md}.
      */
     @VisibleForTesting
     static final String NO_INLINE_HELPERS_BUILD_OPTION = "-D AMD_NOINLINE_HELPERS";
 
     /**
-     * Assembles the {@code clBuildProgram} options string: the constant {@link #CL_BUILD_OPTIONS},
-     * plus {@link #LEGACY_BINARY_GCD_INV_MOD_BUILD_OPTION} when {@link CProducerOpenCL#useSafeGcdInverse}
-     * is {@code false}, the profiling define for a non-{@code FULL}
-     * {@link CProducerOpenCL#kernelProfileStage}, {@link #NV_VERBOSE_BUILD_OPTION} when
+     * Returns whether an OpenCL {@code CL_DEVICE_VENDOR} string denotes an AMD device. Case-insensitive
+     * match on {@code "amd"} or {@code "advanced micro devices"} (the two forms AMD's OpenCL runtimes
+     * report). {@code null}/blank → {@code false}.
+     *
+     * @param deviceVendor the device's {@code CL_DEVICE_VENDOR} string (may be {@code null})
+     * @return {@code true} iff the vendor string identifies AMD
+     */
+    @VisibleForTesting
+    static boolean isAmdVendor(@Nullable String deviceVendor) {
+        if (deviceVendor == null) {
+            return false;
+        }
+        final String v = deviceVendor.toLowerCase(Locale.ROOT);
+        return v.contains("amd") || v.contains("advanced micro devices");
+    }
+
+    /**
+     * Resolves the <b>effective</b> {@code noInlineHelpers} decision for the selected device and logs
+     * the outcome with its reason. Honours the tri-state {@link CProducerOpenCL#noInlineHelpers}:
+     * <ul>
+     *   <li>{@code null} (auto) → {@code true} only when {@link #isAmdVendor(String)} matches the
+     *       device vendor (the AMD multi-minute-compile fix), {@code false} on every other vendor.</li>
+     *   <li>explicit {@link Boolean#TRUE}/{@link Boolean#FALSE} → used verbatim (vendor-detection
+     *       skipped); an explicit {@code false} on an AMD device additionally logs a slow-compile
+     *       warning.</li>
+     * </ul>
+     *
+     * <p>Logged because the choice materially changes both compile time (minutes vs seconds on AMD) and
+     * runtime throughput (≈4.5× on NVIDIA) — operators need an unambiguous record of which path ran and
+     * why. See {@code docs/performance.md} §9–§10.
+     *
+     * @param deviceName   the selected device's {@code CL_DEVICE_NAME} (for the log line)
+     * @param deviceVendor the selected device's {@code CL_DEVICE_VENDOR}
+     * @return the effective decision: {@code true} to build with {@link #NO_INLINE_HELPERS_BUILD_OPTION}
+     */
+    @VisibleForTesting
+    boolean resolveEffectiveNoInlineHelpers(String deviceName, @Nullable String deviceVendor) {
+        final Boolean configured = producerOpenCL.noInlineHelpers;
+        if (configured != null) {
+            if (!configured && isAmdVendor(deviceVendor)) {
+                LOGGER.warn(
+                        "noInlineHelpers is explicitly FALSE on AMD device '{}' (vendor '{}'): building the "
+                                + "fully-inlined kernel, which can take 8-16+ minutes to compile on AMD's LLVM/comgr "
+                                + "back-end (see docs/performance.md, AMD compile section). Set noInlineHelpers=null "
+                                + "(auto) to let the AMD-only out-of-line compile fix engage automatically.",
+                        deviceName,
+                        deviceVendor);
+            } else {
+                LOGGER.info(
+                        "noInlineHelpers={} (explicit configuration) for device '{}' (vendor '{}'); "
+                                + "vendor auto-detection skipped, {} the kernel.",
+                        configured,
+                        deviceName,
+                        deviceVendor,
+                        configured ? "out-of-lining (-D AMD_NOINLINE_HELPERS)" : "inlining");
+            }
+            return configured;
+        }
+        // null = auto: enable the out-of-line compile fix for AMD only.
+        if (isAmdVendor(deviceVendor)) {
+            LOGGER.info(
+                    "noInlineHelpers=auto: AMD device detected ('{}', vendor '{}') -> ENABLING "
+                            + "-D AMD_NOINLINE_HELPERS. Out-of-lining the DECLSPEC helpers cuts the AMD cold compile "
+                            + "from 8-16+ min to ~3 s (see docs/performance.md, AMD compile section). This costs "
+                            + "runtime throughput on other vendors (~4.5x slower on NVIDIA), so it is applied to AMD "
+                            + "only.",
+                    deviceName,
+                    deviceVendor);
+            return true;
+        }
+        LOGGER.info(
+                "noInlineHelpers=auto: non-AMD device ('{}', vendor '{}') -> keeping helpers INLINED for full "
+                        + "throughput (the AMD-only out-of-line compile fix is not needed here).",
+                deviceName,
+                deviceVendor);
+        return false;
+    }
+
+    /**
+     * Assembles the {@code clBuildProgram} options string for this context's producer configuration,
+     * using {@code effectiveNoInlineHelpers} for the {@link #NO_INLINE_HELPERS_BUILD_OPTION} decision
+     * (already resolved against the device vendor by {@link #resolveEffectiveNoInlineHelpers}). Includes
+     * {@link #CL_BUILD_OPTIONS}, plus {@link #LEGACY_BINARY_GCD_INV_MOD_BUILD_OPTION} when
+     * {@link CProducerOpenCL#useSafeGcdInverse} is {@code false}, the profiling define for a
+     * non-{@code FULL} {@link CProducerOpenCL#kernelProfileStage}, {@link #NV_VERBOSE_BUILD_OPTION} when
      * {@link CProducerOpenCL#logGpuDiagnostics} is set, and {@link #REDUCED_RADIX_FIELD_BUILD_OPTION}
      * when {@link CProducerOpenCL#useReducedRadixField} is set.
      *
-     * @return the build options string for this context's producer configuration
+     * @param effectiveNoInlineHelpers the resolved noinline decision (see
+     *     {@link #resolveEffectiveNoInlineHelpers})
+     * @return the build options string
      */
     @VisibleForTesting
-    String buildOptions() {
+    String buildOptions(boolean effectiveNoInlineHelpers) {
         final StringBuilder options = new StringBuilder(CL_BUILD_OPTIONS);
         if (!producerOpenCL.useSafeGcdInverse) {
             options.append(' ').append(LEGACY_BINARY_GCD_INV_MOD_BUILD_OPTION);
@@ -216,10 +301,23 @@ public class OpenCLContext implements ReleaseCLObject {
         if (producerOpenCL.useReducedRadixField) {
             options.append(' ').append(REDUCED_RADIX_FIELD_BUILD_OPTION);
         }
-        if (producerOpenCL.noInlineHelpers) {
+        if (effectiveNoInlineHelpers) {
             options.append(' ').append(NO_INLINE_HELPERS_BUILD_OPTION);
         }
         return options.toString();
+    }
+
+    /**
+     * Config-only overload used where no device vendor is available (unit tests). Treats the tri-state
+     * {@link CProducerOpenCL#noInlineHelpers} as {@code true} iff explicitly {@link Boolean#TRUE}
+     * ({@code null} auto and {@link Boolean#FALSE} both omit the define); the vendor-aware auto path is
+     * exercised through {@link #resolveEffectiveNoInlineHelpers} + {@link #buildOptions(boolean)}.
+     *
+     * @return the build options string for the configured (non-auto-resolved) flags
+     */
+    @VisibleForTesting
+    String buildOptions() {
+        return buildOptions(Boolean.TRUE.equals(producerOpenCL.noInlineHelpers));
     }
 
     private static final ComparableVersion REQUIRED_COMPACT_MODE_VERSION = new ComparableVersion("2.0");
@@ -385,8 +483,12 @@ public class OpenCLContext implements ReleaseCLObject {
         program = clCreateProgramWithSource(context, openCLPrograms.length, openCLPrograms, null, null);
 
         // Build the program with the Stage-0 quick-win options (see CL_BUILD_OPTIONS), plus the
-        // per-config modular-inverse selector (see CProducerOpenCL.useSafeGcdInverse).
-        clBuildProgram(program, 0, null, buildOptions(), null, null);
+        // per-config modular-inverse selector (see CProducerOpenCL.useSafeGcdInverse). The noinline
+        // helper decision is resolved here against the selected device's vendor (auto-enabled for AMD
+        // only; logged) — see resolveEffectiveNoInlineHelpers.
+        final boolean effectiveNoInlineHelpers =
+                resolveEffectiveNoInlineHelpers(device.deviceName(), device.deviceVendor());
+        clBuildProgram(program, 0, null, buildOptions(effectiveNoInlineHelpers), null, null);
 
         if (producerOpenCL.logGpuDiagnostics) {
             logProgramBuildLog(device);

--- a/src/main/resources/copyfromhashcat/inc_vendor.h
+++ b/src/main/resources/copyfromhashcat/inc_vendor.h
@@ -157,6 +157,17 @@ using namespace metal;
 #define DECLSPEC __device__
 #elif defined IS_HIP
 #define DECLSPEC __device__ HC_INLINE
+#elif defined AMD_NOINLINE_HELPERS
+// AMD/OpenCL compile-time experiment (opt-in via -D AMD_NOINLINE_HELPERS). On the generic OpenCL
+// path DECLSPEC is normally empty, so helpers carry no `inline` hint -- but LLVM (AMD's "LC"/comgr
+// back-end) still inlines them at -O3, megamerging the entire secp256k1 + double-hash160 + safegcd
+// kernel into one giant function. The LLVM back-end (greedy regalloc + SelectionDAG scheduling)
+// scales ~super-linearly per function, so that single huge function takes 8-16+ min to build on AMD
+// RDNA3 (vs seconds on NVIDIA's separate ptxas). Forcing the heavy DECLSPEC helpers out-of-line
+// partitions the back-end work into many smaller functions. See docs/performance.md ("slow AMD
+// compile"). Trade-off: out-of-line calls can cost runtime throughput, so this is opt-in and must be
+// validated with an NVIDIA A/B + the parity gate before becoming a default.
+#define DECLSPEC __attribute__((noinline))
 #else
 #define DECLSPEC
 #endif

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLAddKernelSmokeTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLAddKernelSmokeTest.java
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.jocl.CL.CL_MEM_COPY_HOST_PTR;
+import static org.jocl.CL.CL_MEM_READ_ONLY;
+import static org.jocl.CL.CL_MEM_WRITE_ONLY;
+import static org.jocl.CL.CL_TRUE;
+import static org.jocl.CL.clBuildProgram;
+import static org.jocl.CL.clCreateBuffer;
+import static org.jocl.CL.clCreateCommandQueueWithProperties;
+import static org.jocl.CL.clCreateContext;
+import static org.jocl.CL.clCreateKernel;
+import static org.jocl.CL.clCreateProgramWithSource;
+import static org.jocl.CL.clEnqueueNDRangeKernel;
+import static org.jocl.CL.clEnqueueReadBuffer;
+import static org.jocl.CL.clFinish;
+import static org.jocl.CL.clReleaseCommandQueue;
+import static org.jocl.CL.clReleaseContext;
+import static org.jocl.CL.clReleaseKernel;
+import static org.jocl.CL.clReleaseMemObject;
+import static org.jocl.CL.clReleaseProgram;
+import static org.jocl.CL.clSetKernelArg;
+import static org.jocl.CL.setExceptionsEnabled;
+
+import java.util.List;
+import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLBuilder;
+import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDevice;
+import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
+import org.jocl.Pointer;
+import org.jocl.Sizeof;
+import org.jocl.cl_command_queue;
+import org.jocl.cl_context;
+import org.jocl.cl_device_id;
+import org.jocl.cl_kernel;
+import org.jocl.cl_mem;
+import org.jocl.cl_program;
+import org.jocl.cl_queue_properties;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Minimal OpenCL smoke test: compiles and runs a trivial element-wise {@code add} kernel on every
+ * discovered device.
+ *
+ * <p>Its purpose is to verify the bare OpenCL pipeline — build program, set args, enqueue, read back
+ * — works on any vendor (NVIDIA, AMD, or a CPU runtime such as pocl), <em>independently</em> of the
+ * large {@code generateKeysKernel_grid} secp256k1 kernel. The production kernel is a single huge
+ * fully-inlined function whose build time is vendor-sensitive (seconds on NVIDIA, minutes on some
+ * AMD LLVM toolchains); this test deliberately uses a tiny kernel that compiles in milliseconds
+ * everywhere, so "does OpenCL work on this box at all?" can be answered in well under a second.
+ *
+ * <p>Requires only that the OpenCL native library and at least one device are present; it does
+ * <em>not</em> require OpenCL 2.0 (a plain {@code add} needs nothing newer), so it runs on the
+ * widest possible device set. It self-skips (does not fail) when no OpenCL library is available.
+ */
+public class OpenCLAddKernelSmokeTest {
+
+    /** Trivial, vendor-neutral element-wise integer add kernel. Compiles in milliseconds anywhere. */
+    private static final String ADD_KERNEL_SOURCE =
+            "__kernel void add(__global const int* a, __global const int* b, __global int* out) {\n"
+                    + "    int i = get_global_id(0);\n"
+                    + "    out[i] = a[i] + b[i];\n"
+                    + "}\n";
+
+    /** Build options pinned to OpenCL C 1.2, matching the production kernel build (a plain add needs nothing newer). */
+    private static final String BUILD_OPTIONS = "-cl-std=CL1.2";
+
+    /** Kernel entry-point name. */
+    private static final String KERNEL_NAME = "add";
+
+    /** Number of work-items / array elements exercised. */
+    private static final int ELEMENT_COUNT = 1024;
+
+    // <editor-fold defaultstate="collapsed" desc="addKernel_allDevices_computeElementwiseSum">
+    @Test
+    @OpenCLTest
+    public void addKernel_allDevices_computeElementwiseSum() {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailable();
+        // arrange
+        setExceptionsEnabled(true);
+        List<OpenCLPlatform> openCLPlatforms = new OpenCLBuilder().build();
+
+        // act + assert: run the add kernel on every discovered device and verify each result.
+        int devicesExercised = 0;
+        for (OpenCLPlatform openCLPlatform : openCLPlatforms) {
+            for (OpenCLDevice openCLDevice : openCLPlatform.openCLDevices()) {
+                runAddKernelOnDevice(openCLPlatform, openCLDevice);
+                devicesExercised++;
+            }
+        }
+
+        // assert: the library was available, so at least one device must have been exercised.
+        assertThat(devicesExercised, is(greaterThan(0)));
+    }
+    // </editor-fold>
+
+    /**
+     * Compiles and runs the {@link #ADD_KERNEL_SOURCE} kernel on a single device and asserts that
+     * every output element equals the element-wise sum of its inputs. All OpenCL resources created
+     * here are released before returning so the test never leaks across devices.
+     *
+     * @param openCLPlatform the platform owning the device (provides the context properties)
+     * @param openCLDevice   the device to build and run the kernel on
+     */
+    private void runAddKernelOnDevice(OpenCLPlatform openCLPlatform, OpenCLDevice openCLDevice) {
+        final int[] a = new int[ELEMENT_COUNT];
+        final int[] b = new int[ELEMENT_COUNT];
+        final int[] out = new int[ELEMENT_COUNT];
+        for (int i = 0; i < ELEMENT_COUNT; i++) {
+            a[i] = i;
+            b[i] = 2 * i + 1;
+        }
+
+        final cl_device_id deviceId = openCLDevice.device();
+        final cl_context context =
+                clCreateContext(openCLPlatform.contextProperties(), 1, new cl_device_id[] {deviceId}, null, null, null);
+        final cl_command_queue commandQueue =
+                clCreateCommandQueueWithProperties(context, deviceId, new cl_queue_properties(), null);
+        final cl_program program = clCreateProgramWithSource(context, 1, new String[] {ADD_KERNEL_SOURCE}, null, null);
+        clBuildProgram(program, 0, null, BUILD_OPTIONS, null, null);
+        final cl_kernel kernel = clCreateKernel(program, KERNEL_NAME, null);
+
+        final long intBufferBytes = (long) Sizeof.cl_int * ELEMENT_COUNT;
+        final cl_mem aMem =
+                clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, intBufferBytes, Pointer.to(a), null);
+        final cl_mem bMem =
+                clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, intBufferBytes, Pointer.to(b), null);
+        final cl_mem outMem = clCreateBuffer(context, CL_MEM_WRITE_ONLY, intBufferBytes, null, null);
+        try {
+            clSetKernelArg(kernel, 0, Sizeof.cl_mem, Pointer.to(aMem));
+            clSetKernelArg(kernel, 1, Sizeof.cl_mem, Pointer.to(bMem));
+            clSetKernelArg(kernel, 2, Sizeof.cl_mem, Pointer.to(outMem));
+
+            clEnqueueNDRangeKernel(commandQueue, kernel, 1, null, new long[] {ELEMENT_COUNT}, null, 0, null, null);
+            clEnqueueReadBuffer(commandQueue, outMem, CL_TRUE, 0, intBufferBytes, Pointer.to(out), 0, null, null);
+            clFinish(commandQueue);
+
+            for (int i = 0; i < ELEMENT_COUNT; i++) {
+                assertThat(
+                        "add kernel result on device " + openCLDevice.deviceName() + " at index " + i,
+                        out[i],
+                        is(a[i] + b[i]));
+            }
+        } finally {
+            clReleaseMemObject(aMem);
+            clReleaseMemObject(bMem);
+            clReleaseMemObject(outMem);
+            clReleaseKernel(kernel);
+            clReleaseProgram(program);
+            clReleaseCommandQueue(commandQueue);
+            clReleaseContext(context);
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
@@ -629,6 +629,45 @@ public class ProbeAddressesOpenCLTest {
         }
     }
 
+    /**
+     * Byte-identical parity with {@code noInlineHelpers = true} ({@code -D AMD_NOINLINE_HELPERS}).
+     *
+     * <p>The {@code noinline} build forces the kernel's {@code DECLSPEC} helpers out-of-line to fix
+     * the multi-minute AMD/LLVM compile (see {@code docs/performance.md} §9). It is a pure compile
+     * directive and must not change results — this test pins that: it derives a full batch with the
+     * flag on (at {@code keysPerWorkItem > 1}, so the affine walk's out-of-line {@code point_add_xy} /
+     * {@code mul_mod} are exercised) and byte-compares every public key + hash160 against the bitcoinj
+     * reference via {@link #assertPublicKeyBytesCalculatedCorrect}. It also guards against a future
+     * helper that cannot legally be {@code noinline}: the build would fail or the output would diverge,
+     * and this test would catch it. Short by design (one small batch); the inline path is covered
+     * exhaustively by {@link #createKeys_acrossKeysPerWorkItem_allResultsMatchReference}.
+     */
+    @Test
+    @OpenCLTest
+    public void createKeys_noInlineHelpers_resultsMatchReference() throws IOException {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+
+        KeyUtility keyUtility = new KeyUtility(network, byteBufferUtility);
+
+        CProducerOpenCL producerOpenCL = new CProducerOpenCL();
+        producerOpenCL.batchSizeInBits = BITS_FOR_BATCH;
+        producerOpenCL.keysPerWorkItem = KEYS_PER_WORK_ITEM;
+        producerOpenCL.noInlineHelpers = true;
+        try (OpenCLContext openCLContext = new OpenCLContext(producerOpenCL, bitHelper)) {
+            openCLContext.init();
+            Random random = new Random(1337);
+            BigInteger secretKeyBase = keyUtility.createSecret(Secp256k1Constants.PRIVATE_KEY_MAX_NUM_BITS, random);
+            BigInteger secretBase =
+                    keyUtility.alignDown(secretKeyBase, bitHelper.getLowBitMask(producerOpenCL.batchSizeInBits));
+
+            OpenCLGridResult createKeys = openCLContext.createKeys(secretBase);
+            PublicKeyBytes[] publicKeys = createKeys.getPublicKeyBytes();
+
+            assertThat(publicKeys.length, is(equalTo((int) bitHelper.convertBitsToSize(BITS_FOR_BATCH))));
+            assertPublicKeyBytesCalculatedCorrect(publicKeys, secretBase, false, keyUtility);
+        }
+    }
+
     private static void assertAllRuntimePublicKeyCalculationsValid(PublicKeyBytes[] publicKeys) {
         for (int i = 0; i < publicKeys.length; i++) {
             assertRuntimePublicKeyCalculationValid(publicKeys[i]);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
@@ -218,6 +218,19 @@ public class GpuFuse8FilterBenchmark {
     @Param({"false"})
     public boolean useReducedRadixField;
 
+    /**
+     * Forces the kernel's {@code DECLSPEC} helpers out-of-line ({@link CProducerOpenCL#noInlineHelpers},
+     * build define {@code -D AMD_NOINLINE_HELPERS}). {@code false} = normal fully-inlined kernel
+     * (default); {@code true} = helpers built {@code __attribute__((noinline))}. This is purely a
+     * compile-time fix for AMD's LLVM/comgr back-end (minutes → seconds; see {@code docs/performance.md}
+     * §9) and is correctness-neutral. Sweep both (e.g. {@code -p noInlineHelpers=false,true}, both
+     * orderings) at the device sweet spot to measure the <em>runtime</em> throughput cost of
+     * out-of-line calls on NVIDIA — the open question gating whether it can be auto-enabled for AMD or
+     * made a global default (§10 "Track B").
+     */
+    @Param({"false"})
+    public boolean noInlineHelpers;
+
     private OpenCLContext ctx;
     private BigInteger privateKeyBase;
 
@@ -253,6 +266,7 @@ public class GpuFuse8FilterBenchmark {
         p.useSafeGcdInverse = useSafeGcdInverse;
         p.kernelProfileStage = kernelProfileStage;
         p.useReducedRadixField = useReducedRadixField;
+        p.noInlineHelpers = noInlineHelpers;
 
         ctx = new OpenCLContext(p, new BitHelper());
         ctx.init();

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCLTest.java
@@ -35,6 +35,30 @@ public class CProducerOpenCLTest {
     }
 
     @Test
+    public void defaults_noInlineHelpers_isFalse() {
+        // arrange + act
+        CProducerOpenCL config = new CProducerOpenCL();
+
+        // assert
+        assertThat(config.noInlineHelpers, is(false));
+    }
+
+    @Test
+    public void jsonRoundTrip_noInlineHelpers_survivesSerialiseDeserialise() throws Exception {
+        // arrange
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        CProducerOpenCL original = new CProducerOpenCL();
+        original.noInlineHelpers = true;
+
+        // act
+        String json = mapper.writeValueAsString(original);
+        CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
+
+        // assert
+        assertThat(parsed.noInlineHelpers, is(true));
+    }
+
+    @Test
     public void jsonRoundTrip_enableProfiling_survivesSerialiseDeserialise() throws Exception {
         // arrange
         ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -216,12 +240,13 @@ public class CProducerOpenCLTest {
     }
 
     @Test
-    public void defaults_useReducedRadixField_isFalse() {
+    public void defaults_useReducedRadixField_isTrue() {
         // arrange + act
         CProducerOpenCL config = new CProducerOpenCL();
 
-        // assert
-        assertThat(config.useReducedRadixField, is(false));
+        // assert: reduced-radix 2^26 is the default after the cross-device win was confirmed
+        // (+22% RTX 3070 / +8% AMD RX 7900 XTX); see docs/performance.md.
+        assertThat(config.useReducedRadixField, is(true));
     }
 
     @Test
@@ -240,7 +265,7 @@ public class CProducerOpenCLTest {
     }
 
     @Test
-    public void jsonDeserialise_useReducedRadixFieldAbsent_defaultsToFalse() throws Exception {
+    public void jsonDeserialise_useReducedRadixFieldAbsent_defaultsToTrue() throws Exception {
         // arrange
         ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         String json = "{}";
@@ -249,6 +274,6 @@ public class CProducerOpenCLTest {
         CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
 
         // assert
-        assertThat(parsed.useReducedRadixField, is(false));
+        assertThat(parsed.useReducedRadixField, is(true));
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCLTest.java
@@ -5,6 +5,7 @@ package net.ladenthin.bitcoinaddressfinder.configuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,27 +36,56 @@ public class CProducerOpenCLTest {
     }
 
     @Test
-    public void defaults_noInlineHelpers_isFalse() {
+    public void defaults_noInlineHelpers_isNull() {
         // arrange + act
         CProducerOpenCL config = new CProducerOpenCL();
 
-        // assert
-        assertThat(config.noInlineHelpers, is(false));
+        // assert: null = auto / vendor-detect (enabled for AMD only); see OpenCLContext
+        // .resolveEffectiveNoInlineHelpers and docs/performance.md §9-§10.
+        assertThat(config.noInlineHelpers, is(nullValue()));
     }
 
     @Test
-    public void jsonRoundTrip_noInlineHelpers_survivesSerialiseDeserialise() throws Exception {
+    public void jsonRoundTrip_noInlineHelpersTrue_survivesSerialiseDeserialise() throws Exception {
         // arrange
         ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         CProducerOpenCL original = new CProducerOpenCL();
-        original.noInlineHelpers = true;
+        original.noInlineHelpers = Boolean.TRUE;
 
         // act
         String json = mapper.writeValueAsString(original);
         CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
 
         // assert
-        assertThat(parsed.noInlineHelpers, is(true));
+        assertThat(parsed.noInlineHelpers, is(Boolean.TRUE));
+    }
+
+    @Test
+    public void jsonRoundTrip_noInlineHelpersFalse_survivesSerialiseDeserialise() throws Exception {
+        // arrange
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        CProducerOpenCL original = new CProducerOpenCL();
+        original.noInlineHelpers = Boolean.FALSE;
+
+        // act
+        String json = mapper.writeValueAsString(original);
+        CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
+
+        // assert
+        assertThat(parsed.noInlineHelpers, is(Boolean.FALSE));
+    }
+
+    @Test
+    public void jsonDeserialise_noInlineHelpersAbsent_defaultsToNull() throws Exception {
+        // arrange
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        String json = "{}";
+
+        // act
+        CProducerOpenCL parsed = mapper.readValue(json, CProducerOpenCL.class);
+
+        // assert: absent stays null (auto), so the AMD vendor-detect can engage
+        assertThat(parsed.noInlineHelpers, is(nullValue()));
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContextTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContextTest.java
@@ -227,10 +227,10 @@ public class OpenCLContextTest {
     }
 
     @Test
-    public void buildOptions_noInlineHelpersFalse_omitsNoInlineDefine() {
+    public void buildOptions_noInlineHelpersExplicitFalse_omitsNoInlineDefine() {
         // arrange
         CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
-        cProducerOpenCL.noInlineHelpers = false;
+        cProducerOpenCL.noInlineHelpers = Boolean.FALSE;
         OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
 
         // act
@@ -241,10 +241,10 @@ public class OpenCLContextTest {
     }
 
     @Test
-    public void buildOptions_noInlineHelpersTrue_appendsNoInlineDefine() {
+    public void buildOptions_noInlineHelpersExplicitTrue_appendsNoInlineDefine() {
         // arrange
         CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
-        cProducerOpenCL.noInlineHelpers = true;
+        cProducerOpenCL.noInlineHelpers = Boolean.TRUE;
         OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
 
         // act
@@ -252,6 +252,138 @@ public class OpenCLContextTest {
 
         // assert
         assertThat(options, containsString(OpenCLContext.NO_INLINE_HELPERS_BUILD_OPTION));
+    }
+
+    @Test
+    public void buildOptions_noInlineHelpersNullAuto_omitsNoInlineDefine() {
+        // arrange: null (auto) must NOT append the define via the config-only overload; the AMD
+        // vendor-detect lives in resolveEffectiveNoInlineHelpers + buildOptions(boolean) instead.
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.noInlineHelpers = null;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        // act
+        String options = openCLContext.buildOptions();
+
+        // assert
+        assertThat(options, not(containsString(OpenCLContext.NO_INLINE_HELPERS_BUILD_OPTION)));
+    }
+
+    @Test
+    public void buildOptionsBoolean_true_appendsNoInlineDefine() {
+        // arrange
+        OpenCLContext openCLContext = new OpenCLContext(new CProducerOpenCL(), bitHelper);
+
+        // act + assert
+        assertThat(openCLContext.buildOptions(true), containsString(OpenCLContext.NO_INLINE_HELPERS_BUILD_OPTION));
+        assertThat(
+                openCLContext.buildOptions(false), not(containsString(OpenCLContext.NO_INLINE_HELPERS_BUILD_OPTION)));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="noInlineHelpers vendor auto-detect">
+    @Test
+    public void isAmdVendor_recognisesAmdReportsRejectsOthers() {
+        // AMD's OpenCL runtimes report either form; match is case-insensitive.
+        assertThat(OpenCLContext.isAmdVendor("Advanced Micro Devices, Inc."), is(true));
+        assertThat(OpenCLContext.isAmdVendor("AMD"), is(true));
+        assertThat(OpenCLContext.isAmdVendor("amd"), is(true));
+        // non-AMD vendors.
+        assertThat(OpenCLContext.isAmdVendor("NVIDIA Corporation"), is(false));
+        assertThat(OpenCLContext.isAmdVendor("Intel(R) Corporation"), is(false));
+        assertThat(OpenCLContext.isAmdVendor("The pocl project"), is(false));
+        // defensive: null/blank.
+        assertThat(OpenCLContext.isAmdVendor(null), is(false));
+        assertThat(OpenCLContext.isAmdVendor(""), is(false));
+    }
+
+    @Test
+    public void resolveEffectiveNoInlineHelpers_autoOnAmd_enablesAndLogsReason() {
+        // arrange: null = auto.
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.noInlineHelpers = null;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(OpenCLContext.class)) {
+            // act
+            boolean effective = openCLContext.resolveEffectiveNoInlineHelpers(
+                    "AMD Radeon RX 7900 XTX", "Advanced Micro Devices, Inc.");
+
+            // assert
+            assertThat(effective, is(true));
+            assertThat(
+                    logCaptor.getInfoLogs().stream()
+                            .anyMatch(m -> m.contains("noInlineHelpers=auto")
+                                    && m.contains("AMD device detected")
+                                    && m.contains("ENABLING")),
+                    is(true));
+        }
+    }
+
+    @Test
+    public void resolveEffectiveNoInlineHelpers_autoOnNonAmd_disablesAndLogsReason() {
+        // arrange: null = auto.
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.noInlineHelpers = null;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(OpenCLContext.class)) {
+            // act
+            boolean effective = openCLContext.resolveEffectiveNoInlineHelpers(
+                    "NVIDIA GeForce RTX 3070 Laptop GPU", "NVIDIA Corporation");
+
+            // assert
+            assertThat(effective, is(false));
+            assertThat(
+                    logCaptor.getInfoLogs().stream()
+                            .anyMatch(m -> m.contains("noInlineHelpers=auto")
+                                    && m.contains("non-AMD device")
+                                    && m.contains("INLINED")),
+                    is(true));
+        }
+    }
+
+    @Test
+    public void resolveEffectiveNoInlineHelpers_explicitTrue_honouredRegardlessOfVendor() {
+        // arrange
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.noInlineHelpers = Boolean.TRUE;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(OpenCLContext.class)) {
+            // act: forced on even on a non-AMD device.
+            boolean effective =
+                    openCLContext.resolveEffectiveNoInlineHelpers("NVIDIA GeForce RTX 3070", "NVIDIA Corporation");
+
+            // assert
+            assertThat(effective, is(true));
+            assertThat(
+                    logCaptor.getInfoLogs().stream()
+                            .anyMatch(m -> m.contains("explicit configuration")
+                                    && m.contains("vendor auto-detection skipped")),
+                    is(true));
+        }
+    }
+
+    @Test
+    public void resolveEffectiveNoInlineHelpers_explicitFalseOnAmd_honouredWithSlowCompileWarning() {
+        // arrange
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.noInlineHelpers = Boolean.FALSE;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        try (LogCaptor logCaptor = LogCaptor.forClass(OpenCLContext.class)) {
+            // act: forced off on AMD (needed to A/B inlined vs out-of-line on AMD).
+            boolean effective = openCLContext.resolveEffectiveNoInlineHelpers(
+                    "AMD Radeon RX 7900 XTX", "Advanced Micro Devices, Inc.");
+
+            // assert: honoured, but a slow-compile warning is logged.
+            assertThat(effective, is(false));
+            assertThat(
+                    logCaptor.getWarnLogs().stream()
+                            .anyMatch(m -> m.contains("explicitly FALSE on AMD device") && m.contains("8-16+ minutes")),
+                    is(true));
+        }
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContextTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContextTest.java
@@ -225,6 +225,34 @@ public class OpenCLContextTest {
         // assert
         assertThat(options, containsString(OpenCLContext.REDUCED_RADIX_FIELD_BUILD_OPTION));
     }
+
+    @Test
+    public void buildOptions_noInlineHelpersFalse_omitsNoInlineDefine() {
+        // arrange
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.noInlineHelpers = false;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        // act
+        String options = openCLContext.buildOptions();
+
+        // assert
+        assertThat(options, not(containsString(OpenCLContext.NO_INLINE_HELPERS_BUILD_OPTION)));
+    }
+
+    @Test
+    public void buildOptions_noInlineHelpersTrue_appendsNoInlineDefine() {
+        // arrange
+        CProducerOpenCL cProducerOpenCL = new CProducerOpenCL();
+        cProducerOpenCL.noInlineHelpers = true;
+        OpenCLContext openCLContext = new OpenCLContext(cProducerOpenCL, bitHelper);
+
+        // act
+        String options = openCLContext.buildOptions();
+
+        // assert
+        assertThat(options, containsString(OpenCLContext.NO_INLINE_HELPERS_BUILD_OPTION));
+    }
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="kernelProfileStage builds and runs">


### PR DESCRIPTION
Cross-device follow-up to the reduced-radix 2^26 scalar-walker work, plus a fix for AMD's multi-minute kernel compile. Combines results measured on an **NVIDIA RTX 3070** (Ampere) and an **AMD RX 7900 XTX** (RDNA3).

## What changed

**1. Reduced-radix 2^26 field is now the default** (`useReducedRadixField = true`)
Cross-device win confirmed — never a regression on either device:
- RTX 3070: **~+22%** end-to-end
- RX 7900 XTX: **~+8%**

**2. AMD multi-minute compile fix — `-D AMD_NOINLINE_HELPERS`**
On AMD's LLVM/comgr back-end the fully-inlined `generateKeysKernel_grid` takes **8–16+ min** to build (super-linear per-function passes); a trivial kernel compiles in 0.2 s, so it's specific to this one giant function. Forcing the `DECLSPEC` helpers `__attribute__((noinline))` partitions it into many small functions and cuts the **cold compile to ~3 s** (>300x), byte-identical output.

**3. `noInlineHelpers` is tri-state with AMD-only auto-detect + clear logging**
`@Nullable Boolean`: `null` (default) = **auto / vendor-detect** → enabled for AMD only; `true`/`false` force. Resolved at `init()` by `OpenCLContext.resolveEffectiveNoInlineHelpers(...)` (predicate `isAmdVendor(...)`), **logged** with the reason (INFO for auto/explicit, WARN on explicit-false-on-AMD).

## Why AMD-only and not a global default — measured

Out-of-line calls cost real runtime throughput; A/B at each device's sweet spot (compact, reduced-radix on, both orderings):

| device | inlined | out-of-line | penalty |
|---|--:|--:|--:|
| RTX 3070 (kpwi=128) | ~200 ops/s | ~45 ops/s | **~4.5x slower** |
| RX 7900 XTX (kpwi=32) | 265.98 ops/s | 79.63 ops/s | **~3.3x slower** |

So `noinline` is auto-enabled **only where it's required to compile at all (AMD)** and left off on NVIDIA. Because the `comgr` cache makes the slow inlined AMD compile a one-time cost, a sustained AMD scan is ~3.3x faster with `noInlineHelpers=false` once warm (documented). Selective `noinline` (heaviest helpers only) was tried and reverted — ~5.3 min compile, still over the fork budget; the field multiply is both the compile bottleneck and the runtime hot path, so no split wins both.

## Tests
- New: `isAmdVendor` matrix, `resolveEffectiveNoInlineHelpers` logging (LogCaptor) + `buildOptions(boolean)`, tri-state default-null + JSON round-trips, `OpenCLAddKernelSmokeTest` (vendor-independent pipeline check), `ProbeAddressesOpenCLTest#createKeys_noInlineHelpers_resultsMatchReference` (byte-identical vs bitcoinj).
- Green on the RTX 3070; `BitcoinAddressFinderArchitectureTest` 16/0; compiles clean under NullAway; Spotless applied.

## Docs
`docs/performance.md`: §4 cross-device sweep, §9 AMD compile + tri-state "How to enable", §10 compatibility, and Track B → fully RESOLVED (NVIDIA 4.5x + AMD 3.3x + policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)