### PR TITLE
Release 1.6.1 (re-release of 1.6.0 to complete the publish pipeline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-06-18
+
+### Fixed
+- Release/CI: re-release of `1.6.0` to complete the publish pipeline. The `1.6.0`
+  run published to Maven Central but did not attach the signed artifacts to the
+  GitHub release. No functional code changes versus `1.6.0`.
+
 ## [1.6.0] - 2026-06-18
 
 ### Added
@@ -91,7 +98,8 @@ First public pre-release version (Java 8).
 - LMDB database:
   <https://github.com/bernardladenthin/BitcoinAddressFinder#use-my-prepared-database>
 
-[Unreleased]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.3.0-SNAPSHOT...v1.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This document provides guidance for AI assistants working on the BitcoinAddressF
 
 - **Group ID:** `net.ladenthin`
 - **Artifact ID:** `bitcoinaddressfinder`
-- **Version:** 1.6.0
+- **Version:** 1.6.1
 - **Java:** 21
 - **License:** Apache 2.0
 - **Author:** Bernard Ladenthin (Copyright 2017–2025)
@@ -512,7 +512,7 @@ Test-only:
 ./mvnw package -P assembly -DskipTests
 
 # Run (replace config path as needed)
-java -jar target/bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+java -jar target/bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
   examples/config_Find_8CPUProducer.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Copyright (c) 2017-2025 Bernard Ladenthin
     * lmdb
       * data.mdb
       * lock.mdb
-    * bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar
+    * bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar
     * logbackConfiguration.xml
     * config_Find_1OpenCLDevice.js
     * run_Find_1OpenCLDevice.bat  *(Windows)* / run_Find_1OpenCLDevice.sh *(Linux/macOS)*

--- a/examples/run_AddressFilesToLMDB.bat
+++ b/examples/run_AddressFilesToLMDB.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx512m ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar ^
 config_AddressFilesToLMDB.json
 rem >> log_AddressFilesToLMDB.txt 2>&1

--- a/examples/run_AddressFilesToLMDB.sh
+++ b/examples/run_AddressFilesToLMDB.sh
@@ -33,6 +33,6 @@ java \
 -Xmx512m \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
 config_AddressFilesToLMDB.json
 # >> log_AddressFilesToLMDB.txt 2>&1

--- a/examples/run_Find_1CPUProducerBip39.bat
+++ b/examples/run_Find_1CPUProducerBip39.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar ^
 config_Find_1CPUProducerBip39.json
 rem >> log_Find_1CPUProducerBip39.txt 2>&1

--- a/examples/run_Find_1CPUProducerBip39.sh
+++ b/examples/run_Find_1CPUProducerBip39.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
 config_Find_1CPUProducerBip39.json
 # >> log_Find_1CPUProducerBip39.txt 2>&1

--- a/examples/run_Find_1OpenCLDevice.bat
+++ b/examples/run_Find_1OpenCLDevice.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar ^
 config_Find_1OpenCLDevice.json
 rem >> log_Find_1OpenCLDevice.txt 2>&1

--- a/examples/run_Find_1OpenCLDevice.sh
+++ b/examples/run_Find_1OpenCLDevice.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
 config_Find_1OpenCLDevice.json
 # >> log_Find_1OpenCLDevice.txt 2>&1

--- a/examples/run_Find_1OpenCLDeviceAnd2CPUProducer.bat
+++ b/examples/run_Find_1OpenCLDeviceAnd2CPUProducer.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar ^
 config_Find_1OpenCLDeviceAnd2CPUProducer.json
 rem >> log_Find_1OpenCLDeviceAnd2CPUProducer.txt 2>&1

--- a/examples/run_Find_1OpenCLDeviceAnd2CPUProducer.sh
+++ b/examples/run_Find_1OpenCLDeviceAnd2CPUProducer.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
 config_Find_1OpenCLDeviceAnd2CPUProducer.json
 # >> log_Find_1OpenCLDeviceAnd2CPUProducer.txt 2>&1

--- a/examples/run_Find_8CPUProducer.bat
+++ b/examples/run_Find_8CPUProducer.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar ^
 config_Find_8CPUProducer.json
 rem >> log_Find_8CPUProducer.txt 2>&1

--- a/examples/run_Find_8CPUProducer.sh
+++ b/examples/run_Find_8CPUProducer.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
 config_Find_8CPUProducer.json
 # >> log_Find_8CPUProducer.txt 2>&1

--- a/examples/run_Find_SecretsFile.bat
+++ b/examples/run_Find_SecretsFile.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar ^
 config_Find_SecretsFile.json
 rem >> log_Find_SecretsFile.txt 2>&1

--- a/examples/run_Find_SecretsFile.sh
+++ b/examples/run_Find_SecretsFile.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
 config_Find_SecretsFile.json
 # >> log_Find_SecretsFile.txt 2>&1

--- a/examples/run_LMDBToAddressFile.bat
+++ b/examples/run_LMDBToAddressFile.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx512m ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar ^
 config_LMDBToAddressFile.json
 rem >> log_LMDBToAddressFile.txt 2>&1

--- a/examples/run_LMDBToAddressFile.sh
+++ b/examples/run_LMDBToAddressFile.sh
@@ -33,6 +33,6 @@ java \
 -Xmx512m \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
 config_LMDBToAddressFile.json
 # >> log_LMDBToAddressFile.txt 2>&1

--- a/examples/run_OpenCLInfo.bat
+++ b/examples/run_OpenCLInfo.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx512m ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar ^
 config_OpenCLInfo.json
 rem >> log_OpenCLInfo.txt 2>&1

--- a/examples/run_OpenCLInfo.sh
+++ b/examples/run_OpenCLInfo.sh
@@ -33,6 +33,6 @@ java \
 -Xmx512m \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.6.0-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.6.1-jar-with-dependencies.jar \
 config_OpenCLInfo.json
 # >> log_OpenCLInfo.txt 2>&1

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <groupId>net.ladenthin</groupId>
     <artifactId>bitcoinaddressfinder</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <packaging>jar</packaging>
 
     <name>bitcoinaddressfinder</name>


### PR DESCRIPTION
Bumps the project version to **1.6.1**. This is a re-release of `1.6.0`: `1.6.0` published to Maven Central, but its CI run did not attach the signed artifacts to the GitHub release. **No functional code changes versus 1.6.0** — version strings only.

## Bumped to 1.6.1 (project version + run-jar references)
- `pom.xml` → `1.6.1` (`project.version` resolves to `1.6.1`)
- `CHANGELOG.md` → new `## [1.6.1] - 2026-06-18` (re-release note) above the kept `## [1.6.0]` entry; `[1.6.1]` compare link added; `[Unreleased]` points at `v1.6.1`
- `CLAUDE.md` → version `1.6.1` + run-example fat-jar `1.6.1`
- `README.md` → run-example fat-jar `1.6.1`
- `examples/run_*.{bat,sh}` (16 files) → fat-jar `1.6.1`

## Deliberately left at 1.6.0 (not the project version)
- Java-WebSocket **dependency** version (`pom.xml` `java-websocket.version`, `CLAUDE.md` dependency table)
- README "As of version 1.6.0…" AddressPresence feature-history note (feature shipped in 1.6.0, which is on Central)
- `docs/RELEASE.md` tag-format example; the CHANGELOG `1.6.0` history entry + link

## Verification
- `mvn help:evaluate -Dexpression=project.version` → `1.6.1`
- 20 files changed, version strings only; no `.java` touched.

## Release-flow note
1.6.0's double-publish came from two paths deploying the same version (push-to-`main` `publish-snapshot` + the `v` tag `publish-release`). For 1.6.1, ensure only one path deploys it (tag-only, or keep `main` on `-SNAPSHOT` between releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)