### PR TITLE
chore(deps): bump org.bouncycastle:bcprov-jdk15to18 from 1.84 to 1.85

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,7 +481,7 @@ No other sibling repo has OpenCL code, so this distinction is BAF-only.
 | Dependency | Version | Purpose |
 |---|---|---|
 | `bitcoinj-core` | 0.17.1 | Bitcoin crypto, address derivation |
-| `bcprov-jdk15to18` | 1.84 | Bouncy Castle crypto provider (bitcoinj transitive; pinned to fix GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) |
+| `bcprov-jdk15to18` | 1.85 | Bouncy Castle crypto provider (bitcoinj transitive; pinned to fix GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) |
 | `protobuf-javalite` | 4.35.1 | Protocol Buffers (bitcoinj transitive; pinned to latest) |
 | `jsr305` | 3.0.2 | Findbugs nullability annotations (bitcoinj transitive, runtime) |
 | `jcip-annotations` | 1.0 | JCIP concurrency annotations (bitcoinj transitive, runtime) |

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ SPDX-License-Identifier: Apache-2.0
         <jspecify.version>1.0.0</jspecify.version>
         <lombok.version>1.18.46</lombok.version>
         <bitcoinj.version>0.17.1</bitcoinj.version>
-        <bcprov.version>1.84</bcprov.version>
+        <bcprov.version>1.85</bcprov.version>
         <protobuf.version>4.35.1</protobuf.version>
         <jsr305.version>3.0.2</jsr305.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>


### PR DESCRIPTION
## Summary

- Bumps `org.bouncycastle:bcprov-jdk15to18` from `1.84` to `1.85` (`bcprov.version` property in `pom.xml`)
- Updates the matching version note in `CLAUDE.md`'s dependency table
- This dependency is pinned (not left to bitcoinj's transitive default) specifically to carry CVE fixes for GHSA-c3fc-8qff-9hwx and GHSA-p93r-85wp-75v3; 1.85 is a stable patch release

## Test plan

- [x] `mvn compile` succeeds cleanly with the new version resolved
- [ ] CI is green on this branch

## Related issues / PRs

None

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes beyond the dependency bump itself (which is a security-relevant patch update, not a code change)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Hy5v7BEwMeJVHTvdc5vFy)_