### PR TITLE
Real Binary Fuse filter, build progress logging, windowed statistics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,10 +375,11 @@ cost here is OpenCL **kernel compilation**, which happens once in `OpenCLContext
 budget on duration rather than sample count gives the steadier read. For a quick sanity check
 use `-wi 2 -i 4` (~2 min for both arms). Use `OpenCLInfo` (`{"command":"OpenCLInfo"}`) to
 confirm a device is present and pick `platformIndex` / `deviceIndex` before benchmarking.
-`GpuFuse8FilterBenchmark` was validated this way on an NVIDIA RTX 3070 (OpenCL 3.0 CUDA): a
-single ~200 s iteration gave compact FUSE_8 mode ≈ **1.28× faster** than full transfer at
-`batchSizeInBits = 19` (matching the README key-gen table's grid size; the gain grows with
-batch size, ≈ 1.7× at grid 20). The full two-arm long run took ~7m45s of wall time.
+`GpuFuse8FilterBenchmark` was validated this way on an NVIDIA RTX 3070 (OpenCL 3.0 CUDA): with
+the real Binary Fuse filter, the mean of 3 measurement iterations gave compact FUSE_8 mode ≈ **2.2×
+faster** than full transfer at `batchSizeInBits = 19` (compact 18.5 ops/s → ~9.7 M vs full 8.3 ops/s
+→ ~4.35 M candidates/s; matching the README key-gen table's grid size; the gain grows with batch
+size). The compact arm is stable to ~0.2 %; the full-transfer arm is noisier.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ Supported values:
 | `BLOOM`             | ~80 MB – ~1.5 GB (FPP)  | fast for misses      | yes              | when you want to skip LMDB for the common miss case but keep it open to verify hits      |
 | `HASHSET`           | ~80 B / entry           | fast                 | **no**           | small databases where memory is plentiful and exact lookup is required by callers       |
 | `TRUNCATED_LONG_64` | **~8 B / entry**        | **near HASHSET**     | **no**           | best in-RAM trade-off when you *do* want to drop LMDB — near-`HASHSET` latency at ~10× less RAM |
-| `BINARY_FUSE_8`     | **~1.3 B / entry**      | **fast**             | yes              | ultra-low RAM filter in front of LMDB; 0.4% of filter hits are verified against LMDB (also feeds the GPU pre-filter) |
-| `BINARY_FUSE_16`    | **~2.6 B / entry**      | **fast**             | yes              | like Fuse-8 but 0.0015% FPR — fewer LMDB verifications; use when Fuse-8's verification cost is measurable |
+| `BINARY_FUSE_8`     | **~1.13 B / entry**     | **fast**             | yes              | ultra-low RAM filter in front of LMDB; 0.4% of filter hits are verified against LMDB (also feeds the GPU pre-filter) |
+| `BINARY_FUSE_16`    | **~2.25 B / entry**     | **fast**             | yes              | like Fuse-8 but 0.0015% FPR — fewer LMDB verifications; use when Fuse-8's verification cost is measurable |
 
 #### Memory footprint per backend across the published database tiers
 
@@ -294,8 +294,12 @@ Supported values:
 | `HASHSET`           | ~8.0 GB                     | ~10 GB                   | ~110 GB ❌                |
 | `TRUNCATED_LONG_64` | **~0.8 GB**                 | **~1.1 GB**              | **~11 GB**                |
 | `BLOOM` (FPP 0.01)  | ~120 MB                     | ~150 MB                  | ~1.6 GB                   |
-| `BINARY_FUSE_8`     | **~130 MB**                 | **~172 MB**              | **~1.8 GB**               |
-| `BINARY_FUSE_16`    | ~260 MB                     | ~343 MB                  | ~3.6 GB                   |
+| `BINARY_FUSE_8`     | **~113 MB**                 | **~149 MB**              | **~1.5 GB**               |
+| `BINARY_FUSE_16`    | ~225 MB                     | ~298 MB                  | ~3.1 GB                   |
+
+> The Binary Fuse rows are ~1.125 B/entry (Fuse-8) and ~2.25 B/entry (Fuse-16). Only the 132 M
+> (Light DB) tier is directly measured (148,766,720 fingerprint slots); the 100 M and 1.377 B rows
+> are extrapolated from that ratio.
 
 #### Self-contained snapshots release the LMDB env
 
@@ -315,14 +319,18 @@ hash160 is the output of SHA-256 followed by RIPEMD-160 and is cryptographically
 
 #### Binary Fuse Filters — probabilistic presence with no false negatives
 
-`BINARY_FUSE_8` and `BINARY_FUSE_16` are static XOR filters (Graf &amp; Lemire, 2022). Each inserted key maps to three positions in a fingerprint array — one per segment — via independent MurmurHash3 invocations with rotated seeds. A simple XOR invariant across those three slots makes lookup a single three-read check:
+`BINARY_FUSE_8` and `BINARY_FUSE_16` are Binary Fuse Filters (Graf &amp; Lemire, 2022) — a faithful port of the reference *FastFilter* construction. Each inserted key derives a **single** 64-bit hash `murmur64(key + seed)`; its high bits pick a base slot and two low/mid bit-windows offset it into three **consecutive, overlapping** segments. A simple XOR invariant across those three slots makes lookup a single three-read check:
 
 ```
-h0 = reduce(hash64(key, seed),           segSize) + 0·segSize
-h1 = reduce(hash64(key, rotl(seed,21)),  segSize) + 1·segSize
-h2 = reduce(hash64(key, rotl(seed,42)),  segSize) + 2·segSize
-hit ⟺  fingerprints[h0] ⊕ fingerprints[h1] ⊕ fingerprints[h2] == fingerprint(key)
+hash = murmur64(key + seed)
+base = unsignedMulHigh(hash, segmentCountLength)          // in [0, segmentCountLength)
+h0 = base
+h1 = base + 1·segmentLength  ⊕ ((hash >>> 18) & segmentLengthMask)
+h2 = base + 2·segmentLength  ⊕ ( hash         & segmentLengthMask)
+hit ⟺  fingerprints[h0] ⊕ fingerprints[h1] ⊕ fingerprints[h2] == fingerprint(hash)
 ```
+
+Unlike a plain XOR filter's three *disjoint* segments (~1.23× space), the fused overlapping-segment geometry lets construction succeed on the first attempt at only ~1.125× space. Duplicate 64-bit keys (two distinct hash160 sharing their first 8 bytes) cannot be placed, so they are de-duplicated before construction — lossless, since every filter hit is verified against LMDB anyway.
 
 **No false negatives** — every key inserted via `populateFrom` is always found, so a filter **miss** is definitive.  
 **False-positive rate** — 1/256 ≈ 0.4% for Fuse-8 (8-bit fingerprint), 1/65536 ≈ 0.0015% for Fuse-16 (16-bit fingerprint). That FPR is far too high to report a filter hit as a final hit (at 0.4% roughly one in every 250 scanned addresses would be a spurious hit), so the filter is used **exactly like `BLOOM`**: a miss short-circuits without touching LMDB, a hit falls through to LMDB to confirm the address or reject it as a false positive.  
@@ -336,14 +344,14 @@ Choose between the two variants based on how expensive the LMDB verification of 
 
 | Backend             | ns / op |
 |--------------------:|--------:|
-| `LMDB_ONLY`         | 1301    |
-| `BLOOM`             |  731    |
-| `HASHSET`           |   85    |
-| `TRUNCATED_LONG_64` |  108    |
-| `BINARY_FUSE_8`     |   ~25   |
-| `BINARY_FUSE_16`    |   ~25   |
+| `LMDB_ONLY`         |  833    |
+| `BLOOM`             |  155    |
+| `HASHSET`           |   42    |
+| `TRUNCATED_LONG_64` |   40    |
+| `BINARY_FUSE_8`     |   ~20   |
+| `BINARY_FUSE_16`    |   ~23   |
 
-The default backend is `LMDB_ONLY` (no in-RAM structure, exact, can never produce a false hit). When you *do* want to trade RAM for speed, `TRUNCATED_LONG_64` reaches near-`HASHSET` latency at ~10× lower memory cost and is the best in-RAM choice for most cases. `BINARY_FUSE_8` and `BINARY_FUSE_16` offer even lower memory with O(1) lookup (3 direct array reads + 3 hashes) but keep LMDB open to verify hits; cache-cold latency grows with filter size, but for small-to-medium databases the three-read pattern typically stays in L2 or L3 cache.
+The default backend is `LMDB_ONLY` (no in-RAM structure, exact, can never produce a false hit). When you *do* want to trade RAM for speed, `TRUNCATED_LONG_64` reaches near-`HASHSET` latency at ~10× lower memory cost and is the best in-RAM choice for most cases. `BINARY_FUSE_8` and `BINARY_FUSE_16` offer even lower memory with O(1) lookup (3 direct array reads + 1 hash) but keep LMDB open to verify hits; cache-cold latency grows with filter size, but for small-to-medium databases the three-read pattern typically stays in L2 or L3 cache.
 
 Run the backend comparison benchmark yourself with:
 
@@ -402,7 +410,7 @@ Compact mode runs only when a filter was uploaded **and** `transferAll` is false
 
 **Device requirements** — compact mode needs an **OpenCL 2.0+** device (the `atomic_add` on global memory) and a little-endian device (the kernel canonicalises its output as little-endian). Both are checked at producer init and fail fast with a clear message; on an older device set `transferAll: true` to keep the full-transfer path. The GPU/CPU lookup parity (key extraction + hash formula) is pinned by `Fuse8GpuHashParityTest` and exercised end-to-end on a real OpenCL device by `OpenCLCompactOutputIntegrationTest`.
 
-**Measured speedup** — see [GPU Binary Fuse 8 filter — compact output vs. full transfer](#gpu-binary-fuse-8-filter--compact-output-vs-full-transfer) under Performance Benchmarks for an A/B measurement (~1.28× at grid 19 on an RTX 3070).
+**Measured speedup** — see [GPU Binary Fuse 8 filter — compact output vs. full transfer](#gpu-binary-fuse-8-filter--compact-output-vs-full-transfer) under Performance Benchmarks for an A/B measurement (~2.2× at grid 19 on an RTX 3070).
 
 #### Bloom filter — FPP tuning
 
@@ -684,7 +692,7 @@ If you're missing any information or have questions about usage or content, feel
 > ```json
 > "addressLookupBackend" : "TRUNCATED_LONG_64"
 > ```
-> See [Pluggable Address Lookup Backends](#-pluggable-address-lookup-backends-addresslookupbackend) above for the full trade-off matrix and benchmark numbers. `TRUNCATED_LONG_64` loads every hash160 into RAM once at startup as 256 sorted `long[]` buckets (~1.1 GB for the Light DB), then closes the LMDB env and releases its mmap pages — near-`HASHSET` lookup latency at ~10× lower memory cost. If you have memory to spare and prefer exact-bit storage with no probabilistic fallthrough, `HASHSET` (~10 GB for the Light DB) is the next step up. If RAM is tight, `BINARY_FUSE_8` (~172 MB for the Light DB) is the lowest-footprint filter: like `BLOOM` it keeps LMDB open and verifies the ~0.4% of filter hits against it (rejecting false positives), but at a fraction of `BLOOM`'s memory. `BLOOM` (~150 MB) covers a similar niche.
+> See [Pluggable Address Lookup Backends](#-pluggable-address-lookup-backends-addresslookupbackend) above for the full trade-off matrix and benchmark numbers. `TRUNCATED_LONG_64` loads every hash160 into RAM once at startup as 256 sorted `long[]` buckets (~1.1 GB for the Light DB), then closes the LMDB env and releases its mmap pages — near-`HASHSET` lookup latency at ~10× lower memory cost. If you have memory to spare and prefer exact-bit storage with no probabilistic fallthrough, `HASHSET` (~10 GB for the Light DB) is the next step up. If RAM is tight, `BINARY_FUSE_8` (~149 MB for the Light DB) is the lowest-footprint filter: like `BLOOM` it keeps LMDB open and verifies the ~0.4% of filter hits against it (rejecting false positives), but at a fraction of `BLOOM`'s memory. `BLOOM` (~150 MB) covers a similar niche.
 
 <details>
 <summary>Checksums lmdb_light.zip</summary>
@@ -1334,17 +1342,18 @@ back over PCIe.
 
 | GPU Filter (`enableGpuFilter`) | GPU Model              | Key Range (Bits) | Grid Size (Bits) | Effective Keys/s (~) | Speedup        |
 |--------------------------------|------------------------|------------------|------------------|----------------------|----------------|
-| Off — full transfer (legacy)   | NVIDIA RTX 3070 Laptop | 256              | 19               | 1,880,000 keys/s     | 1.00× baseline |
-| On — Binary Fuse 8 compact     | NVIDIA RTX 3070 Laptop | 256              | 19               | 2,410,000 keys/s     | **~1.28×**     |
+| Off — full transfer (legacy)   | NVIDIA RTX 3070 Laptop | 256              | 19               | 4,350,000 keys/s     | 1.00× baseline |
+| On — Binary Fuse 8 compact     | NVIDIA RTX 3070 Laptop | 256              | 19               | 9,710,000 keys/s     | **~2.2×**      |
 
 Measured against a ~1 M-entry filter at `batchSizeInBits = 19` (2¹⁹ ≈ 0.52 M candidates per
 launch), matching the grid size of the raw key-generation table above. The
 `GpuFuse8FilterBenchmark` JMH benchmark A/B-toggles compact mode against the legacy
-full-transfer path on the same kernel and batch; numbers above come from a single long
-measurement iteration (~200 s per arm) since the relevant one-time cost is OpenCL kernel
-compilation (done once in setup) and GPU clock ramp-up, not JVM warmup. The filter wins by
-collapsing the read-back from the full grid down to the ~0.4 % false-positive hits, so the
-advantage grows with `batchSizeInBits` (≈1.7× at grid 20). Run it yourself:
+full-transfer path on the same kernel and batch; numbers above are the mean of 3 measurement
+iterations (compact `18.52 ± 0.05` ops/s, very stable; full transfer `8.30` ops/s, noisier) —
+each op is one launch of 2¹⁹ candidates. The relevant one-time cost is OpenCL kernel compilation
+(done once in setup) and GPU clock ramp-up, not JVM warmup. The filter wins by collapsing the
+read-back from the full grid down to the ~0.4 % false-positive hits, so the advantage grows with
+`batchSizeInBits`. Run it yourself:
 
 ```bash
 mvn test-compile exec:java -Dexec.args="GpuFuse8FilterBenchmark"
@@ -1358,25 +1367,27 @@ and each launch is timestamped on the device. The same grid-19 run on the RTX 30
 
 | Phase | Off — full transfer | On — Binary Fuse 8 compact | Effect |
 |-------|--------------------:|---------------------------:|--------|
-| GPU kernel compute            | 196.2 ms | 200.8 ms | **+4.7 ms (~2.4%)** — the inline filter check |
-| PCIe read-back (device)       |   8.74 ms |  0.035 ms | **~250× less** — only the ~0.4% hits cross the bus |
-| Host-side parse (wall − device) | ~67.9 ms |  ~8.4 ms | **~8× less** — the consumer parses ~2 k hits, not 524 k results |
-| **Per-launch wall time**      | ~272.8 ms | ~209.3 ms |  |
+| GPU kernel compute            | 51.5 ms | 54.8 ms | **+3.3 ms (~6.5%)** — the inline filter check |
+| PCIe read-back (device)       |  8.75 ms | 0.059 ms | **~150× less** — only the ~0.4% hits cross the bus |
+| Host-side parse (wall − device) | ~58.6 ms |  ~0.3 ms | **~185× less** — the consumer parses ~2 k hits, not 524 k results |
+| **Per-launch wall time**      | ~118.8 ms | ~55.2 ms |  |
 
