### PR TITLE
ci: GPG signing-key preflight (gpg + Gradle, cross-repo sync)

### DIFF
--- a/.github/signing-selftest/build.gradle.kts
+++ b/.github/signing-selftest/build.gradle.kts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Throwaway signing project used ONLY by the `verify-signing-key-gradle`
+// preflight job in .github/workflows/publish.yml. It signs a tiny throwaway Zip
+// through Gradle's `signing` plugin + `useInMemoryPgpKeys` (BouncyCastle) — the
+// exact path any Gradle-based publish (e.g. an Android AAR) uses to sign release
+// artifacts, and a stricter parser of the armored key than the `gpg` CLI. The
+// job asserts only that the detached .asc was produced; no secret is ever
+// printed (the key/passphrase arrive via env). Kept identical across the sibling
+// repos so a future Gradle publish is pre-validated ("prepared for Gradle").
+plugins {
+    base
+    signing
+}
+
+val signingKey = System.getenv("MAVEN_GPG_PRIVATE_KEY")
+val signingPassphrase = System.getenv("MAVEN_GPG_PASSPHRASE")
+// Optional signing (sub)key id (e.g. 07D2D767). When set, Gradle selects that
+// key instead of the primary — required when the key's signing capability lives
+// on a subkey (gpg auto-selects it, but the 2-arg useInMemoryPgpKeys picks the
+// primary, whose secret BouncyCastle may not be able to unlock -> null
+// PGPPrivateKey). Driven by the GPG_KEY_ID env secret.
+val signingKeyId = System.getenv("MAVEN_GPG_KEY_ID")
+require(!signingKey.isNullOrBlank()) { "MAVEN_GPG_PRIVATE_KEY is empty" }
+
+val makeArtifact = tasks.register<Zip>("makeArtifact") {
+    archiveBaseName.set("signing-selftest")
+    destinationDirectory.set(layout.buildDirectory)
+    from(layout.projectDirectory.file("settings.gradle.kts"))
+}
+
+signing {
+    if (!signingKeyId.isNullOrBlank()) {
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassphrase ?: "")
+    } else {
+        useInMemoryPgpKeys(signingKey, signingPassphrase ?: "")
+    }
+    sign(makeArtifact.get())
+}

--- a/.github/signing-selftest/settings.gradle.kts
+++ b/.github/signing-selftest/settings.gradle.kts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+rootProject.name = "signing-selftest"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,119 @@ jobs:
     steps:
       - run: echo "Start gate elapsed — proceeding with pipeline."
 
