### PR TITLE
Improve Central publishing resilience and add debug logging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -376,12 +376,18 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      # Runs even when the deploy step failed: a Central publish-poll timeout reds the
+      # job *after* the bundle was uploaded (and typically published server-side), while
+      # the signed jars + .asc files already exist in target/ (signing happens at
+      # verify). Collecting on failure lets the github-snapshot job still attach them.
       - name: Collect signed artifacts
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p signed-snapshot-assets
           cp target/*.jar signed-snapshot-assets/ 2>/dev/null || true
           cp target/*.jar.asc signed-snapshot-assets/ 2>/dev/null || true
       - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
         with:
           name: signed-snapshot-assets
           path: signed-snapshot-assets/
@@ -389,7 +395,10 @@ jobs:
   github-snapshot:
     name: Update Snapshot Pre-release on GitHub
     needs: [publish-snapshot]
-    if: needs.publish-snapshot.result == 'success'
+    # Also runs when publish-snapshot FAILED (not when skipped/cancelled): a Central
+    # publish-poll timeout reds that job after the artifacts were already uploaded —
+    # the GitHub pre-release assets must not be lost in that case.
+    if: ${{ !cancelled() && (needs.publish-snapshot.result == 'success' || needs.publish-snapshot.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -443,12 +452,18 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      # Runs even when the deploy step failed: a Central publish-poll timeout reds the
+      # job *after* the bundle was uploaded (and typically published server-side), while
+      # the signed jars + .asc files already exist in target/ (signing happens at
+      # verify). Collecting on failure lets the github-release job still attach them.
       - name: Collect signed artifacts
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p signed-release-assets
           cp target/*.jar signed-release-assets/ 2>/dev/null || true
           cp target/*.jar.asc signed-release-assets/ 2>/dev/null || true
       - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
         with:
           name: signed-release-assets
           path: signed-release-assets/
@@ -456,7 +471,10 @@ jobs:
   github-release:
     name: Attach Binaries to GitHub Release
     needs: [publish-release]
-    if: needs.publish-release.result == 'success'
+    # Also runs when publish-release FAILED (not when skipped/cancelled): a Central
+    # publish-poll timeout reds that job after the artifacts were already uploaded —
+    # the GitHub release assets must not be lost in that case.
+    if: ${{ !cancelled() && (needs.publish-release.result == 'success' || needs.publish-release.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -365,6 +365,11 @@ jobs:
             *-SNAPSHOT) echo "OK: -SNAPSHOT version, continuing snapshot deploy." ;;
             *) echo "::error::Refusing to publish non-SNAPSHOT version '$VERSION' from the snapshot job. Snapshot publishing requires a -SNAPSHOT version; releases go through the v* tag path."; exit 1 ;;
           esac
+      # Informational only (nothing depends on it): logs the effective POM with the same
+      # profile as the deploy below, so the resolved central-publishing configuration
+      # (waitUntil/waitMaxTime etc.) is visible for debugging.
+      - name: Show effective POM (debug)
+        run: mvn --batch-mode --no-transfer-progress -P release help:effective-pom
       - name: Deploy snapshot
         run: mvn --batch-mode --no-transfer-progress -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true -P release deploy -DskipTests
         env:
@@ -427,6 +432,11 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      # Informational only (nothing depends on it): logs the effective POM with the same
+      # profile as the deploy below, so the resolved central-publishing configuration
+      # (waitUntil/waitMaxTime etc.) is visible for debugging.
+      - name: Show effective POM (debug)
+        run: mvn --batch-mode --no-transfer-progress -P release help:effective-pom
       - name: Deploy release
         run: mvn --batch-mode --no-transfer-progress -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true -P release deploy -DskipTests
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@ SPDX-License-Identifier: Apache-2.0
         <jsr305.version>3.0.2</jsr305.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <guava.version>33.6.0-jre</guava.version>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <lmdbjava.version>0.9.3</lmdbjava.version>
         <jocl.version>2.0.6</jocl.version>
         <commons-io.version>2.22.0</commons-io.version>
@@ -242,7 +242,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.5</version>
+                    <version>1.25.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1059,10 +1059,7 @@ SPDX-License-Identifier: Apache-2.0
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <!-- validated (not published): wait only for portal validation, which is where
-                                 real errors (bad signature, POM rules) surface; the publish step then runs
-                                 server-side via autoPublish. Waiting for "published" timed out on a slow
-                                 Central day (jllama 5.0.6 release) although the deployment published fine. -->
+                            <!-- validated: wait only for portal validation (where real errors surface), not the slow server-side publish; autoPublish completes it -->
                             <waitUntil>validated</waitUntil>
                             <!-- seconds; generous headroom for the validation poll (default 1800) -->
                             <waitMaxTime>21600</waitMaxTime>

--- a/pom.xml
+++ b/pom.xml
@@ -1059,8 +1059,12 @@ SPDX-License-Identifier: Apache-2.0
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
-                            <!-- seconds (6 h); the default 1800 timed out on a slow Central day (jllama 5.0.6 release) -->
+                            <!-- validated (not published): wait only for portal validation, which is where
+                                 real errors (bad signature, POM rules) surface; the publish step then runs
+                                 server-side via autoPublish. Waiting for "published" timed out on a slow
+                                 Central day (jllama 5.0.6 release) although the deployment published fine. -->
+                            <waitUntil>validated</waitUntil>
+                            <!-- seconds; generous headroom for the validation poll (default 1800) -->
                             <waitMaxTime>21600</waitMaxTime>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1060,6 +1060,8 @@ SPDX-License-Identifier: Apache-2.0
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
                             <waitUntil>published</waitUntil>
+                            <!-- seconds (6 h); the default 1800 timed out on a slow Central day (jllama 5.0.6 release) -->
+                            <waitMaxTime>21600</waitMaxTime>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary

- **Reduce Central publish-poll timeout impact:** Change `waitUntil` from `published` to `validated` and increase `waitMaxTime` from 1800s to 21600s. This allows the workflow to complete successfully even when Central's server-side publish is slow, since `autoPublish=true` will complete the publish asynchronously. Artifacts are already signed and uploaded by the time validation completes.
- **Preserve GitHub release assets on Central timeout:** Update `github-snapshot` and `github-release` job conditions to run even when their upstream publish jobs fail (not just on success). This ensures signed artifacts are attached to GitHub releases even if Central's publish-poll times out after artifacts were already uploaded.
- **Add debug visibility:** Insert "Show effective POM" steps in both publish jobs to log the resolved central-publishing configuration, making timeout/validation issues easier to diagnose.
- **Collect artifacts on failure:** Add `if: ${{ !cancelled() }}` to artifact collection and upload steps so they run even when the deploy step fails, preserving signed JARs and `.asc` files for the GitHub jobs.
- **Dependency updates:** Jackson 2.22.0 → 2.22.1, pitest-maven 1.25.5 → 1.25.6.

## Test plan

- CI is green on this branch
- No code logic changes; workflow and configuration adjustments only
- Existing unit/integration tests unaffected

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_018e3Pk8a2yzmrmNb2DEw9JS