-The takeaway: **the GPU-side filtering is not expensive on the GPU.** It adds only ~2.4 % to
-kernel compute (a handful of integer ops + 3–6 fingerprint reads per candidate, versus the
-elliptic-curve math and two SHA-256 + two RIPEMD-160 hashes that dominate the kernel). The
-~1.28× end-to-end gain comes almost entirely from collapsing the PCIe transfer (~250×) and the
-host-side parse (~8×) — i.e. it offloads the address-presence check from the CPU at negligible
-GPU cost, which is exactly the design intent. (Profiling adds a little driver overhead and is
+The takeaway: **the GPU-side filtering is not expensive on the GPU.** It adds only ~6.5 % to
+kernel compute (a handful of integer ops + one `murmur64` hash + 3 fingerprint reads per
+candidate, versus the elliptic-curve math and two SHA-256 + two RIPEMD-160 hashes that dominate
+the kernel). The ~2.2× end-to-end gain comes almost entirely from collapsing the PCIe transfer
+(~150×) and the host-side parse (~185×) — i.e. it offloads the address-presence check from the
+CPU at negligible GPU cost, which is exactly the design intent. (Profiling adds a little driver overhead and is
 **off by default**; it is a diagnostic switch, never enabled by the runtime pipeline.)
 
 
 ## Logging and Runtime Statistics
 
 In `Find` mode the consumer logs a periodic, single-line statistics snapshot at `INFO`
-level. The interval is controlled by `consumerJava.printStatisticsEveryNSeconds`
-(default `60`). All logging goes through **SLF4J / Logback**, so format and destinations
+level. The print interval is controlled by `consumerJava.printStatisticsEveryNSeconds`
+(default `60`); the keys/second and keys/minute figures are a **current** throughput averaged
+over a trailing `consumerJava.statisticsRateWindowSeconds` window (default `60`), independent of
+the print interval. All logging goes through **SLF4J / Logback**, so format and destinations
 are fully configurable (see [Customizing Log Output](#customizing-log-output)).
 
 ### Reading the Statistics Line
@@ -1384,13 +1395,13 @@ are fully configurable (see [Customizing Log Output](#customizing-log-output)).
 A statistics line looks like this:
 
 ```
-Statistics: [Checked 1234 M keys in 5 minutes] [4100 k keys/second] [246 M keys/minute] [Batches per producer: exampleOpenCL (Random, GPU)=5012, exampleRandom (Random, CPU)=480] [Producers running: 2] [Consumers running: 4] [Consumer ready for work (queue empty): 5012] [Producer blocked (queue full): 0] [Average contains time: 0 ms] [keys queue size: 0] [Hits: 0]
+Statistics: [Checked 1234 M keys in 5 minutes] [4100 k keys/second over 60s] [246 M keys/minute over 60s] [Batches per producer: exampleOpenCL (Random, GPU)=5012, exampleRandom (Random, CPU)=480] [Producers running: 2] [Consumers running: 4] [Consumer ready for work (queue empty): 5012] [Producer blocked (queue full): 0] [Average contains time: 0 ms] [keys queue size: 0] [Hits: 0]
 ```
 
 | Field | Meaning |
 |---|---|
-| `Checked N M keys in M minutes` | Total candidate keys checked so far (millions) and elapsed minutes. |
-| `k keys/second` / `M keys/minute` | Throughput — **the headline performance number.** |
+| `Checked N M keys in M minutes` | **Lifetime** total candidate keys checked so far (millions) and elapsed minutes. |
+| `k keys/second over Ns` / `M keys/minute over Ns` | **Current** throughput, averaged over the trailing `statisticsRateWindowSeconds` window (the `over Ns` suffix shows the window). Unlike a lifetime average it tracks warm-up and thermal throttling and drops toward zero when producers stall. **The headline performance number.** |
 | `Batches per producer: <label>=N, …` | Dispatched-batch count per running producer, keyed by `<keyProducerId> (<Strategy>, <CPU\|GPU>)` so concurrently running producers are told apart. The **strategy** (`Random`, `Bip39`, `Incremental`, `Socket`, `WebSocket`, `Zmq`) is derived from the key producer; the **backend** (`CPU` for `producerJava`/`producerJavaSecretsFiles`, `GPU` for `producerOpenCL`) from the producer. `none` until the first batch. |
 | `Producers running: N` | Number of producers currently in the `RUNNING` state. |
 | `Consumers running: N` | Number of consumer worker threads currently running (≤ `consumerJava.threads`). |
@@ -1400,8 +1411,10 @@ Statistics: [Checked 1234 M keys in 5 minutes] [4100 k keys/second] [246 M keys/
 | `keys queue size: N` | Instantaneous depth of the producer→consumer queue (bounded by `consumerJava.queueSize`). |
 | `Hits: N` | Number of address matches found so far (see [Hit Logging](#hit-logging)). |
 
-> All counters are **cumulative since startup**. What matters for diagnosis is how fast a
-> counter *rises between two statistics lines*, not its absolute value.
+> The **count** fields (`Checked … keys`, `Consumer ready`, `Producer blocked`, `Hits`) are
+> **cumulative since startup** — for those, what matters is how fast they *rise between two
+> lines*, not the absolute value. The `keys/second` / `keys/minute` fields are already a
+> **current windowed rate**, so they read directly with no need to difference successive lines.
 
 ### Diagnosing Bottlenecks
 
@@ -1459,8 +1472,9 @@ Typical customizations:
 
 - **Write hits to their own file** — add a `FileAppender` and route the `ConsumerJava` logger
   (or filter on the `hit:` prefix) to it, so matches are never lost in console scrollback.
-- **Adjust the statistics cadence** — change `consumerJava.printStatisticsEveryNSeconds` in
-  the JSON config (this controls *when* the line is emitted; Logback controls *how/where*).
+- **Adjust the statistics cadence / rate window** — `consumerJava.printStatisticsEveryNSeconds`
+  controls *when* the line is emitted; `consumerJava.statisticsRateWindowSeconds` controls the
+  trailing window the keys/second rate is averaged over (Logback controls *how/where*).
 - **Machine-readable output** — the single-line, fixed-field statistics format is intentionally
   stable so an external supervisor or GUI can parse it (e.g. via an inter-process pipe) to plot
   throughput and the ready/blocked health counters over time.

--- a/TODO.md
+++ b/TODO.md
@@ -114,8 +114,8 @@ All three GPU-acceleration TODOs below connect to a single architectural choice:
 | **Filter checked by** | CPU, after kernel returns | GPU, inside the kernel |
 | **What crosses PCIe per batch** | every hash160 (all N work-items × 104 B) | only candidates that passed the filter (~0.4 % with Fuse-8) |
 | **CPU-side lookup cost** | ~25–108 ns per candidate (depends on backend) | ~0 — only LMDB verification on the tiny trickle |
-| **GPU VRAM consumed by filter** | 0 | ~172 MB (Light DB) / ~1.8 GB (Full DB) with Fuse-8 |
-| **Kernel complexity** | unchanged | +3 hash calls + 3 array reads + 1 XOR per work-item |
+| **GPU VRAM consumed by filter** | 0 | ~149 MB (Light DB) / ~1.5 GB (Full DB) with Fuse-8 |
+| **Kernel complexity** | unchanged | +1 hash call + 3 array reads + 1 XOR per work-item |
 | **GPU needed for filter** | no — CPU-only configs work identically | yes — filter must be uploaded to VRAM at startup |
 | **When it wins** | always (no extra GPU work) | when PCIe bandwidth or CPU filter throughput is the bottleneck |
 | **When it regresses** | never | when GPU was already at ~100 % ALU occupancy on ECC |
@@ -299,10 +299,10 @@ This means the Part 2 GPU-side filter and the compact-output-buffer approach app
   - `getPublicKeyFromByteBufferXY_offsetShiftedByHeaderAndIndex` — verify the first key's X bytes are at byte `4 + 4 = 8` (header + index field), not byte 0.
 
   **Step F — In-kernel Fuse8 check + compact output path** ✅ (kernel `.cl` file + `OpenClTask` + `OpenCLContext`)
-  Add 3 new kernel arguments (the 5 metadata ints are passed as one buffer rather than 5 scalars, matching the Step D upload): `fuse8_fp` (fingerprint buffer), `fuse8_meta` (`[seedLo, seedHi, segLen, segLenMask, segCountLen]` buffer), `transfer_all` (uint). The physical entry layout is unchanged from Step E (the unified 108-byte entry); only the *write decision* changes: in compact mode (`transfer_all == 0`) a work-item writes its entry **only if** its uncompressed OR compressed hash160 passes the filter, claiming the slot via `atomic_add` on the count word (which starts at 0). In full-transfer mode (`transfer_all != 0`) every work-item writes its entry at its own index and work-item 0 stamps the sentinel, exactly as Step E. The kernel's Fuse8 primitives (`fuse8_hash64`/`reduce`/`rotl`/`fingerprint`/`contains`) are a byte-exact port of the Java helpers, and `fuse8_key_from_ripemd` byte-swaps the two LE RIPEMD words to reproduce `ByteBuffer.getLong(0)`. `OpenClTask.executeKernel` binds the args, zero-initialises the count word via `clEnqueueWriteBuffer` before launch, and reads back only the bytes the count word reports (full → `workSize` entries; compact → K). `OpenCLContext` allocates a dummy empty filter on `init()` so the args are always bindable, tracks `gpuFilterUploaded`, and computes `transfer_all = transferAll || !gpuFilterUploaded`.
+  Add 3 new kernel arguments (the 5 metadata ints are passed as one buffer rather than 5 scalars, matching the Step D upload): `fuse8_fp` (fingerprint buffer), `fuse8_meta` (`[seedLo, seedHi, segLen, segLenMask, segCountLen]` buffer), `transfer_all` (uint). The physical entry layout is unchanged from Step E (the unified 108-byte entry); only the *write decision* changes: in compact mode (`transfer_all == 0`) a work-item writes its entry **only if** its uncompressed OR compressed hash160 passes the filter, claiming the slot via `atomic_add` on the count word (which starts at 0). In full-transfer mode (`transfer_all != 0`) every work-item writes its entry at its own index and work-item 0 stamps the sentinel, exactly as Step E. The kernel's Fuse8 primitives (`fuse8_murmur64`/`fuse8_mix`/`fuse8_position`/`fuse8_fingerprint`/`fuse8_contains`) are a byte-exact port of the Java helpers, and `fuse8_key_from_ripemd` byte-swaps the two LE RIPEMD words to reproduce `ByteBuffer.getLong(0)`. `OpenClTask.executeKernel` binds the args, zero-initialises the count word via `clEnqueueWriteBuffer` before launch, and reads back only the bytes the count word reports (full → `workSize` entries; compact → K). `OpenCLContext` allocates a dummy empty filter on `init()` so the args are always bindable, tracks `gpuFilterUploaded`, and computes `transfer_all = transferAll || !gpuFilterUploaded`.
   Test: `Fuse8GpuHashParityTest` (no GPU) pins the key-extraction + hash formula against `BinaryFuse8AddressPresence.containsAddress` over 1 000 distinct hash160 inputs (members + non-members), so any kernel drift fails in pure Java. The kernel build + compact execution are exercised end-to-end in Step I (GPU-gated).
 
-  **Hash strategy — MurmurHash3 finalizer (standard for XOR/fuse filters, ~20 lines total):**
+  **Hash strategy — MurmurHash3 finalizer + fused positions (real Binary Fuse Filter):**
   ```c
   static ulong murmur64(ulong h) {       // 5 lines — the entire hash primitive
       h ^= h >> 33;
@@ -313,15 +313,16 @@ This means the Part 2 GPU-side filter and the compact-output-buffer approach app
       return h;
   }
   // Key extraction: first 8 bytes of hash160 as big-endian uint64 — matches Java ByteBuffer.getLong(pos)
-  // h0/h1/h2 via reduce = (uint)(((ulong)(uint)ph * (ulong)seg) >> 32)  [no division]
-  // seed rotations: rotl(seed,21) and rotl(seed,42) for h1/h2 independence
-  // fingerprint: (uchar)(ph ^ (ph >> 32))
+  // per-key mix: hash = murmur64(key + seed)   [one hash drives all three positions + fingerprint]
+  // base = mul_hi(hash, segCountLen); h0 = base; h1 = base + segLen; h2 = base + 2*segLen
+  // within-segment windows: h1 ^= (hash >> 18) & segLenMask; h2 ^= hash & segLenMask   [h0 has none]
+  // fingerprint: (uchar)(hash ^ (hash >> 32))
   // XOR invariant: fp[h0]^fp[h1]^fp[h2] == fingerprint → hit
   ```
   **Critical**: key extraction in the kernel (`first 8 bytes of hash160 as big-endian ulong`) must match `BinaryFuse8AddressPresence.containsAddress()` exactly (`hash160.getLong(hash160.position())`). Any mismatch → false negatives (missed balance hits).
 
   Tests:
-  - `Fuse8GpuHashParityTest` (no GPU needed — pure Java): reimplements the GPU hash logic in Java (`key = ByteBuffer.wrap(h160).getLong(0); ph = hash64(key, seed); h0 = reduce((int)ph, seg); h1 = reduce((int)hash64(key, rotl(seed,21)), seg) + seg; ...`). For 1 000 distinct hash160 inputs, asserts that this Java reimplementation agrees with `BinaryFuse8AddressPresence.containsAddress()` on every hit/miss answer. This pins the exact key-extraction + hash formula in a runnable test before any OpenCL code is written — if the formulas drift, this test fails.
+  - `Fuse8GpuHashParityTest` (no GPU needed — pure Java): reimplements the GPU hash logic in Java (`key = ByteBuffer.wrap(h160).getLong(0); hash = murmur64(key + seed); base = mulHigh(hash, segCountLen); h0 = base; h1 = base + segLen ^ ((hash >>> 18) & segLenMask); h2 = base + 2*segLen ^ (hash & segLenMask); ...`). For 1 000 distinct hash160 inputs, asserts that this Java reimplementation agrees with `BinaryFuse8AddressPresence.containsAddress()` on every hit/miss answer. This pins the exact key-extraction + hash formula in a runnable test — if the formulas drift, this test fails.
 
   **Step G — Java compact-mode reader** ✅ (`opencl/OpenCLGridResult.java`)
   `getPublicKeyBytes()` dispatches on the count word: `0xFFFFFFFF` → `readFullTransfer()` (walk `workSize` entries), otherwise → `readCompact(count)` (walk K entries). Because the entry layout is unified, both paths share the same per-entry parser: read `work_item_index` (entry offset 0), derive secret via `KeyUtility.calculateSecretKey(secretBase, index, USE_OR)`, read X/Y/hash160u/hash160c at the unified `OUTPUT_ENTRY_*` offsets, assemble `PublicKeyBytes` via `PublicKeyBytes.assembleUncompressedPublicKey(x, y)`.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -132,7 +132,7 @@ Independent of the EC knobs above but performance-relevant: the `LMDB_ONLY` defa
 and exact; the in-RAM filters (`BLOOM`, `HASHSET`, `TRUNCATED_LONG_64`, `BINARY_FUSE_8/16`) trade RAM
 for lookup speed; `producerOpenCL.enableGpuFilter` runs a Binary Fuse 8 pre-filter on the GPU so only
 candidate hits are transferred over PCIe. See the README for the user-facing comparison; the GPU
-filter's measured transfer saving (~1.28× at grid 19 on an RTX 3070) is benchmarked by
+filter's measured transfer saving (~2.2× at grid 19 on an RTX 3070) is benchmarked by
 `GpuFuse8FilterBenchmark`.
 
 ---

--- a/examples/config_Find_1CPUProducerBip39.json
+++ b/examples/config_Find_1CPUProducerBip39.json
@@ -19,6 +19,7 @@
         "logStatsOnClose": false
       },
       "printStatisticsEveryNSeconds": 10,
+      "statisticsRateWindowSeconds": 60,
       "threads": 1,
       "queuePollTimeoutMillis": 50,
       "queueSize": 4,

--- a/examples/config_Find_1OpenCLDevice.json
+++ b/examples/config_Find_1OpenCLDevice.json
@@ -66,6 +66,7 @@
         "disableAddressLookup" : false
       },
       "printStatisticsEveryNSeconds": 10,
+      "statisticsRateWindowSeconds": 60,
       "threads": 8,
       "queuePollTimeoutMillis": 50,
       "queueSize": 4,

--- a/examples/config_Find_1OpenCLDeviceAnd2CPUProducer.json
+++ b/examples/config_Find_1OpenCLDeviceAnd2CPUProducer.json
@@ -31,6 +31,7 @@
         "disableAddressLookup" : false
       },
       "printStatisticsEveryNSeconds": 10,
+      "statisticsRateWindowSeconds": 60,
       "threads": 8,
       "queuePollTimeoutMillis": 50,
       "queueSize": 4,

--- a/examples/config_Find_8CPUProducer.json
+++ b/examples/config_Find_8CPUProducer.json
@@ -59,6 +59,7 @@
         "logStatsOnClose": false
       },
       "printStatisticsEveryNSeconds": 10,
+      "statisticsRateWindowSeconds": 60,
       "threads": 4,
       "queuePollTimeoutMillis": 50,
       "queueSize": 4,

--- a/examples/config_Find_GPUFilterCompact.json
+++ b/examples/config_Find_GPUFilterCompact.json
@@ -19,6 +19,7 @@
         "disableAddressLookup": false
       },
       "printStatisticsEveryNSeconds": 10,
+      "statisticsRateWindowSeconds": 60,
       "threads": 8,
       "queuePollTimeoutMillis": 50,
       "queueSize": 4,

--- a/examples/config_Find_SecretsFile.json
+++ b/examples/config_Find_SecretsFile.json
@@ -12,6 +12,7 @@
         "disableAddressLookup" : false
       },
       "printStatisticsEveryNSeconds": 10,
+      "statisticsRateWindowSeconds": 60,
       "threads": 4,
       "queuePollTimeoutMillis": 50,
       "queueSize": 4,

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CConsumerJava.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CConsumerJava.java
@@ -22,6 +22,15 @@ public class CConsumerJava {
     public @NonNull CLMDBConfigurationReadOnly lmdbConfigurationReadOnly = new CLMDBConfigurationReadOnly();
     /** Interval, in seconds, at which throughput statistics are printed. */
     public int printStatisticsEveryNSeconds = 60;
+    /**
+     * Trailing window, in seconds, over which the current keys/second and keys/minute throughput
+     * is averaged. Independent of {@link #printStatisticsEveryNSeconds}, which only controls how
+     * often the line is printed. Unlike a lifetime average, this reflects <em>recent</em>
+     * performance: it rises while the GPU warms up (clocks ramp), falls under thermal throttling,
+     * and drops toward zero when producers stall — and it does not include the one-time startup
+     * dead time (filter build, kernel compile) once the window has advanced past it. Default: 60.
+     */
+    public int statisticsRateWindowSeconds = 60;
     /** Number of consumer worker threads. */
     public int threads = 4;
     /**

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
@@ -5,7 +5,9 @@ package net.ladenthin.bitcoinaddressfinder.consumer;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -122,6 +124,18 @@ public class ConsumerJava implements Consumer {
      * scheduled-executor task that reads it on every tick (fb-contrib AT_NONATOMIC_64BIT_PRIMITIVE).
      */
     protected volatile long startTime = 0;
+
+    /** Cadence, in seconds, at which the throughput sampler records an odometer sample. */
+    private static final long RATE_SAMPLE_INTERVAL_SECONDS = 1L;
+
+    /**
+     * Trailing ring buffer of {@code [timestampMillis, checkedKeysSnapshot]} samples used to
+     * compute the current windowed keys/second. Only ever touched by the single-thread
+     * {@link #scheduledExecutorService} (both the sampler and the printer run on it), so it needs
+     * no synchronization.
+     */
+    @ToString.Exclude
+    private final Deque<long[]> rateSamples = new ArrayDeque<>();
 
     /** Consumer configuration. */
     protected final CConsumerJava consumerJava;
@@ -396,28 +410,87 @@ public class ConsumerJava implements Consumer {
     }
 
     /**
-     * Starts the periodic statistics-printing scheduler.
+     * Computes the windowed throughput in keys/second from the oldest retained sample to now.
+     * Pure and clock-free so the rate logic can be unit-tested without scheduling or a real clock.
+     *
+     * @param oldestSampleMillis timestamp (epoch ms) of the oldest sample still inside the window
+     * @param oldestSampleKeys   odometer value at {@code oldestSampleMillis}
+     * @param nowMillis          the current timestamp (epoch ms)
+     * @param nowKeys            the current odometer value
+     * @return keys/second averaged over {@code [oldestSampleMillis, nowMillis]}, or {@code 0} if
+     *     the interval is non-positive or the odometer did not advance
      */
+    static double windowKeysPerSecond(long oldestSampleMillis, long oldestSampleKeys, long nowMillis, long nowKeys) {
+        long deltaMillis = nowMillis - oldestSampleMillis;
+        if (deltaMillis <= 0L) {
+            return 0.0;
+        }
+        long deltaKeys = nowKeys - oldestSampleKeys;
+        if (deltaKeys <= 0L) {
+            return 0.0;
+        }
+        return deltaKeys * 1_000.0 / deltaMillis;
+    }
+
+    /**
+     * Starts the periodic statistics-printing scheduler plus the throughput sampler that feeds the
+     * trailing windowed keys/second rate. Both tasks run on the same single-thread scheduler.
+     */
+    @FireAndForget("scheduler shutdown via interrupt() drives both tasks' stop")
+    @SuppressWarnings("FutureReturnValueIgnored")
     public void startStatisticsTimer() {
         long period = consumerJava.printStatisticsEveryNSeconds;
         if (period <= 0) {
             throw new IllegalArgumentException(
                     "consumerJava.printStatisticsEveryNSeconds must be > 0 but was " + period);
         }
+        long rateWindowSeconds = consumerJava.statisticsRateWindowSeconds;
+        if (rateWindowSeconds <= 0) {
+            throw new IllegalArgumentException(
+                    "consumerJava.statisticsRateWindowSeconds must be > 0 but was " + rateWindowSeconds);
+        }
+        long rateWindowMillis = rateWindowSeconds * 1_000L;
 
         startTime = System.currentTimeMillis();
 
-        @FireAndForget("scheduler shutdown via interrupt() drives the task's stop")
-        @SuppressWarnings("FutureReturnValueIgnored")
-        Object unused = scheduledExecutorService.scheduleAtFixedRate(
+        // Sampler: record an odometer sample once per second and evict samples older than the
+        // window. Sampling only begins once keys actually flow, so the one-time startup dead time
+        // (filter build, kernel compile) never contaminates the window.
+        scheduledExecutorService.scheduleAtFixedRate(
                 () -> {
-                    // get transient information
-                    long uptime = Math.max(System.currentTimeMillis() - startTime, 1);
+                    long keysNow = checkedKeys.get();
+                    if (keysNow == 0L) {
+                        return;
+                    }
+                    long now = System.currentTimeMillis();
+                    rateSamples.addLast(new long[] {now, keysNow});
+                    long cutoff = now - rateWindowMillis;
+                    while (rateSamples.size() > 1 && Objects.requireNonNull(rateSamples.peekFirst())[0] < cutoff) {
+                        rateSamples.removeFirst();
+                    }
+                },
+                RATE_SAMPLE_INTERVAL_SECONDS,
+                RATE_SAMPLE_INTERVAL_SECONDS,
+                TimeUnit.SECONDS);
+
+        // Printer: emit the statistics line every period, using the current windowed rate.
+        scheduledExecutorService.scheduleAtFixedRate(
+                () -> {
+                    long now = System.currentTimeMillis();
+                    long keysNow = checkedKeys.get();
+                    double rate = 0.0;
+                    long[] oldest = rateSamples.peekFirst();
+                    if (oldest != null) {
+                        rate = windowKeysPerSecond(oldest[0], oldest[1], now, keysNow);
+                    }
+                    long uptime = Math.max(now - startTime, 1);
 
                     String message = new Statistics()
                             .createStatisticsMessage(
                                     uptime,
-                                    checkedKeys.get(),
+                                    keysNow,
+                                    rate,
+                                    rateWindowSeconds,
                                     checkedKeysSumOfTimeToCheckContains.get(),
                                     runtimeStatistics.batchesByProducerSnapshot(),
                                     runtimeStatistics.getRunningProducers(),

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
@@ -4,11 +4,15 @@
 package net.ladenthin.bitcoinaddressfinder.persistence.inmemory;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import lombok.ToString;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressIterable;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressPresence;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Self-contained presence-only snapshot backed by a Binary Fuse Filter with 16-bit
@@ -16,20 +20,10 @@ import org.jspecify.annotations.NonNull;
  *
  * <h2>Algorithm</h2>
  * Identical to {@link BinaryFuse8AddressPresence} except that fingerprints are stored as
- * {@code short} values (16 bits) instead of {@code byte} values (8 bits). Three positions
- * are derived per key using independent MurmurHash3 invocations with rotated seeds.
- * The XOR invariant and peeling-based construction are the same; only the fingerprint
- * width differs.
- *
- * <h2>Hash design</h2>
- * Three independent positions are derived per key:
- * <ul>
- *   <li>{@code h0 = reduce(hash64(key, seed),           segSize) + 0 * segSize}</li>
- *   <li>{@code h1 = reduce(hash64(key, rotl(seed, 21)), segSize) + 1 * segSize}</li>
- *   <li>{@code h2 = reduce(hash64(key, rotl(seed, 42)), segSize) + 2 * segSize}</li>
- * </ul>
- * The fingerprint is {@code (short)(primaryHash ^ (primaryHash >>> 32))} where
- * {@code primaryHash = hash64(key, seed)}.
+ * {@code short} values (16 bits) instead of {@code byte} values (8 bits). Both are faithful
+ * Binary Fuse Filters (Graf &amp; Lemire, 2022): a single mix {@code murmur64(key + seed)} per
+ * key drives three <em>overlapping</em> segment positions, giving reliable first-attempt
+ * construction at ~1.125&#x00d7; space. Only the fingerprint width differs.
  *
  * <h2>False-positive rate</h2>
  * With 16-bit fingerprints the theoretical FPR is approximately 1/65536 &#x2248; 0.0015&nbsp;%.
@@ -38,10 +32,13 @@ import org.jspecify.annotations.NonNull;
  * filter is wrapped by {@link BinaryFuseAccelerator}, which verifies every filter hit against
  * the LMDB read store; the lower FPR simply means fewer verifications.
  *
+ * <h2>Duplicate keys</h2>
+ * Two distinct addresses that share their first 8 bytes collapse to the same 64-bit key; such
+ * duplicates are removed before construction (lossless for a verified presence pre-filter).
+ *
  * <h2>Memory cost</h2>
- * Approximately 2.60&nbsp;bytes per entry (one {@code short} slot per fingerprint position,
- * with the segment allocation overhead). Peak construction memory is approximately
- * 29&nbsp;bytes per entry (working arrays during the peeling algorithm).
+ * Approximately 2.26&nbsp;bytes per entry (one {@code short} slot per fingerprint position, with
+ * the segment allocation overhead).
  *
  * <h2>No false negatives</h2>
  * Every key that was inserted during {@link #populateFrom(AddressIterable)} will always be
@@ -60,28 +57,41 @@ import org.jspecify.annotations.NonNull;
 @ToString
 public final class BinaryFuse16AddressPresence implements AddressPresence {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(BinaryFuse16AddressPresence.class);
+
+    /** Human-readable prefix for construction progress log lines. */
+    private static final String PROGRESS_NAME = "Binary Fuse16 filter";
+
     /** Fixed length of a hash160 entry in bytes. */
     static final int BYTES_PER_ADDRESS = 20;
 
-    /** Initial seed value used for the first construction attempt. */
-    static final long INITIAL_SEED = 0xBEEF_CAFE_1234_5678L;
+    /** Fixed hypergraph arity: each key maps to three fingerprint slots. */
+    private static final int ARITY = 3;
+
+    /** Upper bound on the per-segment length, matching the reference implementation. */
+    private static final int MAX_SEGMENT_LENGTH = 262144;
 
     /** Maximum number of seed attempts before giving up construction. */
     private static final int MAX_SEED_ATTEMPTS = 100;
 
-    /** Number of segments in the fused layout. */
-    private static final int SEGMENT_COUNT = 3;
+    /** Initial construction seed; re-mixed on each failed attempt. */
+    static final long INITIAL_SEED = 0xBEEF_CAFE_1234_5678L;
 
     private final long seed;
-    private final int segSize;
+    private final int segmentLength;
+    private final int segmentLengthMask;
+    private final int segmentCountLength;
 
     // May be large — toString would be log-killing. slotCount() is included instead.
     @ToString.Exclude
     private final short[] fingerprints;
 
-    private BinaryFuse16AddressPresence(long seed, int segSize, short[] fingerprints) {
+    private BinaryFuse16AddressPresence(
+            long seed, int segmentLength, int segmentLengthMask, int segmentCountLength, short[] fingerprints) {
         this.seed = seed;
-        this.segSize = segSize;
+        this.segmentLength = segmentLength;
+        this.segmentLengthMask = segmentLengthMask;
+        this.segmentCountLength = segmentCountLength;
         this.fingerprints = fingerprints;
     }
 
@@ -93,28 +103,43 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
      * @throws IllegalStateException if filter construction fails after {@value #MAX_SEED_ATTEMPTS} seed attempts
      */
     public static BinaryFuse16AddressPresence populateFrom(@NonNull AddressIterable source) {
-        long[] keys = collectKeys(source);
-        int n = keys.length;
+        long[] keys = deduplicate(collectKeys(source));
+        int size = keys.length;
 
-        if (n == 0) {
-            return new BinaryFuse16AddressPresence(INITIAL_SEED, 2, new short[0]);
+        if (size == 0) {
+            LOGGER.info("{}: no addresses to index; filter is empty.", PROGRESS_NAME);
+            return new BinaryFuse16AddressPresence(INITIAL_SEED, 4, 3, 0, new short[0]);
         }
 
-        int segSize = Math.max(2, (int) Math.ceil(n * 1.3 / 3.0) + 3);
-        int m = segSize * SEGMENT_COUNT;
+        int segmentLength = calculateSegmentLength(size);
+        int segmentLengthMask = segmentLength - 1;
+        double sizeFactor = calculateSizeFactor(size);
+        int capacity = (int) Math.round(size * sizeFactor);
+        int initSegmentCount = (capacity + segmentLength - 1) / segmentLength - (ARITY - 1);
+        int arrayLength = (initSegmentCount + ARITY - 1) * segmentLength;
+        int segmentCount = (arrayLength + segmentLength - 1) / segmentLength;
+        segmentCount = segmentCount <= ARITY - 1 ? 1 : segmentCount - (ARITY - 1);
+        arrayLength = (segmentCount + ARITY - 1) * segmentLength;
+        int segmentCountLength = segmentCount * segmentLength;
 
-        long seed = INITIAL_SEED;
-
+        long attemptSeed = INITIAL_SEED;
         for (int attempt = 0; attempt < MAX_SEED_ATTEMPTS; attempt++) {
-            short[] table = tryBuild(keys, n, seed, segSize, m);
-            if (table.length != 0) {
-                return new BinaryFuse16AddressPresence(seed, segSize, table);
+            short[] table = tryBuild(
+                    keys, attemptSeed, segmentLength, segmentLengthMask, segmentCountLength, arrayLength, attempt);
+            if (table != null) {
+                LOGGER.info("{}: ready ({} addresses, {} fingerprint slots).", PROGRESS_NAME, size, table.length);
+                return new BinaryFuse16AddressPresence(
+                        attemptSeed, segmentLength, segmentLengthMask, segmentCountLength, table);
             }
-            seed = hash64(seed, INITIAL_SEED);
+            LOGGER.info(
+                    "{}: construction attempt {} did not converge; retrying with a new seed.",
+                    PROGRESS_NAME,
+                    attempt + 1);
+            attemptSeed = murmur64(attemptSeed + INITIAL_SEED);
         }
 
         throw new IllegalStateException(
-                "BinaryFuse16 construction failed after " + MAX_SEED_ATTEMPTS + " seed attempts for n=" + n);
+                "BinaryFuse16 construction failed after " + MAX_SEED_ATTEMPTS + " seed attempts for n=" + size);
     }
 
     @Override
@@ -126,11 +151,11 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
             return false;
         }
         long key = hash160.getLong(hash160.position());
-        long ph = hash64(key, seed);
-        int h0 = reduce((int) hash64(key, seed), segSize);
-        int h1 = reduce((int) hash64(key, rotl(seed, 21)), segSize) + segSize;
-        int h2 = reduce((int) hash64(key, rotl(seed, 42)), segSize) + 2 * segSize;
-        short fp = fingerprint16(ph);
+        long hash = mix(key, seed);
+        int h0 = hashPosition(0, hash, segmentCountLength, segmentLength, segmentLengthMask);
+        int h1 = hashPosition(1, hash, segmentCountLength, segmentLength, segmentLengthMask);
+        int h2 = hashPosition(2, hash, segmentCountLength, segmentLength, segmentLengthMask);
+        short fp = fingerprint16(hash);
         return (short) (fingerprints[h0] ^ fingerprints[h1] ^ fingerprints[h2]) == fp;
     }
 
@@ -143,7 +168,7 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
      * Returns the total number of fingerprint slots in the filter array.
      * Each slot is 2 bytes, so total memory is {@code 2 * slotCount()} bytes.
      *
-     * @return the number of slots (approximately 1.30 &#x00d7; the inserted key count)
+     * @return the number of slots (approximately 1.13 &#x00d7; the inserted key count)
      */
     @ToString.Include
     public int slotCount() {
@@ -151,14 +176,12 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
     }
 
     /**
-     * MurmurHash3 64-bit finaliser seeded by XOR with {@code seed}.
+     * MurmurHash3 64-bit finaliser.
      *
-     * @param key  the 64-bit key extracted from the hash160
-     * @param seed the per-segment seed (main seed or a rotation of it)
-     * @return the 64-bit hash value
+     * @param h the value to mix
+     * @return the mixed 64-bit value
      */
-    static long hash64(long key, long seed) {
-        long h = key ^ seed;
+    static long murmur64(long h) {
         h ^= h >>> 33;
         h *= 0xff51afd7ed558ccdL;
         h ^= h >>> 33;
@@ -168,29 +191,64 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
     }
 
     /**
-     * 16-bit fingerprint extracted from a 64-bit hash value by XOR-folding the two 32-bit halves.
+     * Per-key mix: {@code murmur64(key + seed)}.
      *
-     * @param h the primary hash value
-     * @return the fingerprint short
+     * @param key  the 64-bit key extracted from the hash160
+     * @param seed the construction seed
+     * @return the 64-bit mixed hash
      */
-    static short fingerprint16(long h) {
-        return (short) (h ^ (h >>> 32));
+    static long mix(long key, long seed) {
+        return murmur64(key + seed);
     }
 
     /**
-     * Maps a 32-bit hash value into the range {@code [0, m)} using a multiply-high trick
-     * that avoids modulo division.
+     * 16-bit fingerprint extracted from a 64-bit hash value by XOR-folding the two 32-bit halves.
      *
-     * @param h the 32-bit hash (treated as unsigned)
-     * @param m the range upper bound (exclusive)
-     * @return a value in {@code [0, m)}
+     * @param hash the per-key mixed hash
+     * @return the fingerprint short
      */
-    static int reduce(int h, int m) {
-        return (int) ((Integer.toUnsignedLong(h) * (long) m) >>> 32);
+    static short fingerprint16(long hash) {
+        return (short) (hash ^ (hash >>> 32));
     }
 
-    private static long rotl(long v, int r) {
-        return (v << r) | (v >>> (64 - r));
+    /**
+     * Computes the fingerprint slot for one of the three fused positions of a key.
+     *
+     * @param index              the position index (0, 1 or 2)
+     * @param hash               the per-key mixed hash
+     * @param segmentCountLength {@code segmentCount * segmentLength}
+     * @param segmentLength      the per-segment length (power of two)
+     * @param segmentLengthMask  {@code segmentLength - 1}
+     * @return the slot index in {@code [0, (segmentCount + 2) * segmentLength)}
+     */
+    static int hashPosition(int index, long hash, int segmentCountLength, int segmentLength, int segmentLengthMask) {
+        long h = Math.unsignedMultiplyHigh(hash, Integer.toUnsignedLong(segmentCountLength));
+        h += (long) index * segmentLength;
+        // h0 is the bare base position; only h1 and h2 xor a within-segment window, drawn from
+        // distinct low/mid hash bit-ranges that do not overlap the high bits used by the base.
+        if (index == 1) {
+            h ^= (hash >>> 18) & Integer.toUnsignedLong(segmentLengthMask);
+        } else if (index == 2) {
+            h ^= hash & Integer.toUnsignedLong(segmentLengthMask);
+        }
+        return (int) h;
+    }
+
+    /** Reference segment-length heuristic for arity 3, capped at {@link #MAX_SEGMENT_LENGTH}. */
+    static int calculateSegmentLength(int size) {
+        if (size == 0) {
+            return 4;
+        }
+        int length = 1 << (int) Math.floor(Math.log(size) / Math.log(3.33) + 2.25);
+        return Math.min(length, MAX_SEGMENT_LENGTH);
+    }
+
+    /** Reference size-factor heuristic for arity 3. */
+    static double calculateSizeFactor(int size) {
+        if (size <= 1) {
+            return 0.0;
+        }
+        return Math.max(1.125, 0.875 + 0.25 * Math.log(1_000_000.0) / Math.log(size));
     }
 
     private static long[] collectKeys(AddressIterable source) {
@@ -198,56 +256,99 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
         if (count > Integer.MAX_VALUE) {
             throw new IllegalStateException("Source contains more than Integer.MAX_VALUE entries: " + count);
         }
+        LOGGER.info("{}: reading {} addresses from the source ...", PROGRESS_NAME, count);
         long[] keys = new long[(int) count];
         int[] idx = {0};
+        FilterBuildProgress progress =
+                new FilterBuildProgress(LOGGER::info, PROGRESS_NAME + ": reading addresses", count);
         try (Stream<ByteBuffer> stream = source.addresses()) {
             stream.forEach(bb -> {
                 if (idx[0] < keys.length && bb.remaining() == BYTES_PER_ADDRESS) {
                     keys[idx[0]++] = bb.getLong(bb.position());
+                    progress.report(idx[0]);
                 }
             });
         }
-        return keys;
+        return idx[0] == keys.length ? keys : Arrays.copyOf(keys, idx[0]);
     }
 
-    private static short[] tryBuild(long[] keys, int n, long seed, int segSize, int m) {
-        long seed1 = rotl(seed, 21);
-        long seed2 = rotl(seed, 42);
+    /**
+     * Removes duplicate 64-bit keys (produced when two distinct hash160 share their first 8 bytes).
+     * The input array is sorted in place; a compacted copy is returned only when duplicates exist.
+     */
+    private static long[] deduplicate(long[] keys) {
+        if (keys.length < 2) {
+            return keys;
+        }
+        Arrays.sort(keys);
+        int write = 1;
+        for (int read = 1; read < keys.length; read++) {
+            if (keys[read] != keys[write - 1]) {
+                keys[write++] = keys[read];
+            }
+        }
+        if (write == keys.length) {
+            return keys;
+        }
+        LOGGER.info(
+                "{}: removed {} truncation-collision duplicate key(s); {} unique keys remain.",
+                PROGRESS_NAME,
+                keys.length - write,
+                write);
+        return Arrays.copyOf(keys, write);
+    }
 
-        long[] primaryHashes = new long[n];
-        int[] count = new int[m];
-        int[] xorIdx = new int[m];
+    /**
+     * One construction attempt over the fused hypergraph. Returns the filled fingerprint table, or
+     * {@code null} if peeling could not place every key (the caller retries with a new seed).
+     */
+    private static short @Nullable [] tryBuild(
+            long[] keys,
+            long seed,
+            int segmentLength,
+            int segmentLengthMask,
+            int segmentCountLength,
+            int arrayLength,
+            int attempt) {
+        String suffix = attempt == 0 ? "" : " (attempt " + (attempt + 1) + ")";
+        int size = keys.length;
 
-        for (int i = 0; i < n; i++) {
-            long ph = hash64(keys[i], seed);
-            primaryHashes[i] = ph;
-            int h0 = reduce((int) ph, segSize);
-            int h1 = reduce((int) hash64(keys[i], seed1), segSize) + segSize;
-            int h2 = reduce((int) hash64(keys[i], seed2), segSize) + 2 * segSize;
+        int[] count = new int[arrayLength];
+        int[] xorIdx = new int[arrayLength];
+
+        FilterBuildProgress indexing =
+                new FilterBuildProgress(LOGGER::info, PROGRESS_NAME + ": indexing" + suffix, size);
+        for (int i = 0; i < size; i++) {
+            long hash = mix(keys[i], seed);
+            int h0 = hashPosition(0, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h1 = hashPosition(1, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h2 = hashPosition(2, hash, segmentCountLength, segmentLength, segmentLengthMask);
             count[h0]++;
             count[h1]++;
             count[h2]++;
             xorIdx[h0] ^= i;
             xorIdx[h1] ^= i;
             xorIdx[h2] ^= i;
+            indexing.report(i + 1);
         }
 
         // Build initial queue of singleton positions.
-        // Maximum writes: m initial + 3*n from peeling (up to 3 positions per key peeled).
-        int[] queue = new int[m + 3 * n];
+        // Maximum enqueues: arrayLength initial + 3*size from peeling (up to 3 positions per key peeled).
+        int[] queue = new int[arrayLength + 3 * size];
         int qHead = 0;
         int qTail = 0;
-        for (int pos = 0; pos < m; pos++) {
+        for (int pos = 0; pos < arrayLength; pos++) {
             if (count[pos] == 1) {
                 queue[qTail++] = pos;
             }
         }
 
-        int[] order = new int[n];
-        int[] alone = new int[n];
+        int[] order = new int[size];
+        int[] alone = new int[size];
         int done = 0;
 
-        // Peeling loop: peel one singleton at a time
+        // Peeling loop: peel one singleton at a time.
+        FilterBuildProgress peeling = new FilterBuildProgress(LOGGER::info, PROGRESS_NAME + ": peeling" + suffix, size);
         while (qHead < qTail) {
             int pos = queue[qHead++];
             if (count[pos] != 1) {
@@ -257,11 +358,12 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
             order[done] = keyIdx;
             alone[done] = pos;
             done++;
+            peeling.report(done);
 
-            long key = keys[keyIdx];
-            int h0 = reduce((int) hash64(key, seed), segSize);
-            int h1 = reduce((int) hash64(key, seed1), segSize) + segSize;
-            int h2 = reduce((int) hash64(key, seed2), segSize) + 2 * segSize;
+            long hash = mix(keys[keyIdx], seed);
+            int h0 = hashPosition(0, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h1 = hashPosition(1, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h2 = hashPosition(2, hash, segmentCountLength, segmentLength, segmentLengthMask);
 
             count[h0]--;
             xorIdx[h0] ^= keyIdx;
@@ -282,19 +384,22 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
             }
         }
 
-        if (done < n) {
-            return new short[0];
+        if (done < size) {
+            return null;
         }
 
-        // Reverse assignment: fill fingerprints from last peeled to first
-        short[] table = new short[m];
+        // Reverse assignment: fill fingerprints from last peeled to first.
+        short[] table = new short[arrayLength];
+        FilterBuildProgress assigning =
+                new FilterBuildProgress(LOGGER::info, PROGRESS_NAME + ": assigning" + suffix, size);
         for (int j = done - 1; j >= 0; j--) {
-            long key = keys[order[j]];
-            int h0 = reduce((int) hash64(key, seed), segSize);
-            int h1 = reduce((int) hash64(key, seed1), segSize) + segSize;
-            int h2 = reduce((int) hash64(key, seed2), segSize) + 2 * segSize;
+            int keyIdx = order[j];
+            long hash = mix(keys[keyIdx], seed);
+            int h0 = hashPosition(0, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h1 = hashPosition(1, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h2 = hashPosition(2, hash, segmentCountLength, segmentLength, segmentLengthMask);
             int pos = alone[j];
-            short fp = fingerprint16(primaryHashes[order[j]]);
+            short fp = fingerprint16(hash);
             if (pos == h0) {
                 table[h0] = (short) (fp ^ table[h1] ^ table[h2]);
             } else if (pos == h1) {
@@ -302,6 +407,7 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
             } else {
                 table[h2] = (short) (fp ^ table[h0] ^ table[h1]);
             }
+            assigning.report(done - j);
         }
 
         return table;

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
@@ -4,34 +4,50 @@
 package net.ladenthin.bitcoinaddressfinder.persistence.inmemory;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import lombok.ToString;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressIterable;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressPresence;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Self-contained presence-only snapshot backed by a Binary Fuse Filter with 8-bit
  * fingerprints implementing {@link AddressPresence}.
  *
  * <h2>Algorithm</h2>
- * Binary Fuse Filters (Graf &amp; Lemire, 2022) are a variant of XOR filters that use
- * fused segments to guarantee successful construction for any input with high probability.
- * Each key maps to three positions — one per segment — using independent MurmurHash3
- * invocations. The three stored fingerprints satisfy an XOR invariant, enabling O(1)
- * lookup. No false negatives are possible.
+ * This is a faithful implementation of the Binary Fuse Filter (Graf &amp; Lemire, 2022), the
+ * same construction shipped by the reference <em>FastFilter</em> C library. Unlike a plain XOR
+ * filter (three <em>disjoint</em> segments, ~1.23&#x00d7; space) a binary fuse uses <em>fused,
+ * overlapping</em> segments: each key derives a single 64-bit hash whose high bits pick a base
+ * position and whose bit-windows pick three slots in three <em>consecutive</em> segments. This
+ * geometry makes construction succeed on the first attempt with very high probability at only
+ * ~1.125&#x00d7; space, avoiding the repeated re-seeding that a marginally-sized XOR layout
+ * suffers on large inputs.
  *
  * <h2>Hash design</h2>
- * Three independent positions are derived per key:
- * <ul>
- *   <li>{@code h0 = reduce(hash64(key, seed),           segSize) + 0 * segSize}</li>
- *   <li>{@code h1 = reduce(hash64(key, rotl(seed, 21)), segSize) + 1 * segSize}</li>
- *   <li>{@code h2 = reduce(hash64(key, rotl(seed, 42)), segSize) + 2 * segSize}</li>
- * </ul>
- * Using rotations of the seed produces independent 64-bit hashes per segment, preventing
- * the correlated-key collisions that occur with a single-hash bit-window approach.
- * The fingerprint is {@code (byte)(primaryHash ^ (primaryHash >>> 32))} where
- * {@code primaryHash = hash64(key, seed)}.
+ * A single mix {@code hash = murmur64(key + seed)} is computed per key. The three fingerprint
+ * positions are then, for {@code index} in {@code {0, 1, 2}}:
+ * <pre>{@code
+ *   base = unsignedMulHigh(hash, segmentCountLength)   // in [0, segmentCountLength)
+ *   h0   = base
+ *   h1   = base + segmentLength      ^ ((hash >>> 18) & segmentLengthMask)
+ *   h2   = base + 2 * segmentLength  ^ ( hash         & segmentLengthMask)
+ * }</pre>
+ * Because {@code segmentLength} is a power of two and the three indices land in three distinct
+ * segment-aligned blocks, the three positions are always distinct and within
+ * {@code [0, arrayLength)} where {@code arrayLength = (segmentCount + 2) * segmentLength}. The
+ * fingerprint is {@code (byte)(hash ^ (hash >>> 32))}.
+ *
+ * <h2>Duplicate keys</h2>
+ * The filter keys on the first 8 bytes of each hash160. Two distinct addresses that share those
+ * bytes collapse to the same 64-bit key; a binary fuse cannot place two identical keys, so such
+ * duplicates are removed before construction. This is lossless for a presence pre-filter: every
+ * filter hit is verified against the exact backend (LMDB) anyway, so collapsing two 64-bit-equal
+ * addresses into one slot never causes a missed balance.
  *
  * <h2>False-positive rate</h2>
  * With 8-bit fingerprints the theoretical FPR is approximately 1/256 &#x2248; 0.4&nbsp;%.
@@ -42,9 +58,9 @@ import org.jspecify.annotations.NonNull;
  * without consulting the delegate.
  *
  * <h2>Memory cost</h2>
- * Approximately 1.30&nbsp;bytes per entry (one {@code byte} slot per fingerprint position,
- * with the segment allocation overhead). Peak construction memory is approximately
- * 29&nbsp;bytes per entry (working arrays during the peeling algorithm).
+ * Approximately 1.13&nbsp;bytes per entry (one {@code byte} slot per fingerprint position, with
+ * the segment allocation overhead). Peak construction memory is dominated by the peeling working
+ * arrays.
  *
  * <h2>No false negatives</h2>
  * Every key that was inserted during {@link #populateFrom(AddressIterable)} will always be
@@ -63,28 +79,41 @@ import org.jspecify.annotations.NonNull;
 @ToString
 public final class BinaryFuse8AddressPresence implements AddressPresence {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(BinaryFuse8AddressPresence.class);
+
+    /** Human-readable prefix for construction progress log lines. */
+    private static final String PROGRESS_NAME = "Binary Fuse8 filter";
+
     /** Fixed length of a hash160 entry in bytes. */
     static final int BYTES_PER_ADDRESS = 20;
 
-    /** Initial seed value used for the first construction attempt. */
-    static final long INITIAL_SEED = 0xBEEF_CAFE_1234_5678L;
+    /** Fixed hypergraph arity: each key maps to three fingerprint slots. */
+    private static final int ARITY = 3;
+
+    /** Upper bound on the per-segment length, matching the reference implementation. */
+    private static final int MAX_SEGMENT_LENGTH = 262144;
 
     /** Maximum number of seed attempts before giving up construction. */
     private static final int MAX_SEED_ATTEMPTS = 100;
 
-    /** Number of segments in the fused layout. */
-    private static final int SEGMENT_COUNT = 3;
+    /** Initial construction seed; re-mixed on each failed attempt. */
+    static final long INITIAL_SEED = 0xBEEF_CAFE_1234_5678L;
 
     private final long seed;
-    private final int segSize;
+    private final int segmentLength;
+    private final int segmentLengthMask;
+    private final int segmentCountLength;
 
     // May be large — toString would be log-killing. slotCount() is included instead.
     @ToString.Exclude
     private final byte[] fingerprints;
 
-    private BinaryFuse8AddressPresence(long seed, int segSize, byte[] fingerprints) {
+    private BinaryFuse8AddressPresence(
+            long seed, int segmentLength, int segmentLengthMask, int segmentCountLength, byte[] fingerprints) {
         this.seed = seed;
-        this.segSize = segSize;
+        this.segmentLength = segmentLength;
+        this.segmentLengthMask = segmentLengthMask;
+        this.segmentCountLength = segmentCountLength;
         this.fingerprints = fingerprints;
     }
 
@@ -96,28 +125,43 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
      * @throws IllegalStateException if filter construction fails after {@value #MAX_SEED_ATTEMPTS} seed attempts
      */
     public static BinaryFuse8AddressPresence populateFrom(@NonNull AddressIterable source) {
-        long[] keys = collectKeys(source);
-        int n = keys.length;
+        long[] keys = deduplicate(collectKeys(source));
+        int size = keys.length;
 
-        if (n == 0) {
-            return new BinaryFuse8AddressPresence(INITIAL_SEED, 2, new byte[0]);
+        if (size == 0) {
+            LOGGER.info("{}: no addresses to index; filter is empty.", PROGRESS_NAME);
+            return new BinaryFuse8AddressPresence(INITIAL_SEED, 4, 3, 0, new byte[0]);
         }
 
-        int segSize = Math.max(2, (int) Math.ceil(n * 1.3 / 3.0) + 3);
-        int m = segSize * SEGMENT_COUNT;
+        int segmentLength = calculateSegmentLength(size);
+        int segmentLengthMask = segmentLength - 1;
+        double sizeFactor = calculateSizeFactor(size);
+        int capacity = (int) Math.round(size * sizeFactor);
+        int initSegmentCount = (capacity + segmentLength - 1) / segmentLength - (ARITY - 1);
+        int arrayLength = (initSegmentCount + ARITY - 1) * segmentLength;
+        int segmentCount = (arrayLength + segmentLength - 1) / segmentLength;
+        segmentCount = segmentCount <= ARITY - 1 ? 1 : segmentCount - (ARITY - 1);
+        arrayLength = (segmentCount + ARITY - 1) * segmentLength;
+        int segmentCountLength = segmentCount * segmentLength;
 
-        long seed = INITIAL_SEED;
-
+        long attemptSeed = INITIAL_SEED;
         for (int attempt = 0; attempt < MAX_SEED_ATTEMPTS; attempt++) {
-            byte[] table = tryBuild(keys, n, seed, segSize, m);
-            if (table.length != 0) {
-                return new BinaryFuse8AddressPresence(seed, segSize, table);
+            byte[] table = tryBuild(
+                    keys, attemptSeed, segmentLength, segmentLengthMask, segmentCountLength, arrayLength, attempt);
+            if (table != null) {
+                LOGGER.info("{}: ready ({} addresses, {} fingerprint slots).", PROGRESS_NAME, size, table.length);
+                return new BinaryFuse8AddressPresence(
+                        attemptSeed, segmentLength, segmentLengthMask, segmentCountLength, table);
             }
-            seed = hash64(seed, INITIAL_SEED);
+            LOGGER.info(
+                    "{}: construction attempt {} did not converge; retrying with a new seed.",
+                    PROGRESS_NAME,
+                    attempt + 1);
+            attemptSeed = murmur64(attemptSeed + INITIAL_SEED);
         }
 
         throw new IllegalStateException(
-                "BinaryFuse8 construction failed after " + MAX_SEED_ATTEMPTS + " seed attempts for n=" + n);
+                "BinaryFuse8 construction failed after " + MAX_SEED_ATTEMPTS + " seed attempts for n=" + size);
     }
 
     @Override
@@ -129,11 +173,11 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
             return false;
         }
         long key = hash160.getLong(hash160.position());
-        long ph = hash64(key, seed);
-        int h0 = reduce((int) hash64(key, seed), segSize);
-        int h1 = reduce((int) hash64(key, rotl(seed, 21)), segSize) + segSize;
-        int h2 = reduce((int) hash64(key, rotl(seed, 42)), segSize) + 2 * segSize;
-        byte fp = fingerprint8(ph);
+        long hash = mix(key, seed);
+        int h0 = hashPosition(0, hash, segmentCountLength, segmentLength, segmentLengthMask);
+        int h1 = hashPosition(1, hash, segmentCountLength, segmentLength, segmentLengthMask);
+        int h2 = hashPosition(2, hash, segmentCountLength, segmentLength, segmentLengthMask);
+        byte fp = fingerprint8(hash);
         return (byte) (fingerprints[h0] ^ fingerprints[h1] ^ fingerprints[h2]) == fp;
     }
 
@@ -145,7 +189,7 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
     /**
      * Returns the total number of fingerprint slots in the filter array.
      *
-     * @return the number of slots (approximately 1.30 &#x00d7; the inserted key count)
+     * @return the number of slots (approximately 1.13 &#x00d7; the inserted key count)
      */
     @ToString.Include
     public int slotCount() {
@@ -182,7 +226,7 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
     }
 
     /**
-     * Returns the construction seed of the first successful build.
+     * Returns the construction seed of the successful build.
      *
      * @return the seed value used by {@link #containsAddress(ByteBuffer)} for hashing
      */
@@ -191,47 +235,41 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
     }
 
     /**
-     * Returns the per-segment length used by the {@code reduce} position mapping.
+     * Returns the per-segment length (a power of two) used by the fused position mapping.
      *
      * @return the segment length
      */
     int getSegmentLength() {
-        return segSize;
+        return segmentLength;
     }
 
     /**
-     * Returns {@link #getSegmentLength()} minus one.
-     * <p>
-     * Provided as GPU-upload metadata to mirror the standard Binary Fuse filter layout; the
-     * {@code reduce}-based position mapping used here does not consume the mask directly.
+     * Returns {@code segmentLength - 1}, the mask applied to each within-segment bit-window.
      *
-     * @return {@code getSegmentLength() - 1}
+     * @return the segment-length mask
      */
     int getSegmentLengthMask() {
-        return segSize - 1;
+        return segmentLengthMask;
     }
 
     /**
-     * Returns the total number of fingerprint slots (the three segments combined).
-     * <p>
-     * Equals {@link #getFingerprints()}{@code .length}, so the value matches the size of the
-     * buffer uploaded to GPU VRAM exactly.
+     * Returns {@code segmentCount * segmentLength}, the exclusive upper bound of the base
+     * position produced by the high-bits reduction. This is <em>not</em> the fingerprint array
+     * length (which is {@code (segmentCount + 2) * segmentLength}).
      *
-     * @return the total slot count across all segments
+     * @return the segment-count length used by the position mapping
      */
     int getSegmentCountLength() {
-        return fingerprints.length;
+        return segmentCountLength;
     }
 
     /**
-     * MurmurHash3 64-bit finaliser seeded by XOR with {@code seed}.
+     * MurmurHash3 64-bit finaliser.
      *
-     * @param key  the 64-bit key extracted from the hash160
-     * @param seed the per-segment seed (main seed or a rotation of it)
-     * @return the 64-bit hash value
+     * @param h the value to mix
+     * @return the mixed 64-bit value
      */
-    static long hash64(long key, long seed) {
-        long h = key ^ seed;
+    static long murmur64(long h) {
         h ^= h >>> 33;
         h *= 0xff51afd7ed558ccdL;
         h ^= h >>> 33;
@@ -241,29 +279,65 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
     }
 
     /**
-     * 8-bit fingerprint extracted from a 64-bit hash value by XOR-folding the two 32-bit halves.
+     * Per-key mix: {@code murmur64(key + seed)}. A single mix drives all three positions and the
+     * fingerprint.
      *
-     * @param h the primary hash value
-     * @return the fingerprint byte
+     * @param key  the 64-bit key extracted from the hash160
+     * @param seed the construction seed
+     * @return the 64-bit mixed hash
      */
-    static byte fingerprint8(long h) {
-        return (byte) (h ^ (h >>> 32));
+    static long mix(long key, long seed) {
+        return murmur64(key + seed);
     }
 
     /**
-     * Maps a 32-bit hash value into the range {@code [0, m)} using a multiply-high trick
-     * that avoids modulo division.
+     * 8-bit fingerprint extracted from a 64-bit hash value by XOR-folding the two 32-bit halves.
      *
-     * @param h the 32-bit hash (treated as unsigned)
-     * @param m the range upper bound (exclusive)
-     * @return a value in {@code [0, m)}
+     * @param hash the per-key mixed hash
+     * @return the fingerprint byte
      */
-    static int reduce(int h, int m) {
-        return (int) ((Integer.toUnsignedLong(h) * (long) m) >>> 32);
+    static byte fingerprint8(long hash) {
+        return (byte) (hash ^ (hash >>> 32));
     }
 
-    private static long rotl(long v, int r) {
-        return (v << r) | (v >>> (64 - r));
+    /**
+     * Computes the fingerprint slot for one of the three fused positions of a key.
+     *
+     * @param index              the position index (0, 1 or 2)
+     * @param hash               the per-key mixed hash
+     * @param segmentCountLength {@code segmentCount * segmentLength}
+     * @param segmentLength      the per-segment length (power of two)
+     * @param segmentLengthMask  {@code segmentLength - 1}
+     * @return the slot index in {@code [0, (segmentCount + 2) * segmentLength)}
+     */
+    static int hashPosition(int index, long hash, int segmentCountLength, int segmentLength, int segmentLengthMask) {
+        long h = Math.unsignedMultiplyHigh(hash, Integer.toUnsignedLong(segmentCountLength));
+        h += (long) index * segmentLength;
+        // h0 is the bare base position; only h1 and h2 xor a within-segment window, drawn from
+        // distinct low/mid hash bit-ranges that do not overlap the high bits used by the base.
+        if (index == 1) {
+            h ^= (hash >>> 18) & Integer.toUnsignedLong(segmentLengthMask);
+        } else if (index == 2) {
+            h ^= hash & Integer.toUnsignedLong(segmentLengthMask);
+        }
+        return (int) h;
+    }
+
+    /** Reference segment-length heuristic for arity 3, capped at {@link #MAX_SEGMENT_LENGTH}. */
+    static int calculateSegmentLength(int size) {
+        if (size == 0) {
+            return 4;
+        }
+        int length = 1 << (int) Math.floor(Math.log(size) / Math.log(3.33) + 2.25);
+        return Math.min(length, MAX_SEGMENT_LENGTH);
+    }
+
+    /** Reference size-factor heuristic for arity 3. */
+    static double calculateSizeFactor(int size) {
+        if (size <= 1) {
+            return 0.0;
+        }
+        return Math.max(1.125, 0.875 + 0.25 * Math.log(1_000_000.0) / Math.log(size));
     }
 
     private static long[] collectKeys(AddressIterable source) {
@@ -271,56 +345,100 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
         if (count > Integer.MAX_VALUE) {
             throw new IllegalStateException("Source contains more than Integer.MAX_VALUE entries: " + count);
         }
+        LOGGER.info("{}: reading {} addresses from the source ...", PROGRESS_NAME, count);
         long[] keys = new long[(int) count];
         int[] idx = {0};
+        FilterBuildProgress progress =
+                new FilterBuildProgress(LOGGER::info, PROGRESS_NAME + ": reading addresses", count);
         try (Stream<ByteBuffer> stream = source.addresses()) {
             stream.forEach(bb -> {
                 if (idx[0] < keys.length && bb.remaining() == BYTES_PER_ADDRESS) {
                     keys[idx[0]++] = bb.getLong(bb.position());
+                    progress.report(idx[0]);
                 }
             });
         }
-        return keys;
+        // trim in case the source yielded fewer valid entries than count() reported
+        return idx[0] == keys.length ? keys : Arrays.copyOf(keys, idx[0]);
     }
 
-    private static byte[] tryBuild(long[] keys, int n, long seed, int segSize, int m) {
-        long seed1 = rotl(seed, 21);
-        long seed2 = rotl(seed, 42);
+    /**
+     * Removes duplicate 64-bit keys (produced when two distinct hash160 share their first 8 bytes).
+     * The input array is sorted in place; a compacted copy is returned only when duplicates exist.
+     */
+    private static long[] deduplicate(long[] keys) {
+        if (keys.length < 2) {
+            return keys;
+        }
+        Arrays.sort(keys);
+        int write = 1;
+        for (int read = 1; read < keys.length; read++) {
+            if (keys[read] != keys[write - 1]) {
+                keys[write++] = keys[read];
+            }
+        }
+        if (write == keys.length) {
+            return keys;
+        }
+        LOGGER.info(
+                "{}: removed {} truncation-collision duplicate key(s); {} unique keys remain.",
+                PROGRESS_NAME,
+                keys.length - write,
+                write);
+        return Arrays.copyOf(keys, write);
+    }
 
-        long[] primaryHashes = new long[n];
-        int[] count = new int[m];
-        int[] xorIdx = new int[m];
+    /**
+     * One construction attempt over the fused hypergraph. Returns the filled fingerprint table, or
+     * {@code null} if peeling could not place every key (the caller retries with a new seed).
+     */
+    private static byte @Nullable [] tryBuild(
+            long[] keys,
+            long seed,
+            int segmentLength,
+            int segmentLengthMask,
+            int segmentCountLength,
+            int arrayLength,
+            int attempt) {
+        String suffix = attempt == 0 ? "" : " (attempt " + (attempt + 1) + ")";
+        int size = keys.length;
 
-        for (int i = 0; i < n; i++) {
-            long ph = hash64(keys[i], seed);
-            primaryHashes[i] = ph;
-            int h0 = reduce((int) ph, segSize);
-            int h1 = reduce((int) hash64(keys[i], seed1), segSize) + segSize;
-            int h2 = reduce((int) hash64(keys[i], seed2), segSize) + 2 * segSize;
+        int[] count = new int[arrayLength];
+        int[] xorIdx = new int[arrayLength];
+
+        FilterBuildProgress indexing =
+                new FilterBuildProgress(LOGGER::info, PROGRESS_NAME + ": indexing" + suffix, size);
+        for (int i = 0; i < size; i++) {
+            long hash = mix(keys[i], seed);
+            int h0 = hashPosition(0, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h1 = hashPosition(1, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h2 = hashPosition(2, hash, segmentCountLength, segmentLength, segmentLengthMask);
             count[h0]++;
             count[h1]++;
             count[h2]++;
             xorIdx[h0] ^= i;
             xorIdx[h1] ^= i;
             xorIdx[h2] ^= i;
+            indexing.report(i + 1);
         }
 
         // Build initial queue of singleton positions.
-        // Maximum writes: m initial + 3*n from peeling (up to 3 positions per key peeled).
-        int[] queue = new int[m + 3 * n];
+        // Maximum enqueues: arrayLength initial + 3*size from peeling (up to 3 positions per key peeled).
+        int[] queue = new int[arrayLength + 3 * size];
         int qHead = 0;
         int qTail = 0;
-        for (int pos = 0; pos < m; pos++) {
+        for (int pos = 0; pos < arrayLength; pos++) {
             if (count[pos] == 1) {
                 queue[qTail++] = pos;
             }
         }
 
-        int[] order = new int[n];
-        int[] alone = new int[n];
+        int[] order = new int[size];
+        int[] alone = new int[size];
         int done = 0;
 
-        // Peeling loop: peel one singleton at a time
+        // Peeling loop: peel one singleton at a time.
+        FilterBuildProgress peeling = new FilterBuildProgress(LOGGER::info, PROGRESS_NAME + ": peeling" + suffix, size);
         while (qHead < qTail) {
             int pos = queue[qHead++];
             if (count[pos] != 1) {
@@ -330,11 +448,12 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
             order[done] = keyIdx;
             alone[done] = pos;
             done++;
+            peeling.report(done);
 
-            long key = keys[keyIdx];
-            int h0 = reduce((int) hash64(key, seed), segSize);
-            int h1 = reduce((int) hash64(key, seed1), segSize) + segSize;
-            int h2 = reduce((int) hash64(key, seed2), segSize) + 2 * segSize;
+            long hash = mix(keys[keyIdx], seed);
+            int h0 = hashPosition(0, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h1 = hashPosition(1, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h2 = hashPosition(2, hash, segmentCountLength, segmentLength, segmentLengthMask);
 
             count[h0]--;
             xorIdx[h0] ^= keyIdx;
@@ -355,19 +474,22 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
             }
         }
 
-        if (done < n) {
-            return new byte[0];
+        if (done < size) {
+            return null;
         }
 
-        // Reverse assignment: fill fingerprints from last peeled to first
-        byte[] table = new byte[m];
+        // Reverse assignment: fill fingerprints from last peeled to first.
+        byte[] table = new byte[arrayLength];
+        FilterBuildProgress assigning =
+                new FilterBuildProgress(LOGGER::info, PROGRESS_NAME + ": assigning" + suffix, size);
         for (int j = done - 1; j >= 0; j--) {
-            long key = keys[order[j]];
-            int h0 = reduce((int) hash64(key, seed), segSize);
-            int h1 = reduce((int) hash64(key, seed1), segSize) + segSize;
-            int h2 = reduce((int) hash64(key, seed2), segSize) + 2 * segSize;
+            int keyIdx = order[j];
+            long hash = mix(keys[keyIdx], seed);
+            int h0 = hashPosition(0, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h1 = hashPosition(1, hash, segmentCountLength, segmentLength, segmentLengthMask);
+            int h2 = hashPosition(2, hash, segmentCountLength, segmentLength, segmentLengthMask);
             int pos = alone[j];
-            byte fp = fingerprint8(primaryHashes[order[j]]);
+            byte fp = fingerprint8(hash);
             if (pos == h0) {
                 table[h0] = (byte) (fp ^ table[h1] ^ table[h2]);
             } else if (pos == h1) {
@@ -375,6 +497,7 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
             } else {
                 table[h2] = (byte) (fp ^ table[h0] ^ table[h1]);
             }
+            assigning.report(done - j);
         }
 
         return table;

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/FilterBuildProgress.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/FilterBuildProgress.java
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence.inmemory;
+
+/**
+ * Bounded progress reporter for the O(n) phases of Binary Fuse filter construction.
+ *
+ * <p>Building a filter over a large address set (tens or hundreds of millions of entries) is a
+ * single-threaded, multi-second-to-multi-minute, otherwise <em>silent</em> computation. Without
+ * any output the process looks hung — which is exactly the confusion this reporter removes: it
+ * emits a small, bounded number of lines per phase (roughly one per {@code 100 / }{@link #SEGMENTS}
+ * &nbsp;% of progress) so a user watching the log can see the build is alive and roughly how far
+ * along it is.
+ *
+ * <p>Interim percentage lines are suppressed for small inputs (fewer than {@link #MIN_ENTRIES}
+ * units); callers still emit their own start/end lines, so tiny databases and unit-test runs stay
+ * quiet instead of spamming a line per entry.
+ *
+ * <p>Output is delivered through a caller-supplied {@link LogSink} (typically the owning filter
+ * class's {@code LOGGER::info}); this keeps the helper free of a {@code Logger} field and lets each
+ * filter log under its own category.
+ *
+ * <p><strong>Not thread-safe.</strong> Each instance is advanced by the single construction thread.
+ */
+final class FilterBuildProgress {
+
+    /**
+     * Destination for a single, fully rendered progress line. Kept as a minimal functional type so
+     * this helper does not hold a logger reference of its own.
+     */
+    @FunctionalInterface
+    interface LogSink {
+        /**
+         * Emits one rendered progress line.
+         *
+         * @param message the complete, human-readable progress message
+         */
+        void log(String message);
+    }
+
+    /** Approximate number of interim percentage lines emitted per phase for large inputs. */
+    static final int SEGMENTS = 10;
+
+    /** Inputs smaller than this (in units) emit no interim percentage lines. */
+    static final long MIN_ENTRIES = 1_000_000L;
+
+    private final LogSink sink;
+    private final String phase;
+    private final long total;
+    private final boolean interimEnabled;
+    private final long step;
+    private long nextThreshold;
+
+    /**
+     * Creates a reporter for a single construction phase.
+     *
+     * @param sink  the destination for rendered progress lines
+     * @param phase a human-readable phase label, e.g. {@code "Binary Fuse8 filter: peeling"}
+     * @param total the total number of units this phase will process; interim lines are emitted
+     *              only when this is at least {@link #MIN_ENTRIES}
+     */
+    FilterBuildProgress(LogSink sink, String phase, long total) {
+        this.sink = sink;
+        this.phase = phase;
+        this.total = Math.max(0L, total);
+        this.interimEnabled = this.total >= MIN_ENTRIES;
+        this.step = Math.max(1L, this.total / SEGMENTS);
+        this.nextThreshold = this.step;
+    }
+
+    /**
+     * Reports that {@code done} units of this phase are complete. Emits at most one line per
+     * {@code 100 / }{@link #SEGMENTS}&nbsp;% milestone crossed; calls below the next milestone, and
+     * all calls for small inputs, are cheap no-ops.
+     *
+     * @param done the number of units completed so far (monotonically non-decreasing)
+     */
+    void report(long done) {
+        if (!interimEnabled || done < nextThreshold) {
+            return;
+        }
+        long percent = total == 0L ? 100L : Math.min(100L, done * 100L / total);
+        sink.log(phase + ": " + percent + "% (" + done + "/" + total + ").");
+        do {
+            nextThreshold += step;
+        } while (nextThreshold <= done);
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/statistics/Statistics.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/statistics/Statistics.java
@@ -18,11 +18,22 @@ public class Statistics {
     @Deprecated
     public static final int ONE_SECOND_IN_MILLISECONDS = 1000;
 
+    /** Number of seconds per minute. */
+    private static final double SECONDS_PER_MINUTE = 60.0;
+
     /**
      * Builds the periodic human-readable statistics line logged by the consumer.
      *
-     * @param uptime                       elapsed run time in milliseconds
-     * @param keys                         total number of keys checked so far
+     * <p>The {@code Checked … keys} figure is the lifetime total; the keys/second and keys/minute
+     * figures are the <em>current windowed</em> throughput (averaged over
+     * {@code rateWindowSeconds}), not a lifetime average, so they track warm-up and thermal
+     * throttling rather than settling to a long-run mean.
+     *
+     * @param uptime                       elapsed run time in milliseconds (lifetime)
+     * @param keys                         total number of keys checked so far (lifetime)
+     * @param windowKeysPerSecond          current throughput in keys/second, averaged over the
+     *                                     trailing {@code rateWindowSeconds} window
+     * @param rateWindowSeconds            the trailing window (seconds) the rate is averaged over
      * @param keysSumOfTimeToCheckContains cumulative time (ms) spent in presence lookups
      * @param batchesByProducer            dispatched-batch counts keyed by producer label
      *                                     ({@code "<keyProducerId> (<Strategy>, <CPU|GPU>)"}); lets
@@ -41,6 +52,8 @@ public class Statistics {
     public String createStatisticsMessage(
             long uptime,
             long keys,
+            double windowKeysPerSecond,
+            long rateWindowSeconds,
             long keysSumOfTimeToCheckContains,
             Map<String, Long> batchesByProducer,
             long producersRunning,
@@ -49,12 +62,12 @@ public class Statistics {
             long producerBlocked,
             long keysQueueSize,
             long hits) {
-        // calculate uptime
+        // calculate uptime (lifetime)
         long uptimeInSeconds = uptime / (long) ONE_SECOND_IN_MILLISECONDS;
         long uptimeInMinutes = uptimeInSeconds / 60;
-        // calculate per time, prevent division by zero with Math.max
-        long keysPerSecond = keys / Math.max(uptimeInSeconds, 1);
-        long keysPerMinute = keys / Math.max(uptimeInMinutes, 1);
+        // current windowed throughput, rounded to the displayed k / M units
+        long keysPerSecondK = Math.round(windowKeysPerSecond / 1_000.0);
+        long keysPerMinuteM = Math.round(windowKeysPerSecond * SECONDS_PER_MINUTE / 1_000_000.0);
         // calculate average contains time
         long averageContainsTime = keysSumOfTimeToCheckContains / Math.max(keys, 1);
         // per-producer batch breakdown, rendered as "label=count, label=count" (or "none")
@@ -65,8 +78,8 @@ public class Statistics {
                         .collect(Collectors.joining(", "));
 
         return "Statistics: [Checked " + (keys / 1_000_000L) + " M keys in " + uptimeInMinutes + " minutes] ["
-                + (keysPerSecond / 1_000L) + " k keys/second] [" + (keysPerMinute / 1_000_000L)
-                + " M keys/minute] [Batches per producer: " + batches
+                + keysPerSecondK + " k keys/second over " + rateWindowSeconds + "s] [" + keysPerMinuteM
+                + " M keys/minute over " + rateWindowSeconds + "s] [Batches per producer: " + batches
                 + "] [Producers running: " + producersRunning + "] [Consumers running: " + consumersRunning
                 + "] [Consumer ready for work (queue empty): " + consumerReady
                 + "] [Producer blocked (queue full): " + producerBlocked + "] [Average contains time: "

--- a/src/main/resources/inc_ecc_secp256k1custom.cl
+++ b/src/main/resources/inc_ecc_secp256k1custom.cl
@@ -633,12 +633,12 @@ inline void ripemd160_hash_prebuilt_block_swap(const u32 *block, u32 *out_h)
 // ======================================================================================
 // ==== GPU-side Binary Fuse 8 filter (mirrors BinaryFuse8AddressPresence exactly) ======
 // ======================================================================================
-// These four primitives are a byte-exact port of the Java hash64 / reduce / fingerprint8
-// helpers. Any divergence produces silent false negatives (a stored address never flagged),
-// so they are pinned against the Java implementation by Fuse8GpuHashParityTest.
+// These primitives are a byte-exact port of the Java murmur64 / mix / fingerprint8 /
+// hashPosition helpers of the real Binary Fuse Filter (fused overlapping segments). Any
+// divergence produces silent false negatives (a stored address never flagged), so they are
+// pinned against the Java implementation by Fuse8GpuHashParityTest.
 
-inline ulong fuse8_hash64(ulong key, ulong seed) {
-    ulong h = key ^ seed;
+inline ulong fuse8_murmur64(ulong h) {
     h ^= h >> 33;
     h *= 0xff51afd7ed558ccdUL;
     h ^= h >> 33;
@@ -647,17 +647,30 @@ inline ulong fuse8_hash64(ulong key, ulong seed) {
     return h;
 }
 
-inline uint fuse8_reduce(uint h, uint m) {
-    // Multiply-high mapping into [0, m): (uint)(((ulong)h * (ulong)m) >> 32). No division.
-    return (uint)(((ulong)h * (ulong)m) >> 32);
-}
-
-inline ulong fuse8_rotl(ulong v, int r) {
-    return (v << r) | (v >> (64 - r));
+// Per-key mix: murmur64(key + seed). A single mix drives all three positions and the fingerprint.
+inline ulong fuse8_mix(ulong key, ulong seed) {
+    return fuse8_murmur64(key + seed);
 }
 
 inline uchar fuse8_fingerprint(ulong h) {
     return (uchar)(h ^ (h >> 32));
+}
+
+// One fused fingerprint position: high bits of the hash pick a base in [0, seg_count_len), then
+// index*seg selects one of three consecutive segments and a within-segment bit-window (masked by
+// seg_mask) offsets inside it. mul_hi is the unsigned 64x64->high64 multiply (== Java
+// Math.unsignedMultiplyHigh), matching the CPU base reduction exactly.
+inline uint fuse8_position(int index, ulong hash, uint seg_count_len, uint seg, uint seg_mask) {
+    ulong h = mul_hi(hash, (ulong)seg_count_len);
+    h += (ulong)((uint)index * seg);
+    // h0 is the bare base position; only h1 and h2 xor a within-segment window from distinct
+    // hash bit-ranges that do not overlap the high bits used by the base.
+    if (index == 1) {
+        h ^= (hash >> 18) & (ulong)seg_mask;
+    } else if (index == 2) {
+        h ^= hash & (ulong)seg_mask;
+    }
+    return (uint)h;
 }
 
 // Key extraction: the first 8 bytes of the hash160 read as a big-endian uint64. The two
@@ -669,15 +682,16 @@ inline ulong fuse8_key_from_ripemd(const u32 *h) {
 }
 
 // Returns true when the key is POSSIBLY present (no false negatives; ~0.4% false positives).
-inline bool fuse8_contains(__global const uchar *fp, ulong seed, uint seg, uint seg_count_len, ulong key) {
+inline bool fuse8_contains(
+    __global const uchar *fp, ulong seed, uint seg, uint seg_mask, uint seg_count_len, ulong key) {
     if (seg_count_len == 0) {
         return false; // empty filter never matches
     }
-    ulong ph = fuse8_hash64(key, seed);
-    uint h0 = fuse8_reduce((uint)ph, seg);
-    uint h1 = fuse8_reduce((uint)fuse8_hash64(key, fuse8_rotl(seed, 21)), seg) + seg;
-    uint h2 = fuse8_reduce((uint)fuse8_hash64(key, fuse8_rotl(seed, 42)), seg) + 2 * seg;
-    uchar f8 = fuse8_fingerprint(ph);
+    ulong hash = fuse8_mix(key, seed);
+    uint h0 = fuse8_position(0, hash, seg_count_len, seg, seg_mask);
+    uint h1 = fuse8_position(1, hash, seg_count_len, seg, seg_mask);
+    uint h2 = fuse8_position(2, hash, seg_count_len, seg, seg_mask);
+    uchar f8 = fuse8_fingerprint(hash);
     return (uchar)(fp[h0] ^ fp[h1] ^ fp[h2]) == f8;
 }
 
@@ -872,6 +886,7 @@ __kernel void generateKeysKernel_grid(
     // Load the Binary Fuse 8 filter metadata once (only consulted in compact mode).
     ulong fuse8_seed = ((ulong)fuse8_meta[1] << 32) | (ulong)fuse8_meta[0]; // [seedHi, seedLo]
     uint fuse8_seg = fuse8_meta[2];
+    uint fuse8_seg_mask = fuse8_meta[3];
     uint fuse8_seg_count_len = fuse8_meta[4];
 
     // Full-transfer mode: work-item 0 stamps the count header with the sentinel. Every
@@ -1137,8 +1152,10 @@ __kernel void generateKeysKernel_grid(
             } else {
                 ulong key_uncompressed = fuse8_key_from_ripemd(ripemd_uncompressed_h);
                 ulong key_compressed   = fuse8_key_from_ripemd(ripemd_compressed_h);
-                bool hit = fuse8_contains(fuse8_fp, fuse8_seed, fuse8_seg, fuse8_seg_count_len, key_uncompressed)
-                        || fuse8_contains(fuse8_fp, fuse8_seed, fuse8_seg, fuse8_seg_count_len, key_compressed);
+                bool hit = fuse8_contains(
+                                fuse8_fp, fuse8_seed, fuse8_seg, fuse8_seg_mask, fuse8_seg_count_len, key_uncompressed)
+                        || fuse8_contains(
+                                fuse8_fp, fuse8_seed, fuse8_seg, fuse8_seg_mask, fuse8_seg_count_len, key_compressed);
                 should_write = hit;
                 slot = 0;
                 if (hit) {

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/cli/ConfigFixturesParseTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/cli/ConfigFixturesParseTest.java
@@ -15,18 +15,20 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Smoke-loads every {@code examples/config_Find_*.json} fixture through
- * {@link Main#loadConfiguration(Path)} and asserts that the new
- * {@code awaitTerminateSeconds} / {@code awaitQueueEmptySeconds} fields
- * are explicitly set in each file (i.e. the example configs document
- * the timeout fields rather than hiding them behind production defaults).
+ * {@link Main#loadConfiguration(Path)} and asserts that the
+ * {@code awaitTerminateSeconds} / {@code awaitQueueEmptySeconds} /
+ * {@code statisticsRateWindowSeconds} fields are explicitly set in each file
+ * (i.e. the example configs document these fields rather than hiding them
+ * behind production defaults).
  *
  * <p>This test fails-loud if any future contributor strips the fields back
- * out — the documented contract is that all Find examples carry the timeouts.
+ * out — the documented contract is that all Find examples carry them.
  */
 public class ConfigFixturesParseTest {
 
     private static final long EXPECTED_AWAIT_TERMINATE_SECONDS = 365L * 1000L * 24L * 3600L;
     private static final long EXPECTED_AWAIT_QUEUE_EMPTY_SECONDS = 60L;
+    private static final int EXPECTED_STATISTICS_RATE_WINDOW_SECONDS = 60;
 
     public ConfigFixturesParseTest() {}
 
@@ -49,6 +51,10 @@ public class ConfigFixturesParseTest {
                     name + " missing awaitQueueEmptySeconds",
                     raw.contains("\"awaitQueueEmptySeconds\""),
                     is(equalTo(true)));
+            assertThat(
+                    name + " missing statisticsRateWindowSeconds",
+                    raw.contains("\"statisticsRateWindowSeconds\""),
+                    is(equalTo(true)));
 
             CConfiguration parsed = Main.loadConfiguration(file);
             assertThat(name + " finder", parsed.finder, is(notNullValue()));
@@ -61,6 +67,10 @@ public class ConfigFixturesParseTest {
                     name + " awaitQueueEmptySeconds",
                     parsed.finder.consumerJava.awaitQueueEmptySeconds,
                     is(equalTo(EXPECTED_AWAIT_QUEUE_EMPTY_SECONDS)));
+            assertThat(
+                    name + " statisticsRateWindowSeconds",
+                    parsed.finder.consumerJava.statisticsRateWindowSeconds,
+                    is(equalTo(EXPECTED_STATISTICS_RATE_WINDOW_SECONDS)));
         }
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
@@ -395,7 +395,7 @@ public class ConsumerJavaTest {
                     arguments,
                     hasItem(
                             equalTo(
-                                    "Statistics: [Checked 0 M keys in 0 minutes] [0 k keys/second] [0 M keys/minute] [Batches per producer: none] [Producers running: 0] [Consumers running: 0] [Consumer ready for work (queue empty): 0] [Producer blocked (queue full): 0] [Average contains time: 0 ms] [keys queue size: 0] [Hits: 0]")));
+                                    "Statistics: [Checked 0 M keys in 0 minutes] [0 k keys/second over 60s] [0 M keys/minute over 60s] [Batches per producer: none] [Producers running: 0] [Consumers running: 0] [Consumer ready for work (queue empty): 0] [Producer blocked (queue full): 0] [Average contains time: 0 ms] [keys queue size: 0] [Hits: 0]")));
         }
     }
 
@@ -406,6 +406,34 @@ public class ConsumerJavaTest {
 
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
         assertThrows(IllegalArgumentException.class, () -> consumerJava.startStatisticsTimer());
+    }
+
+    @Test
+    public void startStatisticsTimer_invalidRateWindow_throwsException() throws Exception {
+        CConsumerJava cConsumerJava = new CConsumerJava();
+        cConsumerJava.printStatisticsEveryNSeconds = 1;
+        cConsumerJava.statisticsRateWindowSeconds = 0;
+
+        ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
+        assertThrows(IllegalArgumentException.class, () -> consumerJava.startStatisticsTimer());
+    }
+
+    @Test
+    public void windowKeysPerSecond_computesRateOverTheWindow() {
+        // 5000 keys advanced over 1000 ms -> 5000 keys/s
+        assertThat(ConsumerJava.windowKeysPerSecond(1_000L, 0L, 2_000L, 5_000L), is(equalTo(5_000.0)));
+        // 3,000,000 keys over 2000 ms -> 1,500,000 keys/s
+        assertThat(ConsumerJava.windowKeysPerSecond(0L, 0L, 2_000L, 3_000_000L), is(equalTo(1_500_000.0)));
+    }
+
+    @Test
+    public void windowKeysPerSecond_nonPositiveIntervalOrNoAdvance_returnsZero() {
+        // zero elapsed time
+        assertThat(ConsumerJava.windowKeysPerSecond(1_000L, 0L, 1_000L, 5_000L), is(equalTo(0.0)));
+        // negative elapsed time
+        assertThat(ConsumerJava.windowKeysPerSecond(2_000L, 0L, 1_000L, 5_000L), is(equalTo(0.0)));
+        // odometer did not advance
+        assertThat(ConsumerJava.windowKeysPerSecond(1_000L, 5_000L, 2_000L, 5_000L), is(equalTo(0.0)));
     }
 
     @AwaitTimeTest

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresenceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresenceTest.java
@@ -124,19 +124,29 @@ class BinaryFuse16AddressPresenceTest {
     }
 
     @Test
-    void reduce_mapsUniformly() {
-        assertThat(BinaryFuse16AddressPresence.reduce(0, 100), is(equalTo(0)));
-        assertThat(BinaryFuse16AddressPresence.reduce(Integer.MAX_VALUE, 100), is(lessThan(100)));
-        assertThat(BinaryFuse16AddressPresence.reduce(-1, 100), is(lessThan(100)));
+    void hashPosition_positionsAreDistinctAndInRange() {
+        int segLen = 32;
+        int segMask = segLen - 1;
+        int segCountLen = segLen; // segmentCount * segmentLength = 1 * 32
+        int arrayLength = (1 + 2) * segLen;
+        long hash = BinaryFuse16AddressPresence.mix(0xABCDEF12345L, BinaryFuse16AddressPresence.INITIAL_SEED);
+        int h0 = BinaryFuse16AddressPresence.hashPosition(0, hash, segCountLen, segLen, segMask);
+        int h1 = BinaryFuse16AddressPresence.hashPosition(1, hash, segCountLen, segLen, segMask);
+        int h2 = BinaryFuse16AddressPresence.hashPosition(2, hash, segCountLen, segLen, segMask);
+        assertThat("positions must be distinct", h0 != h1 && h1 != h2 && h0 != h2, is(true));
+        for (int h : new int[] {h0, h1, h2}) {
+            assertThat(h, is(greaterThanOrEqualTo(0)));
+            assertThat(h, is(lessThan(arrayLength)));
+        }
     }
 
     @Test
-    void hash64_isDistributed() {
-        long h1 = BinaryFuse16AddressPresence.hash64(0x1234567890ABCDEFL, 0L);
-        long h2 = BinaryFuse16AddressPresence.hash64(0x1234567890ABCDEFL, 1L);
+    void mix_isDistributed() {
+        long h1 = BinaryFuse16AddressPresence.mix(0x1234567890ABCDEFL, 0L);
+        long h2 = BinaryFuse16AddressPresence.mix(0x1234567890ABCDEFL, 1L);
         assertThat(h1 == h2, is(false));
-        long h3 = BinaryFuse16AddressPresence.hash64(0L, 0L);
-        long h4 = BinaryFuse16AddressPresence.hash64(1L, 0L);
+        long h3 = BinaryFuse16AddressPresence.mix(0L, 0L);
+        long h4 = BinaryFuse16AddressPresence.mix(1L, 0L);
         assertThat(h3 == h4, is(false));
     }
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresenceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresenceTest.java
@@ -105,20 +105,31 @@ class BinaryFuse8AddressPresenceTest {
     }
 
     @Test
-    void hash64_isDistributed() {
-        long h1 = BinaryFuse8AddressPresence.hash64(0x1234567890ABCDEFL, 0L);
-        long h2 = BinaryFuse8AddressPresence.hash64(0x1234567890ABCDEFL, 1L);
+    void mix_isDistributed() {
+        long h1 = BinaryFuse8AddressPresence.mix(0x1234567890ABCDEFL, 0L);
+        long h2 = BinaryFuse8AddressPresence.mix(0x1234567890ABCDEFL, 1L);
         assertThat(h1 == h2, is(false));
-        long h3 = BinaryFuse8AddressPresence.hash64(0L, 0L);
-        long h4 = BinaryFuse8AddressPresence.hash64(1L, 0L);
+        long h3 = BinaryFuse8AddressPresence.mix(0L, 0L);
+        long h4 = BinaryFuse8AddressPresence.mix(1L, 0L);
         assertThat(h3 == h4, is(false));
     }
 
     @Test
-    void reduce_mapsUniformly() {
-        assertThat(BinaryFuse8AddressPresence.reduce(0, 100), is(equalTo(0)));
-        assertThat(BinaryFuse8AddressPresence.reduce(Integer.MAX_VALUE, 100), is(lessThan(100)));
-        assertThat(BinaryFuse8AddressPresence.reduce(-1, 100), is(lessThan(100)));
+    void hashPosition_positionsAreDistinctAndInRange() {
+        // A one-segment layout: segmentCount = 1, so arrayLength = (1 + 2) * segmentLength.
+        int segLen = 32;
+        int segMask = segLen - 1;
+        int segCountLen = segLen; // segmentCount * segmentLength = 1 * 32
+        int arrayLength = (1 + 2) * segLen;
+        long hash = BinaryFuse8AddressPresence.mix(0xABCDEF12345L, BinaryFuse8AddressPresence.INITIAL_SEED);
+        int h0 = BinaryFuse8AddressPresence.hashPosition(0, hash, segCountLen, segLen, segMask);
+        int h1 = BinaryFuse8AddressPresence.hashPosition(1, hash, segCountLen, segLen, segMask);
+        int h2 = BinaryFuse8AddressPresence.hashPosition(2, hash, segCountLen, segLen, segMask);
+        assertThat("positions must be distinct", h0 != h1 && h1 != h2 && h0 != h2, is(true));
+        for (int h : new int[] {h0, h1, h2}) {
+            assertThat(h, is(greaterThanOrEqualTo(0)));
+            assertThat(h, is(lessThan(arrayLength)));
+        }
     }
 
     @Test
@@ -142,6 +153,27 @@ class BinaryFuse8AddressPresenceTest {
         for (int i = 1; i <= 200; i++) {
             assertThat("entry " + i, presence.containsAddress(hash20(i % 256, i)), is(true));
         }
+    }
+
+    /**
+     * Two <em>distinct</em> 20-byte addresses that share their first 8 bytes collapse to the same
+     * 64-bit key (the filter keys on the first 8 bytes only). A binary fuse cannot place two
+     * identical keys, so {@code populateFrom} de-duplicates the truncated keys before construction.
+     * The build therefore succeeds, and both addresses are reported as present (they share the one
+     * surviving key). This is lossless for a presence pre-filter, since every hit is verified
+     * against the exact backend anyway.
+     */
+    @Test
+    void firstEightBytesCollide_deduplicated_buildsAndBothAddressesFound() {
+        // both addresses: identical first 8 bytes {1..8}; distinct tails (index 8 differs)
+        byte[] a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        byte[] b = {1, 2, 3, 4, 5, 6, 7, 8, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        ListIterable src = new ListIterable().add(ByteBuffer.wrap(a)).add(ByteBuffer.wrap(b));
+
+        BinaryFuse8AddressPresence presence = BinaryFuse8AddressPresence.populateFrom(src);
+
+        assertThat(presence.containsAddress(ByteBuffer.wrap(a)), is(true));
+        assertThat(presence.containsAddress(ByteBuffer.wrap(b)), is(true));
     }
 
     @Test
@@ -208,17 +240,17 @@ class BinaryFuse8AddressPresenceTest {
         // internally. Rebuild one inserted key's XOR invariant by hand with getSeed() and
         // assert the three fingerprint slots XOR to the key's fingerprint (i.e. it is a hit).
         long seed = presence.getSeed();
-        int seg = presence.getSegmentLength();
+        int segLen = presence.getSegmentLength();
+        int segMask = presence.getSegmentLengthMask();
+        int segCountLen = presence.getSegmentCountLength();
         byte[] fp = presence.getFingerprints();
         ByteBuffer member = hash20(0x20, 5);
         long key = member.getLong(member.position());
-        long ph = BinaryFuse8AddressPresence.hash64(key, seed);
-        int h0 = BinaryFuse8AddressPresence.reduce((int) ph, seg);
-        int h1 = BinaryFuse8AddressPresence.reduce((int) BinaryFuse8AddressPresence.hash64(key, rotl(seed, 21)), seg)
-                + seg;
-        int h2 = BinaryFuse8AddressPresence.reduce((int) BinaryFuse8AddressPresence.hash64(key, rotl(seed, 42)), seg)
-                + 2 * seg;
-        byte expectedFp = BinaryFuse8AddressPresence.fingerprint8(ph);
+        long hash = BinaryFuse8AddressPresence.mix(key, seed);
+        int h0 = BinaryFuse8AddressPresence.hashPosition(0, hash, segCountLen, segLen, segMask);
+        int h1 = BinaryFuse8AddressPresence.hashPosition(1, hash, segCountLen, segLen, segMask);
+        int h2 = BinaryFuse8AddressPresence.hashPosition(2, hash, segCountLen, segLen, segMask);
+        byte expectedFp = BinaryFuse8AddressPresence.fingerprint8(hash);
         assertThat((byte) (fp[h0] ^ fp[h1] ^ fp[h2]), is(equalTo(expectedFp)));
     }
 
@@ -240,7 +272,10 @@ class BinaryFuse8AddressPresenceTest {
         }
         BinaryFuse8AddressPresence presence = BinaryFuse8AddressPresence.populateFrom(src);
         assertThat(presence.getFingerprints().length, is(equalTo(presence.slotCount())));
-        assertThat(presence.getSegmentCountLength(), is(equalTo(presence.slotCount())));
+        // segmentCountLength is the base-position bound (segmentCount * segmentLength); the full
+        // fingerprint array carries two extra segments of headroom for the fused offsets.
+        assertThat(
+                presence.getSegmentCountLength(), is(equalTo(presence.slotCount() - 2 * presence.getSegmentLength())));
     }
 
     @Test
@@ -268,10 +303,6 @@ class BinaryFuse8AddressPresenceTest {
         for (int i = 0; i < 25; i++) {
             assertThat("entry " + (i + 1), presence.containsAddress(hash20(0x50, i + 1)), is(equalTo(before[i])));
         }
-    }
-
-    private static long rotl(long v, int r) {
-        return (v << r) | (v >>> (64 - r));
     }
 
     @Test

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/FilterBuildProgressTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/FilterBuildProgressTest.java
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence.inmemory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FilterBuildProgressTest {
+
+    private final List<String> lines = new ArrayList<>();
+    private final FilterBuildProgress.LogSink sink = lines::add;
+
+    @Test
+    void smallTotal_belowMinEntries_neverLogs() {
+        FilterBuildProgress progress = new FilterBuildProgress(sink, "phase", FilterBuildProgress.MIN_ENTRIES - 1);
+
+        // even reporting completion of every unit must stay silent for small inputs
+        for (long done = 1; done <= FilterBuildProgress.MIN_ENTRIES - 1; done += 50_000) {
+            progress.report(done);
+        }
+        progress.report(FilterBuildProgress.MIN_ENTRIES - 1);
+
+        assertThat(lines, is(empty()));
+    }
+
+    @Test
+    void largeTotal_belowFirstMilestone_doesNotLogYet() {
+        long total = FilterBuildProgress.MIN_ENTRIES; // step = total / SEGMENTS
+        FilterBuildProgress progress = new FilterBuildProgress(sink, "phase", total);
+
+        progress.report((total / FilterBuildProgress.SEGMENTS) - 1);
+
+        assertThat(lines, is(empty()));
+    }
+
+    @Test
+    void largeTotal_firstMilestone_logsCorrectPercentDoneAndTotal() {
+        long total = FilterBuildProgress.MIN_ENTRIES; // 1_000_000, step = 100_000
+        long step = total / FilterBuildProgress.SEGMENTS;
+        FilterBuildProgress progress = new FilterBuildProgress(sink, "phase", total);
+
+        progress.report(step);
+
+        assertThat(lines, contains("phase: 10% (100000/1000000)."));
+    }
+
+    @Test
+    void largeTotal_fullSweep_logsOncePerSegment() {
+        long total = 2_000_000L; // step = 200_000, exactly SEGMENTS milestones
+        long step = total / FilterBuildProgress.SEGMENTS;
+        FilterBuildProgress progress = new FilterBuildProgress(sink, "phase", total);
+
+        for (long done = step; done <= total; done += step) {
+            progress.report(done);
+        }
+
+        assertThat(lines, hasSize(FilterBuildProgress.SEGMENTS));
+        assertThat(lines.get(0), is("phase: 10% (200000/2000000)."));
+        assertThat(lines.get(FilterBuildProgress.SEGMENTS - 1), is("phase: 100% (2000000/2000000)."));
+    }
+
+    @Test
+    void largeTotal_singleGiantJump_logsOnlyOnce() {
+        long total = 5_000_000L;
+        FilterBuildProgress progress = new FilterBuildProgress(sink, "phase", total);
+
+        // one report that overshoots every milestone must still emit at most one line
+        progress.report(total);
+
+        assertThat(lines, hasSize(1));
+        assertThat(lines.get(0), is("phase: 100% (5000000/5000000)."));
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/Fuse8GpuHashParityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/Fuse8GpuHashParityTest.java
@@ -24,12 +24,13 @@ import org.junit.jupiter.api.Test;
  *
  * <p>{@link #gpuStyleContains(BinaryFuse8AddressPresence, byte[])} below is an independent
  * re-implementation of the lookup, written exactly as the OpenCL C will be written:
- * {@code key = bytes[0..7] big-endian}, {@code ph = hash64(key, seed)},
- * {@code h0 = reduce((int) ph, seg)}, {@code h1 = reduce(hash64(key, rotl(seed,21)), seg) + seg},
- * {@code h2 = reduce(hash64(key, rotl(seed,42)), seg) + 2*seg},
- * {@code hit = (fp[h0] ^ fp[h1] ^ fp[h2]) == fingerprint8(ph)}. The test asserts this agrees
- * with {@code containsAddress} on every one of 1 000 distinct hash160 inputs (members and
- * non-members alike). If the formula ever drifts, this test fails.
+ * {@code key = bytes[0..7] big-endian}, {@code hash = murmur64(key + seed)},
+ * {@code base = unsignedMulHigh(hash, segCountLen)}, {@code h0 = base},
+ * {@code h1 = base + segLen ^ ((hash >>> 18) & segMask)},
+ * {@code h2 = base + 2*segLen ^ (hash & segMask)},
+ * {@code hit = (fp[h0] ^ fp[h1] ^ fp[h2]) == fingerprint8(hash)}. The test asserts
+ * this agrees with {@code containsAddress} on every one of 1 000 distinct hash160 inputs (members
+ * and non-members alike). If the formula ever drifts, this test fails.
  */
 class Fuse8GpuHashParityTest {
 
@@ -53,32 +54,40 @@ class Fuse8GpuHashParityTest {
         return h;
     }
 
-    private static long rotl(long v, int r) {
-        return (v << r) | (v >>> (64 - r));
+    /** One fused position, computed inline exactly as the OpenCL kernel will compute it. */
+    private static int gpuStylePosition(int index, long hash, int segCountLen, int segLen, int segMask) {
+        long h = Math.unsignedMultiplyHigh(hash, Integer.toUnsignedLong(segCountLen));
+        h += (long) index * segLen;
+        if (index == 1) {
+            h ^= (hash >>> 18) & Integer.toUnsignedLong(segMask);
+        } else if (index == 2) {
+            h ^= hash & Integer.toUnsignedLong(segMask);
+        }
+        return (int) h;
     }
 
     /** Independent re-implementation of the lookup, written exactly as the OpenCL kernel will be. */
     private static boolean gpuStyleContains(BinaryFuse8AddressPresence filter, byte[] hash160) {
         byte[] fp = filter.getFingerprints();
         int segCountLen = filter.getSegmentCountLength();
-        if (segCountLen == 0) {
+        if (fp.length == 0) {
             return false;
         }
         long seed = filter.getSeed();
-        int seg = filter.getSegmentLength();
+        int segLen = filter.getSegmentLength();
+        int segMask = filter.getSegmentLengthMask();
 
         // Key extraction: first 8 bytes of hash160 as a big-endian uint64. This is exactly what
         // ByteBuffer.wrap(hash160).getLong(0) yields, and exactly what the kernel computes from
         // the two little-endian RIPEMD-160 output words via byte-swap.
         long key = ByteBuffer.wrap(hash160).getLong(0);
 
-        long ph = BinaryFuse8AddressPresence.hash64(key, seed);
-        int h0 = BinaryFuse8AddressPresence.reduce((int) ph, seg);
-        int h1 = BinaryFuse8AddressPresence.reduce((int) BinaryFuse8AddressPresence.hash64(key, rotl(seed, 21)), seg)
-                + seg;
-        int h2 = BinaryFuse8AddressPresence.reduce((int) BinaryFuse8AddressPresence.hash64(key, rotl(seed, 42)), seg)
-                + 2 * seg;
-        byte f8 = BinaryFuse8AddressPresence.fingerprint8(ph);
+        // Single mix per key: murmur64(key + seed). Positions come from bit-windows of this hash.
+        long hash = BinaryFuse8AddressPresence.murmur64(key + seed);
+        int h0 = gpuStylePosition(0, hash, segCountLen, segLen, segMask);
+        int h1 = gpuStylePosition(1, hash, segCountLen, segLen, segMask);
+        int h2 = gpuStylePosition(2, hash, segCountLen, segLen, segMask);
+        byte f8 = BinaryFuse8AddressPresence.fingerprint8(hash);
         return (byte) (fp[h0] ^ fp[h1] ^ fp[h2]) == f8;
     }
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/statistics/StatisticsTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/statistics/StatisticsTest.java
@@ -25,14 +25,25 @@ public class StatisticsTest {
 
         // act
         String result = statistics.createStatisticsMessage(
-                234_000L, 999_000_000L, 345_000_000_000L, batchesByProducer, 2L, 4L, 4567L, 1234L, 5678L, 6789L);
+                234_000L,
+                999_000_000L,
+                1_500_000.0,
+                60L,
+                345_000_000_000L,
+                batchesByProducer,
+                2L,
+                4L,
+                4567L,
+                1234L,
+                5678L,
+                6789L);
 
         // assert
         assertThat(
                 result,
                 is(
                         equalTo(
-                                "Statistics: [Checked 999 M keys in 3 minutes] [4269 k keys/second] [333 M keys/minute] [Batches per producer: exampleOpenCL (Random, GPU)=20, exampleRandom (Random, CPU)=10] [Producers running: 2] [Consumers running: 4] [Consumer ready for work (queue empty): 4567] [Producer blocked (queue full): 1234] [Average contains time: 345 ms] [keys queue size: 5678] [Hits: 6789]")));
+                                "Statistics: [Checked 999 M keys in 3 minutes] [1500 k keys/second over 60s] [90 M keys/minute over 60s] [Batches per producer: exampleOpenCL (Random, GPU)=20, exampleRandom (Random, CPU)=10] [Producers running: 2] [Consumers running: 4] [Consumer ready for work (queue empty): 4567] [Producer blocked (queue full): 1234] [Average contains time: 345 ms] [keys queue size: 5678] [Hits: 6789]")));
     }
 
     @Test
@@ -42,14 +53,14 @@ public class StatisticsTest {
 
         // act
         String result = statistics.createStatisticsMessage(
-                234_000L, 999_000_000L, 345_000_000_000L, new TreeMap<>(), 0L, 0L, 0L, 0L, 0L, 0L);
+                234_000L, 999_000_000L, 1_500_000.0, 60L, 345_000_000_000L, new TreeMap<>(), 0L, 0L, 0L, 0L, 0L, 0L);
 
         // assert
         assertThat(
                 result,
                 is(
                         equalTo(
-                                "Statistics: [Checked 999 M keys in 3 minutes] [4269 k keys/second] [333 M keys/minute] [Batches per producer: none] [Producers running: 0] [Consumers running: 0] [Consumer ready for work (queue empty): 0] [Producer blocked (queue full): 0] [Average contains time: 345 ms] [keys queue size: 0] [Hits: 0]")));
+                                "Statistics: [Checked 999 M keys in 3 minutes] [1500 k keys/second over 60s] [90 M keys/minute over 60s] [Batches per producer: none] [Producers running: 0] [Consumers running: 0] [Consumer ready for work (queue empty): 0] [Producer blocked (queue full): 0] [Average contains time: 345 ms] [keys queue size: 0] [Hits: 0]")));
     }
     // </editor-fold>
 


### PR DESCRIPTION
## Summary

- **Real Binary Fuse filter** replaces the mis-sized XOR-style presence filter: a single `murmur64(key+seed)` hash drives three fused, overlapping segments at ~1.125× space (Graf & Lemire). Fixes the repeated construction retries that made startup on large databases (132M entries) look hung — it now converges on the **first attempt**. Adds 64-bit-key de-duplication (fixes the truncation-collision crash) and the matching OpenCL kernel; CPU/GPU lookup parity stays pinned by `Fuse8GpuHashParityTest`.
- **Filter-build progress logging** (`FilterBuildProgress` + Fuse8/16): bounded per-phase `reading/indexing/peeling/assigning` progress so the multi-second build is never silent.
- **Windowed keys/second statistics**: the lifetime-average rate becomes a current rate over a configurable `consumerJava.statisticsRateWindowSeconds` (default 60), keeping the lifetime total. All example Find configs document the new field (guarded by `ConfigFixturesParseTest`).
- **Docs refresh**: README/CLAUDE/TODO/`docs/performance.md` updated to the new algorithm and re-measured on an RTX 3070 (GPU compact ~2.2× vs full transfer; refreshed CPU-lookup latency and Binary Fuse memory figures).

## Test plan

- [x] Affected unit / integration tests pass locally — full suite **1931 tests, 0 failures, 0 errors, 4 skipped** (LMDB + OpenCL on RTX 3070)
- [x] End-to-end verified on the real 132M-entry LMDB: one-pass filter build, GPU kernel runs, ~1.16M+ keys/s
- [ ] CI is green on this branch
- [x] Docs updated (README, docs/performance.md, CLAUDE.md, TODO.md, example configs)

## Related issues / PRs

<!-- none -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YANSuv6zz6xk36j9cHuL2U