+  # ---------------------------------------------------------------------------
+  # GPG signing-key preflight (standalone, no `needs:` — runs in parallel at the
+  # very start on every trigger). Reproduces what maven-gpg-plugin does at deploy
+  # time so a bad/expired key or wrong passphrase is caught in ~20s instead of
+  # failing the publish stage. Declares `environment: maven-central` so it reads
+  # the SAME GPG_PRIVATE_KEY / GPG_PASSPHRASE secret the publish jobs use.
+  #
+  # It is EXPECTED to go RED on refs where the secret is not delivered — fork PRs
+  # and other contributors' branches (secrets are withheld there). That red is
+  # the intended signal: "this ref cannot sign a release", not a regression.
+  #
+  # SECURITY: this job NEVER prints secret material. It imports the key into an
+  # ephemeral keyring, prints only PUBLIC key metadata (key id, fingerprint,
+  # owner UID, algorithm, created/expiry — all of which live on public
+  # keyservers), and validates the passphrase by producing + verifying a
+  # throwaway signature. The passphrase is passed on fd 3 (never argv, never a
+  # log line), `set -x` is deliberately never enabled, and the passphrase is
+  # additionally `::add-mask::`ed.
+  # ---------------------------------------------------------------------------
+  verify-signing-key:
+    name: Verify GPG signing key (no secrets printed)
+    runs-on: ubuntu-latest
+    environment: maven-central
+    steps:
+      - name: Import key + run sign/verify self-test (prints only PUBLIC metadata)
+        shell: bash
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail   # NOTE: deliberately NO `set -x` — it would echo the passphrase.
+
+          if [ -z "${GPG_PRIVATE_KEY:-}" ]; then
+            echo "::error::GPG_PRIVATE_KEY is empty for this run. Either the secret is not set, or it is scoped to a different environment/branch than 'maven-central' on this ref. Nothing to verify."
+            exit 1
+          fi
+          # Defensive: even though we never print it, register the passphrase as a
+          # masked value so any accidental echo downstream is redacted.
+          if [ -n "${GPG_PASSPHRASE:-}" ]; then echo "::add-mask::${GPG_PASSPHRASE}"; fi
+
+          echo "gpg: $(gpg --version | head -n1)"
+
+          # Ephemeral, private keyring; removed on exit.
+          export GNUPGHOME="$(mktemp -d)"
+          chmod 700 "$GNUPGHOME"
+          cleanup() { gpgconf --kill gpg-agent >/dev/null 2>&1 || true; rm -rf "$GNUPGHOME"; }
+          trap cleanup EXIT
+
+          echo "== Import private key into an ephemeral keyring (key via stdin, never argv) =="
+          printf '%s\n' "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+          COLONS="$(gpg --list-secret-keys --with-colons --fixed-list-mode)"
+          SECCOUNT="$(printf '%s\n' "$COLONS" | awk -F: '$1=="sec"{n++} END{print n+0}')"
+          echo "Secret keys imported: $SECCOUNT"
+          if [ "$SECCOUNT" -lt 1 ]; then
+            echo "::error::No secret key was imported — GPG_PRIVATE_KEY is not a valid armored secret key (check that the secret contains the full -----BEGIN PGP PRIVATE KEY BLOCK----- with intact newlines)."
+            exit 1
+          fi
+
+          KEYID="$(printf '%s\n' "$COLONS"  | awk -F: '$1=="sec"{print $5; exit}')"
+          ALGO="$(printf '%s\n'  "$COLONS"  | awk -F: '$1=="sec"{print $4; exit}')"
+          CREATED="$(printf '%s\n' "$COLONS"| awk -F: '$1=="sec"{print $6; exit}')"
+          EXPIRES="$(printf '%s\n' "$COLONS"| awk -F: '$1=="sec"{print $7; exit}')"
+          FPR="$(printf '%s\n'   "$COLONS"  | awk -F: '$1=="fpr"{print $10; exit}')"
+
+          echo "== PUBLIC key metadata =="
+          echo "  Key ID (long):  $KEYID"
+          echo "  Fingerprint:    $FPR"
+          echo "  Pubkey algo id: $ALGO"
+          echo "  Created (UTC):  $(date -u -d "@$CREATED" 2>/dev/null || echo "$CREATED")"
+          echo "  Owner UID(s):"
+          printf '%s\n' "$COLONS" | awk -F: '$1=="uid"{print "    - " $10}'
+
+          # --- Expiration gate ---
+          NOW="$(date -u +%s)"
+          if [ -n "$EXPIRES" ]; then
+            echo "  Expires (UTC):  $(date -u -d "@$EXPIRES" 2>/dev/null || echo "$EXPIRES")"
+            if [ "$EXPIRES" -le "$NOW" ]; then
+              echo "::error::Signing key is EXPIRED — Maven Central will reject its signatures. Extend the key's expiry and update the GPG_PRIVATE_KEY secret."
+              exit 1
+            fi
+            echo "  Days to expiry: $(( (EXPIRES - NOW) / 86400 ))"
+            if [ "$(( (EXPIRES - NOW) / 86400 ))" -lt 30 ]; then
+              echo "::warning::Signing key expires in under 30 days — plan to rotate it."
+            fi
+          else
+            echo "  Expires (UTC):  never"
+          fi
+
+          # --- Signing-capability gate ---
+          if printf '%s\n' "$COLONS" | awk -F: '($1=="sec"||$1=="ssb"){print $12}' | grep -q 's'; then
+            echo "  Signing capability: present"
+          else
+            echo "::error::No signing-capable (sub)key found — this key cannot produce release signatures."
+            exit 1
+          fi
+
+          # --- Passphrase unlock + sign + verify roundtrip (the exact failure mode) ---
+          # Passphrase on fd 3 only. Payload is a throwaway nonce; only the signature's
+          # validity (exit codes) matters — no secret is ever emitted.
+          echo "== Passphrase unlock + detached-sign + verify self-test =="
+          WORK="$(mktemp -d)"
+          printf '%s' "ai-index signing-selftest" > "$WORK/payload.txt"
+          gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+              --local-user "$KEYID" \
+              --detach-sign --armor --output "$WORK/payload.txt.asc" "$WORK/payload.txt" \
+              3<<<"${GPG_PASSPHRASE:-}"
+          echo "  Signature produced: $(wc -c < "$WORK/payload.txt.asc") armored bytes"
+          gpg --batch --verify "$WORK/payload.txt.asc" "$WORK/payload.txt"
+          rm -rf "$WORK"
+
+          echo "RESULT: OK — key imports, is not expired, is signing-capable, and the passphrase successfully unlocked it to produce a VALID signature. maven-gpg-plugin will be able to sign with this key/passphrase."
+
   code-style:
     name: Code style (spotless) + package graph
     needs: startgate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,6 +147,67 @@ jobs:
 
           echo "RESULT: OK — key imports, is not expired, is signing-capable, and the passphrase successfully unlocked it to produce a VALID signature. maven-gpg-plugin will be able to sign with this key/passphrase."
 
