### PR TITLE
Add manual trigger for Maven Central release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,11 @@ on:
     tags: ['v*']
   pull_request:
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Publish a RELEASE to Maven Central. Off by default; the release publish runs only when this is true AND the workflow is run on a v* tag."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -389,7 +394,7 @@ jobs:
   publish-release:
     name: Publish Release to Central
     needs: [check-tag, code-style]
-    if: needs.check-tag.result == 'success'
+    if: needs.check-tag.result == 'success' && inputs.publish_release
     runs-on: ubuntu-latest
     environment: maven-central
     permissions:


### PR DESCRIPTION
## Summary

- Add a `publish_release` boolean input to the `workflow_dispatch` trigger in the publish workflow, allowing manual control over whether a release is published to Maven Central
- Update the `publish-release` job condition to require both a successful tag check AND the `publish_release` input to be explicitly set to `true`
- This prevents accidental releases and gives maintainers fine-grained control over when releases are published

## Test plan

- CI is green on this branch
- The workflow condition logic can be verified by manually triggering the workflow with and without the `publish_release` flag set to `true`

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01JGZdUCy6YnTzKSJKA6B6KZ