### PR TITLE
ci: add SpotBugs static analysis check to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
           distribution: temurin
       - name: Spotless check (fail fast on format violations)
         run: mvn -B --no-transfer-progress spotless:check
+      - name: SpotBugs check (fail fast on static-analysis findings)
+        run: mvn -B --no-transfer-progress -DskipTests -Denforcer.skip=true compile spotbugs:check
       - name: Print internal package dependency graph (jdeps, informational)
         continue-on-error: true
         run: |


### PR DESCRIPTION
## Summary

- Add SpotBugs static analysis check to the publish workflow's fail-fast validation stage
- Runs after Spotless format check to catch potential bugs early in CI
- Configured to skip tests and enforcer checks for faster execution

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_0137c1LhUbNvW3kt4eF9Kqyb