+  # ---------------------------------------------------------------------------
+  # GPG signing-key preflight — GRADLE / BouncyCastle path.
+  # Companion to the `verify-signing-key` (gpg) job above: that one mirrors
+  # maven-gpg-plugin (how the Maven artifacts are signed); this one drives
+  # Gradle's `signing` plugin + `useInMemoryPgpKeys` (BouncyCastle) — the path any
+  # Gradle-based publish (e.g. an Android AAR) uses to sign. BouncyCastle is a
+  # STRICTER parser of the armored key than gpg, so it catches key/format problems
+  # gpg tolerates (e.g. the primary-vs-signing-subkey null-PGPPrivateKey issue).
+  # It signs a throwaway project (.github/signing-selftest/) — no repo build is
+  # involved — so this job is IDENTICAL across the sibling repos and validates the
+  # release key via the Gradle path even in repos that do not publish via Gradle
+  # yet ("prepared for Gradle"). Standalone (no `needs:`), parallel at pipeline
+  # start, `environment: maven-central` so it reads the same secret the publish
+  # uses. Red-by-design where the secret is not delivered (see the gpg job's note).
+  #
+  # SECURITY: prints no secret material. Key/passphrase reach Gradle only via env
+  # (read by System.getenv at runtime); `set -x` is never enabled; the passphrase
+  # is `::add-mask::`ed; Gradle runs with `--stacktrace` only. Only the produced
+  # `.asc` (exit code) is asserted. Uses Gradle 8.14.3.
+  # ---------------------------------------------------------------------------
+  verify-signing-key-gradle:
+    name: Verify GPG signing key — Gradle/BouncyCastle path (no secrets printed)
+    runs-on: ubuntu-latest
+    environment: maven-central
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.14.3"
+      - name: Sign a throwaway artifact via useInMemoryPgpKeys (BouncyCastle)
+        shell: bash
+        env:
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        run: |
+          set -euo pipefail   # NOTE: deliberately NO `set -x` — it would echo the passphrase.
+
+          if [ -z "${MAVEN_GPG_PRIVATE_KEY:-}" ]; then
+            echo "::error::MAVEN_GPG_PRIVATE_KEY is empty for this run. The maven-central environment did not deliver the secret to this ref (fork PR / other branch). Nothing to verify."
+            exit 1
+          fi
+          if [ -n "${MAVEN_GPG_PASSPHRASE:-}" ]; then echo "::add-mask::${MAVEN_GPG_PASSPHRASE}"; fi
+
+          PROJ=".github/signing-selftest"
+          echo "== Sign a throwaway artifact through Gradle's useInMemoryPgpKeys (BouncyCastle) =="
+          gradle --no-daemon -p "$PROJ" signMakeArtifact --stacktrace
+
+          ASC="$PROJ/build/signing-selftest.zip.asc"
+          if [ -f "$ASC" ]; then
+            echo "  Detached signature produced: $(wc -c < "$ASC") armored bytes"
+            echo "RESULT: OK — Gradle's useInMemoryPgpKeys accepted the armored key + passphrase and produced a signature."
+          else
+            echo "::error::Gradle signing produced no .asc — useInMemoryPgpKeys could not build a usable signatory from MAVEN_GPG_PRIVATE_KEY / MAVEN_GPG_PASSPHRASE."
+            exit 1
+          fi
+
   code-style:
     name: Code style (spotless) + package graph
     needs: startgate


### PR DESCRIPTION
## Summary

- Adds a standalone **`verify-signing-key`** (gpg) job — reproduces what `maven-gpg-plugin` does at deploy time (import key, check expiry + signing capability, passphrase-unlock → sign → verify) so a bad/expired key or wrong passphrase is caught in ~20s instead of failing the publish stage.
- Adds a companion **`verify-signing-key-gradle`** job + the throwaway `.github/signing-selftest/` Gradle project — validates the key can also sign via Gradle's `useInMemoryPgpKeys` (BouncyCastle), a stricter armored-key parser than gpg. This repo doesn't publish via Gradle yet; it's kept **byte-identical to the sibling repos** ("prepared for Gradle", a deliberate uniformity choice).
- Both jobs are standalone (no `needs:`), run in parallel at pipeline start under `environment: maven-central`, and **print no secret material** (passphrase on fd 3 / via env, `set -x` never enabled, `::add-mask::`ed).

## Test plan

- [ ] After merge, both jobs run green on `main` (they read the `maven-central` env secrets `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE` / `GPG_KEY_ID`).
- [ ] On this PR branch both go **red by design** — the `maven-central` environment gate rejects non-`main` refs before a runner starts. That red is the intended "this ref can't sign a release" signal, not a regression.

## Related issues / PRs

Cross-repo synchronization of the signing-key preflight (origin: java-llama.cpp #306 / #307).

## Checklist

- [x] My commits follow Conventional Commits
- [x] No new secret material exposed — `GPG_KEY_ID` is a public key id (`07D2D767`); the private key and passphrase never appear in any log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018pwn51YPBbtiuUyiLRrfrG)_