### PR TITLE
docs: consolidate PIT mutation testing policy to shared workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -591,6 +591,13 @@ Build System above.
 
 See [`../workspace/policies/ci-test-diagnostics.md`](../workspace/policies/ci-test-diagnostics.md).
 
+## PIT Mutation Testing
+
+See [`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md).
+Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`
+(CI adds `-Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true`). The gate covers an
+explicit 16-class list at a 100% threshold.
+
 ## Open TODOs
 
 Open TODOs for this repo live in [`TODO.md`](TODO.md). Cross-repo status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,9 +594,7 @@ See [`../workspace/policies/ci-test-diagnostics.md`](../workspace/policies/ci-te
 ## PIT Mutation Testing
 
 See [`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md).
-Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`
-(CI adds `-Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true`). The gate covers an
-explicit 16-class list at a 100% threshold.
+Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`.
 
 ## Open TODOs
 

--- a/pom.xml
+++ b/pom.xml
@@ -779,21 +779,14 @@ SPDX-License-Identifier: Apache-2.0
             </plugin>
             <plugin>
                 <!--
-                  PIT mutation testing is gated at a 100% threshold on every CI
-                  build over the explicit list of classes that have reached 100%
-                  mutation parity (verified with pitest-maven 1.25.4). Expand the
-                  targetClasses list as more classes reach parity (see README
-                  TODO). The targeted classes are covered by fast, pure-Java unit
-                  tests (no LMDB / OpenCL / GPU needed), kept in lock-step in the
-                  targetTests list.
-
-                  CI invocation pattern (matches streambuffer):
-                      mvn test-compile org.pitest:pitest-maven:mutationCoverage
-                  PIT runs right after test-compile so the prepare-package-bound
-                  module-info-compile execution does not fire; module-info.class
-                  stays out of target/classes/ and the forked PIT JVMs continue
-                  to run in classpath mode (consistent with the rest of the test
-                  suite).
+                  Generic PIT policy (version, 100% gate, invocation, expansion rule):
+                  see ../workspace/policies/pit-mutation-testing.md.
+                  Repo-specific: the gated classes are covered by fast, pure-Java unit
+                  tests (no LMDB / OpenCL / GPU needed), kept in lock-step in targetTests.
+                  BAF-specific timing: running PIT right after test-compile (not a later
+                  phase) keeps the prepare-package-bound module-info-compile execution from
+                  firing, so module-info.class stays out of target/classes/ and the forked
+                  PIT JVMs run in classpath mode (consistent with the rest of the test suite).
                 -->
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>


### PR DESCRIPTION
## Summary

- Moved PIT mutation testing policy documentation from inline `pom.xml` comments to a shared workspace policy file (`../workspace/policies/pit-mutation-testing.md`)
- Updated `pom.xml` to reference the external policy document while retaining BAF-specific implementation details (timing constraints around `module-info-compile`)
- Added a new "PIT Mutation Testing" section to `CLAUDE.md` with a link to the policy and the correct invocation command

## Rationale

This change follows the cross-repo documentation consolidation pattern already established for CI test diagnostics. Generic PIT policy (version, 100% gate threshold, invocation pattern, expansion rules) is now centralized in the shared workspace, reducing duplication across sibling repositories while preserving repo-specific implementation notes (e.g., BAF's module-info timing constraints).

## Test plan

- [x] No code changes; documentation only
- [x] CI is green on this branch
- [x] CLAUDE.md updated with new section and correct invocation command

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_017i6A5bMhgCSbiKibQhxwuz