### PR TITLE
Fix two CI failures: OpenCL no-platform skip + ZMQ ephemeral-port bind

### DIFF
--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLBuilder.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLBuilder.java
@@ -42,6 +42,7 @@ import static org.jocl.CL.CL_DEVICE_VENDOR;
 import static org.jocl.CL.CL_DEVICE_VERSION;
 import static org.jocl.CL.CL_DRIVER_VERSION;
 import static org.jocl.CL.CL_PLATFORM_NAME;
+import static org.jocl.CL.CL_PLATFORM_NOT_FOUND_KHR;
 import static org.jocl.CL.clGetDeviceIDs;
 import static org.jocl.CL.clGetDeviceInfo;
 import static org.jocl.CL.clGetPlatformIDs;
@@ -55,6 +56,7 @@ import java.util.ArrayList;
 import java.util.List;
 import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
 import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.jocl.CLException;
 import org.jocl.Pointer;
 import org.jocl.Sizeof;
 import org.jocl.cl_context_properties;
@@ -88,10 +90,26 @@ public class OpenCLBuilder {
      * @return the list of detected OpenCL platforms
      */
     public List<OpenCLPlatform> build() {
-        // Obtain the number of platforms
+        // Obtain the number of platforms. An OpenCL ICD *loader* can be present (so the native
+        // library loads) while no ICD/platform is actually installed — common on bare CI runners
+        // (e.g. Windows without a GPU driver). In that case the loader returns
+        // CL_PLATFORM_NOT_FOUND_KHR, which JOCL surfaces as a CLException when exceptions are enabled.
+        // Treat "no platforms" as an empty result rather than failing, so callers (and the
+        // OpenCLAddKernelSmokeTest) can cleanly skip instead of erroring.
         int[] numPlatforms = new int[1];
-        clGetPlatformIDs(0, null, numPlatforms);
+        try {
+            clGetPlatformIDs(0, null, numPlatforms);
+        } catch (CLException e) {
+            if (e.getStatus() == CL_PLATFORM_NOT_FOUND_KHR) {
+                return new ArrayList<>();
+            }
+            throw e;
+        }
         int numPlatformCount = numPlatforms[0];
+        if (numPlatformCount == 0) {
+            // Exceptions-disabled path: the call returned the error code instead of throwing.
+            return new ArrayList<>();
+        }
 
         // Obtain the platform IDs
         List<OpenCLPlatform> openCLPlatforms = new ArrayList<>(numPlatformCount);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLAddKernelSmokeTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLAddKernelSmokeTest.java
@@ -4,7 +4,6 @@
 package net.ladenthin.bitcoinaddressfinder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.jocl.CL.CL_MEM_COPY_HOST_PTR;
 import static org.jocl.CL.CL_MEM_READ_ONLY;
@@ -40,6 +39,7 @@ import org.jocl.cl_kernel;
 import org.jocl.cl_mem;
 import org.jocl.cl_program;
 import org.jocl.cl_queue_properties;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -55,7 +55,9 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Requires only that the OpenCL native library and at least one device are present; it does
  * <em>not</em> require OpenCL 2.0 (a plain {@code add} needs nothing newer), so it runs on the
- * widest possible device set. It self-skips (does not fail) when no OpenCL library is available.
+ * widest possible device set. It self-skips (does not fail) when no OpenCL library is available, and
+ * also when the library/loader is present but reports no platform or device (e.g. a bare CI runner
+ * without a GPU driver — the loader returns {@code CL_PLATFORM_NOT_FOUND_KHR}).
  */
 public class OpenCLAddKernelSmokeTest {
 
@@ -93,8 +95,11 @@ public class OpenCLAddKernelSmokeTest {
             }
         }
 
-        // assert: the library was available, so at least one device must have been exercised.
-        assertThat(devicesExercised, is(greaterThan(0)));
+        // An OpenCL loader can be present with zero platforms/devices (a bare CI runner without a GPU
+        // driver — the loader returns CL_PLATFORM_NOT_FOUND_KHR, which OpenCLBuilder.build() maps to an
+        // empty list). There is nothing to smoke-test then, so skip cleanly rather than fail. When a
+        // device IS present, runAddKernelOnDevice above has already asserted the elementwise sum on it.
+        Assumptions.assumeTrue(devicesExercised > 0, "No OpenCL platform/device present — skipping smoke test");
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/engine/FinderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/engine/FinderTest.java
@@ -45,7 +45,6 @@ import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaSocketTest;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaTest;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaWebSocket;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaZmq;
-import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaZmqTest;
 import net.ladenthin.bitcoinaddressfinder.producer.Producer;
 import net.ladenthin.bitcoinaddressfinder.producer.ProducerState;
 import net.ladenthin.bitcoinaddressfinder.producer.ProducerStateProvider;
@@ -414,10 +413,15 @@ public class FinderTest {
         webSocket.port = KeyProducerJavaSocketTest.findFreePort();
         cFinder.keyProducerJavaWebSocket.add(webSocket);
 
-        // 6. JavaZmq
+        // 6. JavaZmq — bind to a ZMQ ephemeral port ("*"), not a pre-picked one. The producer binds
+        // in BIND mode (default); pre-picking a port via findFreePort() (open ServerSocket(0), close,
+        // reuse the number) has a TOCTOU race — the port can be taken between the close and the ZMQ
+        // bind, which intermittently failed CI with "ZMQ Errno 48" (EADDRINUSE). ZMQ resolves "*" to a
+        // free port atomically at bind time. This test only asserts the producer instance exists, so it
+        // never needs the concrete port.
         CKeyProducerJavaZmq zmq = new CKeyProducerJavaZmq();
         zmq.keyProducerId = "zmqId";
-        zmq.address = KeyProducerJavaZmqTest.findFreeZmqAddress();
+        zmq.address = "tcp://127.0.0.1:*";
         cFinder.keyProducerJavaZmq.add(zmq);
 
         Finder finder = new Finder(cFinder);
@@ -502,7 +506,11 @@ public class FinderTest {
 
     private void configureKeyProducerJavaZmq(String keyProducerId, CFinder cFinder) {
         CKeyProducerJavaZmq zmq = new CKeyProducerJavaZmq();
-        zmq.address = KeyProducerJavaZmqTest.findFreeZmqAddress();
+        // Bind to a ZMQ ephemeral port ("*") rather than a pre-picked findFreePort() number, which has
+        // a TOCTOU race (the port can be taken between the probe's ServerSocket close and the ZMQ bind
+        // -> "ZMQ Errno 48" EADDRINUSE). ZMQ resolves "*" atomically at bind time; these tests only
+        // exercise the producer lifecycle and never connect a client, so the concrete port is unneeded.
+        zmq.address = "tcp://127.0.0.1:*";
         zmq.timeoutMillis = KeyProducerJavaTest.TIMEOUT_FOR_TERMINATE;
         zmq.keyProducerId = keyProducerId;
         cFinder.keyProducerJavaZmq.add(zmq);


### PR DESCRIPTION
Fixes two independent test-infrastructure failures seen on `main` CI. **Neither is from the reduced-radix work** — one is a guard gap (from #265), the other a long-standing flaky-port race.

## 1. `OpenCLAddKernelSmokeTest` → `CL_PLATFORM_NOT_FOUND_KHR` (Windows job)

An OpenCL ICD **loader** can be present (so the JOCL native library loads and the existing `assumeOpenClLibraryAvailable()` guard passes) while **no platform/ICD is installed** — typical on a bare Windows runner without a GPU driver. `clGetPlatformIDs` then returns `CL_PLATFORM_NOT_FOUND_KHR`, which JOCL surfaces as a `CLException` with exceptions enabled → the test **errored instead of skipping**.

- `OpenCLBuilder.build()` now maps `CL_PLATFORM_NOT_FOUND_KHR` (and a 0-count result on the exceptions-disabled path) to an **empty platform list** — the spec's "no platforms" sentinel. Production fix; any caller benefits.
- `OpenCLAddKernelSmokeTest` now **skips** (`Assumptions.assumeTrue`) when no device was exercised, instead of asserting `> 0`. The per-device elementwise-sum asserts still run when a device exists.

## 2. `FinderTest` → `ZMQ Errno 48` (EADDRINUSE) (pocl job)

The ZMQ key producer binds (default `BIND` mode) to a pre-picked `findFreePort()` number; that helper opens `ServerSocket(0)`, **closes it**, and reuses the port — a TOCTOU race, since the port can be taken (or still in `TIME_WAIT`) before the ZMQ `bind()`. Flaky under parallel CI load.

- Both FinderTest ZMQ configs now bind to a **ZMQ ephemeral port `tcp://127.0.0.1:*`** (ZMQ picks a free port atomically at bind time). These tests only exercise the producer lifecycle and never connect a client, so the concrete port is unneeded.
- Removed the now-unused `KeyProducerJavaZmqTest` import.

## Verification
Verified on an RTX 3070: `OpenCLBuilderTest` 3/0, `OpenCLAddKernelSmokeTest` 1/0, `FinderTest` 20/0; compiles clean (NullAway), Spotless applied. The no-platform **skip** path and the ZMQ race are environment-specific — the real proof is this branch's CI matrix going green.

3 files: `OpenCLBuilder.java` (prod), `OpenCLAddKernelSmokeTest.java`, `FinderTest.java`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)