### PR TITLE
Bump NullAway to 0.13.7 and pitest-maven to 1.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ SPDX-License-Identifier: Apache-2.0
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <errorprone.version>2.50.0</errorprone.version>
-        <nullaway.version>0.13.6</nullaway.version>
+        <nullaway.version>0.13.7</nullaway.version>
         <checker.version>4.2.0</checker.version>
         <java-websocket.version>1.6.0</java-websocket.version>
         <jeromq.version>0.6.0</jeromq.version>
@@ -242,7 +242,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.4</version>
+                    <version>1.25.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
## Summary

- Upgrade NullAway from 0.13.6 to 0.13.7 for improved null-safety analysis
- Upgrade pitest-maven from 1.25.4 to 1.25.5 for enhanced mutation testing capabilities

## Test plan

- [x] CI is green on this branch
- [x] No source code changes — dependency version bumps only

## Related issues / PRs

None

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01LjWiKSyNzqqpobSKYRiew5