### PR TITLE
release: v1.7.0 (set release version) + Similar-projects comparison matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This document provides guidance for AI assistants working on the BitcoinAddressF
 
 - **Group ID:** `net.ladenthin`
 - **Artifact ID:** `bitcoinaddressfinder`
-- **Version:** 1.7.0-SNAPSHOT
+- **Version:** 1.7.0
 - **Java:** 21
 - **License:** Apache 2.0
 - **Author:** Bernard Ladenthin (Copyright 2017–2025)

--- a/README.md
+++ b/README.md
@@ -1871,28 +1871,41 @@ This resembles the historic Android `SecureRandom` vulnerability: the elliptic-c
 BitcoinAddressFinder can simulate this type of scenario by generating keys using intentionally weak or deterministic RNGs and scanning the resulting restricted key ranges. This makes it possible to study how insecure RNGs can compromise wallets.
 
 ## Similar projects
-* The [LBC](https://lbc.cryptoguru.org/) is optimized to find keys for the [Bitcoin Puzzle Transaction](https://privatekeys.pw/puzzles/bitcoin-puzzle-tx). It require communication to a server, doesn't support altcoin and pattern matching.
-* https://privatekeys.pw/scanner/bitcoin
-* https://allprivatekeys.com/get-lucky
-* https://allprivatekeys.com/vanity-address
-* https://github.com/treyyoder/bitcoin-wallet-finder
-* https://github.com/albertobsd/keyhunt
-* https://github.com/brichard19/BitCrack — CUDA/OpenCL secp256k1 brute-forcer
-* https://github.com/kanhavishva/KeyHunt-Cuda — CUDA key/puzzle hunter (a modified version of [VanitySearch](https://github.com/JeanLucPons/VanitySearch))
-* https://github.com/mvrc42/bitp0wn
-* https://github.com/JeanLucPons/BTCCollider
-* https://github.com/JeanLucPons/VanitySearch
-* https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder
-* https://github.com/mingfunwong/all-bitcoin-private-key
-* https://github.com/Frankenmint/PKGenerator_Checker
-* https://github.com/Henshall/BitcoinPrivateKeyHunter
-* https://github.com/Xefrok/BitBruteForce-Wallet
-* https://github.com/Isaacdelly/Plutus
-* https://github.com/Noname400/Hunt-to-Mnemonic
-* https://github.com/Py-Project/Bitcoin-wallet-cracker
-* https://github.com/johncantrell97/bip39-solver-gpu
-* https://github.com/ilkerccom/bitcrackrandomiser
-* https://btcpuzzle.info/
+
+A non-exhaustive list of related tools and services. **Type** is a rough category for orientation, not an endorsement or a feature guarantee.
+
+| Project | Type |
+|---|---|
+| [LBC](https://lbc.cryptoguru.org/) | Puzzle solver — server-based, no altcoin/vanity |
+| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | Online key scanner |
+| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | Online cloud key search |
+| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | Online random key try |
+| [allprivatekeys.com — vanity address](https://allprivatekeys.com/vanity-address) | Online vanity generator |
+| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | Wallet / balance finder |
+| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | CPU key / puzzle hunter |
+| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | GPU brute-forcer (CUDA/OpenCL secp256k1) |
+| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | GPU key / puzzle hunter (CUDA; [VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
+| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | Key-recovery experiments |
+| [JeanLucPons/BTCCollider](https://github.com/JeanLucPons/BTCCollider) | Address collider (RIPEMD-160) |
+| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | GPU vanity generator |
+| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | Key finder |
+| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | Key enumeration |
+| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | Key generator + balance checker |
+| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | Key hunter |
+| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | Brute-forcer |
+| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | Balance checker |
+| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | Mnemonic hunter |
+| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | Wallet cracker |
+| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | BIP39 seed solver (GPU) |
+| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | BitCrack randomiser (puzzle) |
+| [btcpuzzle.info](https://btcpuzzle.info/) | Puzzle site |
+| [oritwoen/vgen](https://github.com/oritwoen/vgen) | Vanity generator |
+| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | Key finder |
+| [samr7/vanitygen](https://github.com/samr7/vanitygen) | CPU vanity generator (the classic) |
+| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | Vanity generator (multi-coin fork) |
+| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | Wallet password / seed recovery |
+| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | Wallet recovery (.NET) |
+| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | Wallet key import/export (GUI) |
 
 ### Deep learning private key prediction
 An export of the full database can be used to predict private keys with deep learning. A funny idea: https://github.com/DRSZL/BitcoinTensorFlowPrivateKeyPrediction

--- a/README.md
+++ b/README.md
@@ -1872,40 +1872,51 @@ BitcoinAddressFinder can simulate this type of scenario by generating keys using
 
 ## Similar projects
 
-A non-exhaustive list of related tools and services. **Type** is a rough category for orientation, not an endorsement or a feature guarantee.
+How **BitcoinAddressFinder** (pinned first, in bold) compares to related tools. Its distinguishing mix is
+GPU **and** CPU generation, 100+ coins, an offline check against a local database of known addresses,
+and optional vanity — where most others focus on one of those.
 
-| Project | Type |
-|---|---|
-| [LBC](https://lbc.cryptoguru.org/) | Puzzle solver — server-based, no altcoin/vanity |
-| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | Online key scanner |
-| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | Online cloud key search |
-| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | Online random key try |
-| [allprivatekeys.com — vanity address](https://allprivatekeys.com/vanity-address) | Online vanity generator |
-| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | Wallet / balance finder |
-| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | CPU key / puzzle hunter |
-| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | GPU brute-forcer (CUDA/OpenCL secp256k1) |
-| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | GPU key / puzzle hunter (CUDA; [VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
-| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | Key-recovery experiments |
-| [JeanLucPons/BTCCollider](https://github.com/JeanLucPons/BTCCollider) | Address collider (RIPEMD-160) |
-| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | GPU vanity generator |
-| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | Key finder |
-| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | Key enumeration |
-| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | Key generator + balance checker |
-| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | Key hunter |
-| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | Brute-forcer |
-| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | Balance checker |
-| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | Mnemonic hunter |
-| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | Wallet cracker |
-| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | BIP39 seed solver (GPU) |
-| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | BitCrack randomiser (puzzle) |
-| [btcpuzzle.info](https://btcpuzzle.info/) | Puzzle site |
-| [oritwoen/vgen](https://github.com/oritwoen/vgen) | Vanity generator |
-| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | Key finder |
-| [samr7/vanitygen](https://github.com/samr7/vanitygen) | CPU vanity generator (the classic) |
-| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | Vanity generator (multi-coin fork) |
-| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | Wallet password / seed recovery |
-| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | Wallet recovery (.NET) |
-| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | Wallet key import/export (GUI) |
+**Legend:** ✅ yes · ❌ no · ❓ unclear / unverified. **Columns:** *GPU* / *CPU* = compute backend · *Coins* =
+many non-Bitcoin coins · *DB* = checks generated addresses against a set of known/funded addresses ·
+*Vanity* = pattern/prefix matching · *Offline* = runs without contacting a server · *OSS* = open source.
+
+> Marks for third-party projects are best-effort, inferred from each project's public description, and may
+> be imprecise or outdated — corrections via PR are welcome. Categorisation is for orientation, not an
+> endorsement.
+
+| Project | GPU | CPU | Coins | DB | Vanity | Offline | OSS | Main goal |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|---|
+| **[BitcoinAddressFinder](https://github.com/bernardladenthin/BitcoinAddressFinder)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Scan random/sequential keys for 100+ coins and check them against a local address database; optional vanity** |
+| [LBC](https://lbc.cryptoguru.org/) | ❓ | ✅ | ❌ | ✅ | ❌ | ❌ | ❓ | Distributed pool solving the Bitcoin puzzle transaction |
+| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | ❌ | ❌ | ❓ | ✅ | ❌ | ❌ | ❌ | Browse/scan random keys online |
+| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | ❌ | ❌ | ❓ | ✅ | ❌ | ❌ | ❌ | Cloud key-search service |
+| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | Try random keys online for a hit |
+| [allprivatekeys.com — vanity](https://allprivatekeys.com/vanity-address) | ❌ | ❌ | ❓ | ❌ | ✅ | ❌ | ❌ | Online vanity address generator |
+| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Generate keys and check balances via an online API |
+| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | CPU hunter with several search modes (address, BSGS, xpoint) |
+| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | GPU brute-force of a keyspace for target addresses |
+| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | CUDA hunter for puzzle/target addresses ([VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
+| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | ❌ | ✅ | ❌ | ❓ | ❌ | ✅ | ✅ | Educational key-recovery / attack experiments |
+| [JeanLucPons/BTCCollider](https://github.com/JeanLucPons/BTCCollider) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Find RIPEMD-160 address collisions (birthday paradox) |
+| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | ✅ | ✅ | ❓ | ❌ | ✅ | ✅ | ✅ | GPU/CPU vanity address generator |
+| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | ❌ | ✅ | ❌ | ✅ | ❌ | ❓ | ✅ | Generate keys and check for a balance |
+| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Enumerate the private-key space (demonstration) |
+| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Generate keys and check balances online |
+| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | ❌ | ✅ | ❌ | ✅ | ❌ | ❓ | ✅ | Hunt for funded keys |
+| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Brute-force wallets and check balances |
+| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Keys vs a local database of funded addresses |
+| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | ❌ | ✅ | ❌ | ❓ | ❌ | ❓ | ✅ | Search for BIP39 mnemonics |
+| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | ❌ | ✅ | ❌ | ✅ | ❌ | ❓ | ✅ | Scan/crack wallets |
+| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | GPU search of BIP39 seed space for a known address |
+| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | Randomised pool wrapper around BitCrack (puzzle) |
+| [btcpuzzle.info](https://btcpuzzle.info/) | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | Bitcoin puzzle info / pool site |
+| [oritwoen/vgen](https://github.com/oritwoen/vgen) | ❓ | ✅ | ❓ | ❌ | ✅ | ✅ | ✅ | Vanity address generator |
+| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | ❓ | ✅ | ❓ | ✅ | ❌ | ❓ | ✅ | Key finder / scanner |
+| [samr7/vanitygen](https://github.com/samr7/vanitygen) | ✅ | ✅ | ❓ | ❌ | ✅ | ✅ | ✅ | The original vanity generator (CPU + OpenCL) |
+| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | Vanitygen fork supporting many coins |
+| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | Recover your own wallet password / BIP39 seed |
+| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Recover damaged keys / seeds / addresses you own |
+| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | ❌ | ✅ | ❓ | ❌ | ❌ | ✅ | ✅ | GUI to import/export/convert wallet keys |
 
 ### Deep learning private key prediction
 An export of the full database can be used to predict private keys with deep learning. A funny idea: https://github.com/DRSZL/BitcoinTensorFlowPrivateKeyPrediction

--- a/README.md
+++ b/README.md
@@ -1872,51 +1872,53 @@ BitcoinAddressFinder can simulate this type of scenario by generating keys using
 
 ## Similar projects
 
-How **BitcoinAddressFinder** (pinned first, in bold) compares to related tools. Its distinguishing mix is
-GPU **and** CPU generation, 100+ coins, an offline check against a local database of known addresses,
-and optional vanity — where most others focus on one of those.
+How **BitcoinAddressFinder** (pinned first, in bold) compares to related tools. Its distinguishing mix —
+GPU **and** CPU generation, 100+ coins, and an **offline** check against a **local** database of known/funded
+addresses — is rare here: most others do just one of vanity generation, puzzle-solving, online balance
+lookups, or wallet recovery.
 
-**Legend:** ✅ yes · ❌ no · ❓ unclear / unverified. **Columns:** *GPU* / *CPU* = compute backend · *Coins* =
-many non-Bitcoin coins · *DB* = checks generated addresses against a set of known/funded addresses ·
-*Vanity* = pattern/prefix matching · *Offline* = runs without contacting a server · *OSS* = open source.
+**Legend:** ✅ yes · ❌ no · ❓ could not confirm. **Columns:** *GPU* / *CPU* = compute backend the user runs ·
+*Coins* = many non-Bitcoin coins · *DB* = checks derived addresses against a set of known/funded/target
+addresses · *Vanity* = pattern/prefix matching · *Offline* = the search runs without contacting a
+server/API · *OSS* = source publicly available.
 
-> Marks for third-party projects are best-effort, inferred from each project's public description, and may
-> be imprecise or outdated — corrections via PR are welcome. Categorisation is for orientation, not an
+> Flags verified 2026-07-20 against each project's repository or site; the few cells that stayed
+> unconfirmable are marked ❓ — corrections via PR are welcome. Categorisation is for orientation, not an
 > endorsement.
 
 | Project | GPU | CPU | Coins | DB | Vanity | Offline | OSS | Main goal |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|---|
-| **[BitcoinAddressFinder](https://github.com/bernardladenthin/BitcoinAddressFinder)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Scan random/sequential keys for 100+ coins and check them against a local address database; optional vanity** |
-| [LBC](https://lbc.cryptoguru.org/) | ❓ | ✅ | ❌ | ✅ | ❌ | ❌ | ❓ | Distributed pool solving the Bitcoin puzzle transaction |
-| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | ❌ | ❌ | ❓ | ✅ | ❌ | ❌ | ❌ | Browse/scan random keys online |
-| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | ❌ | ❌ | ❓ | ✅ | ❌ | ❌ | ❌ | Cloud key-search service |
-| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | Try random keys online for a hit |
-| [allprivatekeys.com — vanity](https://allprivatekeys.com/vanity-address) | ❌ | ❌ | ❓ | ❌ | ✅ | ❌ | ❌ | Online vanity address generator |
-| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Generate keys and check balances via an online API |
-| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | CPU hunter with several search modes (address, BSGS, xpoint) |
-| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | GPU brute-force of a keyspace for target addresses |
-| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | CUDA hunter for puzzle/target addresses ([VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
-| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | ❌ | ✅ | ❌ | ❓ | ❌ | ✅ | ✅ | Educational key-recovery / attack experiments |
+| **[BitcoinAddressFinder](https://github.com/bernardladenthin/BitcoinAddressFinder)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Scan random/sequential keys for 100+ coins vs a local LMDB address database; optional vanity** |
+| [LBC](https://lbc.cryptoguru.org/) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❓ | Distributed pool scanning the hash160 space for funded-address collisions (legacy) |
+| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | In-browser random-key scanner against a hosted funded-address filter |
+| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | ❓ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Rent cloud GPUs to scan for the Bitcoin puzzle (pool) |
+| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | Browse server-generated key pages (BTC/BCH/BTG) with tx/balance flags |
+| [allprivatekeys.com — vanity](https://allprivatekeys.com/vanity-address) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❓ | In-browser vanity generator; keys stay local (can run offline) |
+| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Random keys, balances checked via the blockchain.info API (demo) |
+| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | CPU hunter with several modes (address, BSGS, xpoint) over a bit range |
+| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | GPU brute-force of a keyspace range for target addresses |
+| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | CUDA hunter for puzzle/target addresses over a range ([VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
+| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Educational ECDSA nonce-reuse / discrete-log attack demos |
 | [JeanLucPons/BTCCollider](https://github.com/JeanLucPons/BTCCollider) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Find RIPEMD-160 address collisions (birthday paradox) |
-| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | ✅ | ✅ | ❓ | ❌ | ✅ | ✅ | ✅ | GPU/CPU vanity address generator |
-| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | ❌ | ✅ | ❌ | ✅ | ❌ | ❓ | ✅ | Generate keys and check for a balance |
-| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Enumerate the private-key space (demonstration) |
-| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Generate keys and check balances online |
-| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | ❌ | ✅ | ❌ | ✅ | ❌ | ❓ | ✅ | Hunt for funded keys |
-| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Brute-force wallets and check balances |
-| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Keys vs a local database of funded addresses |
-| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | ❌ | ✅ | ❌ | ❓ | ❌ | ❓ | ✅ | Search for BIP39 mnemonics |
-| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | ❌ | ✅ | ❌ | ✅ | ❌ | ❓ | ✅ | Scan/crack wallets |
-| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | GPU search of BIP39 seed space for a known address |
-| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | Randomised pool wrapper around BitCrack (puzzle) |
-| [btcpuzzle.info](https://btcpuzzle.info/) | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | Bitcoin puzzle info / pool site |
-| [oritwoen/vgen](https://github.com/oritwoen/vgen) | ❓ | ✅ | ❓ | ❌ | ✅ | ✅ | ✅ | Vanity address generator |
-| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | ❓ | ✅ | ❓ | ✅ | ❌ | ❓ | ✅ | Key finder / scanner |
-| [samr7/vanitygen](https://github.com/samr7/vanitygen) | ✅ | ✅ | ❓ | ❌ | ✅ | ✅ | ✅ | The original vanity generator (CPU + OpenCL) |
-| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | Vanitygen fork supporting many coins |
-| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | Recover your own wallet password / BIP39 seed |
-| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Recover damaged keys / seeds / addresses you own |
-| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | ❌ | ✅ | ❓ | ❌ | ❌ | ✅ | ✅ | GUI to import/export/convert wallet keys |
+| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | GPU/CPU vanity address generator (prefix + wildcards) |
+| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Random keys vs one user-supplied target address (novelty) |
+| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | ❌ | ✅ | ❌ | ❌ | ❌ | ❓ | ✅ | Web page to browse the whole key space (no balance check) |
+| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Random keys, balances checked via an online explorer API (demo) |
+| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Random keys vs a user-supplied local list of known-funded addresses |
+| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Random keys vs a bundled local ~123k-address list (linear scan) |
+| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Sequential keyspace walk vs a local funded-wallet DB (Bloom filter) |
+| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | BIP39 / seed hunt vs local Bloom-filter address databases |
+| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Random BIP39 wallets vs a local address list (offline GUI) |
+| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | ✅ | ❓ | ❌ | ✅ | ❌ | ✅ | ✅ | GPU brute-force of missing BIP39 words for a known address |
+| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Pool client that drives BitCrack for the Bitcoin puzzle |
+| [btcpuzzle.info](https://btcpuzzle.info/) | ✅ | ❓ | ❌ | ❌ | ✅ | ❌ | ✅ | Solo-pool platform + open-source client for the Bitcoin puzzle |
+| [oritwoen/vgen](https://github.com/oritwoen/vgen) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | Regex-driven vanity generator (Rust; wgpu or CPU) |
+| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Random/sequential keys vs a local address list (or online API) |
+| [samr7/vanitygen](https://github.com/samr7/vanitygen) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | The original vanity generator (CPU + OpenCL, regex) |
+| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | Multi-coin vanity generator (100+ coins; CPU / OpenCL) |
+| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | Recover your own wallet password / BIP39 seed (optional AddressDb) |
+| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Reconstruct your own damaged key / seed / address (GUI) |
+| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | GUI to import/export/convert wallet keys (no search) |
 
 ### Deep learning private key prediction
 An export of the full database can be used to predict private keys with deep learning. A funny idea: https://github.com/DRSZL/BitcoinTensorFlowPrivateKeyPrediction

--- a/README.md
+++ b/README.md
@@ -1875,51 +1875,55 @@ BitcoinAddressFinder can simulate this type of scenario by generating keys using
 How **BitcoinAddressFinder** (pinned first, in bold) compares to related tools. Its distinguishing mix —
 GPU **and** CPU generation, 100+ coins, and an **offline** check against a **local** database of known/funded
 addresses — is rare here: most others do just one of vanity generation, puzzle-solving, online balance
-lookups, or wallet recovery.
+lookups, or wallet recovery. It also stays efficient against a **~10⁹-entry** address database (≈1.38 billion
+/ ~57 GB) via an **O(1)** memory-mapped LMDB lookup with an optional Binary Fuse / Blocked Bloom pre-filter
+— the axis (`≥10⁹ DB`) most other tools do not scale on.
 
-**Legend:** ✅ yes · ❌ no · ❓ could not confirm. **Columns:** *Category* = what the tool is for · *GPU* / *CPU* =
-compute backend the user runs · *Coins* = many non-Bitcoin coins · *Vanity* = pattern/prefix matching ·
-*Offline* = the search runs without contacting a server/API · *OSS* = source publicly available ·
-*Checks against* = what a derived address is matched against — `Local funded DB` · `Target list` (usually
-user-supplied) · `Online API` · `Puzzle target` · `Own wallet` · `None` (generate-only).
+**Legend:** ✅ yes · ❌ no · ❓ could not confirm · ~ partial. **Columns:** *Category* = what the tool is for ·
+*GPU* / *CPU* = compute backend the user runs · *Coins* = many non-Bitcoin coins · *Vanity* = pattern/prefix
+matching · *Offline* = the search runs without contacting a server/API · *OSS* = source publicly available ·
+*≥10⁹ DB* = efficient (O(1) / indexed) lookup against a very large (~10⁹) known-address set (`✅` yes · `~`
+indexed but at smaller scale · `❌` linear / tiny / online / none) · *Checks against* = what a derived address
+is matched against — `Local funded DB` · `Target list` (usually user-supplied) · `Online API` · `Puzzle
+target` · `Own wallet` · `None` (generate-only).
 
 > Flags verified 2026-07-20 against each project's repository or site; the few cells that stayed
 > unconfirmable are marked ❓ — corrections via PR are welcome. Rows are grouped by *Category*
 > (BitcoinAddressFinder pinned first). Categorisation is for orientation, not an endorsement.
 
-| Project | Category | GPU | CPU | Coins | Vanity | Offline | OSS | Checks against | Main goal |
-|---|---|:-:|:-:|:-:|:-:|:-:|:-:|---|---|
-| **[BitcoinAddressFinder](https://github.com/bernardladenthin/BitcoinAddressFinder)** | **Address-DB scan** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Local funded DB** | **Scan random/sequential keys for 100+ coins vs a local LMDB address database; optional vanity** |
-| [LBC](https://lbc.cryptoguru.org/) | Address-DB scan | ✅ | ✅ | ❌ | ❌ | ❌ | ❓ | Local funded DB | Distributed pool scanning the hash160 space for funded-address collisions (legacy) |
-| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | Address-DB scan | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | Local funded DB | In-browser random-key scanner against a hosted funded-address filter |
-| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | Address-DB scan | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | Online API | Browse server-generated key pages (BTC/BCH/BTG) with tx/balance flags |
-| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | Online API | Random keys, balances checked via the blockchain.info API (demo) |
-| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | Online API | Random keys, balances checked via an online explorer API (demo) |
-| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Target list | Random keys vs a user-supplied local list of known-funded addresses |
-| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Local funded DB | Random keys vs a bundled local ~123k-address list (linear scan) |
-| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Local funded DB | Sequential keyspace walk vs a local funded-wallet DB (Bloom filter) |
-| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Local funded DB | BIP39 / seed hunt vs local Bloom-filter address databases |
-| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Target list | Random BIP39 wallets vs a local address list (offline GUI) |
-| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Local funded DB | Random/sequential keys vs a local address list (or online API) |
-| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | Puzzle solver | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | Target list | CPU hunter with several modes (address, BSGS, xpoint) over a bit range |
-| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | Puzzle solver | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Target list | GPU brute-force of a keyspace range for target addresses |
-| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | Puzzle solver | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | Target list | CUDA hunter for puzzle/target addresses over a range ([VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
-| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | Puzzle solver | ❓ | ❌ | ❌ | ❌ | ❌ | ❌ | Puzzle target | Rent cloud GPUs to scan for the Bitcoin puzzle (pool) |
-| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | Puzzle solver | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | Puzzle target | Pool client that drives BitCrack for the Bitcoin puzzle |
-| [btcpuzzle.info](https://btcpuzzle.info/) | Puzzle solver | ✅ | ❓ | ❌ | ✅ | ❌ | ✅ | Puzzle target | Solo-pool platform + open-source client for the Bitcoin puzzle |
-| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | None | GPU/CPU vanity address generator (prefix + wildcards) |
-| [samr7/vanitygen](https://github.com/samr7/vanitygen) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | None | The original vanity generator (CPU + OpenCL, regex) |
-| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | Vanity generator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | None | Multi-coin vanity generator (100+ coins; CPU / OpenCL) |
-| [oritwoen/vgen](https://github.com/oritwoen/vgen) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | None | Regex-driven vanity generator (Rust; wgpu or CPU) |
-| [allprivatekeys.com — vanity](https://allprivatekeys.com/vanity-address) | Vanity generator | ❌ | ✅ | ❌ | ✅ | ✅ | ❓ | None | In-browser vanity generator; keys stay local (can run offline) |
-| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | Wallet recovery | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | Own wallet | Recover your own wallet password / BIP39 seed (optional AddressDb) |
-| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | Wallet recovery | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Own wallet | Reconstruct your own damaged key / seed / address (GUI) |
-| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | Wallet recovery | ✅ | ❓ | ❌ | ❌ | ✅ | ✅ | Own wallet | GPU brute-force of missing BIP39 words for a known address |
-| [JeanLucPons/BTCCollider](https://github.com/JeanLucPons/BTCCollider) | Research / collision | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | None | Find RIPEMD-160 address collisions (birthday paradox) |
-| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | Research / collision | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | None | Educational ECDSA nonce-reuse / discrete-log attack demos |
-| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | Novelty / utility | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Target list | Random keys vs one user-supplied target address (novelty) |
-| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | Novelty / utility | ❌ | ✅ | ❌ | ❌ | ❓ | ✅ | None | Web page to browse the whole key space (no balance check) |
-| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | Novelty / utility | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | None | GUI to import/export/convert wallet keys (no search) |
+| Project | Category | GPU | CPU | Coins | Vanity | Offline | OSS | ≥10⁹ DB | Checks against | Main goal |
+|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|---|---|
+| **[BitcoinAddressFinder](https://github.com/bernardladenthin/BitcoinAddressFinder)** | **Address-DB scan** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **✅** | **Local funded DB** | **Scan random/sequential keys for 100+ coins vs a local LMDB address database; optional vanity** |
+| [LBC](https://lbc.cryptoguru.org/) | Address-DB scan | ✅ | ✅ | ❌ | ❌ | ❌ | ❓ | ~ | Local funded DB | Distributed pool scanning the hash160 space for funded-address collisions (legacy) |
+| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | Address-DB scan | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ~ | Local funded DB | In-browser random-key scanner against a hosted funded-address filter |
+| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | Address-DB scan | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | Online API | Browse server-generated key pages (BTC/BCH/BTG) with tx/balance flags |
+| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | Online API | Random keys, balances checked via the blockchain.info API (demo) |
+| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | Online API | Random keys, balances checked via an online explorer API (demo) |
+| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | Target list | Random keys vs a user-supplied local list of known-funded addresses |
+| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | Local funded DB | Random keys vs a bundled local ~123k-address list (linear scan) |
+| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ~ | Local funded DB | Sequential keyspace walk vs a local funded-wallet DB (Bloom filter) |
+| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ~ | Local funded DB | BIP39 / seed hunt vs local Bloom-filter address databases |
+| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | Target list | Random BIP39 wallets vs a local address list (offline GUI) |
+| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | Local funded DB | Random/sequential keys vs a local address list (or online API) |
+| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | Puzzle solver | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | Target list | CPU hunter with several modes (address, BSGS, xpoint) over a bit range |
+| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | Puzzle solver | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | Target list | GPU brute-force of a keyspace range for target addresses |
+| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | Puzzle solver | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | Target list | CUDA hunter for puzzle/target addresses over a range ([VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
+| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | Puzzle solver | ❓ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Puzzle target | Rent cloud GPUs to scan for the Bitcoin puzzle (pool) |
+| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | Puzzle solver | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | Puzzle target | Pool client that drives BitCrack for the Bitcoin puzzle |
+| [btcpuzzle.info](https://btcpuzzle.info/) | Puzzle solver | ✅ | ❓ | ❌ | ✅ | ❌ | ✅ | ❌ | Puzzle target | Solo-pool platform + open-source client for the Bitcoin puzzle |
+| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | None | GPU/CPU vanity address generator (prefix + wildcards) |
+| [samr7/vanitygen](https://github.com/samr7/vanitygen) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | None | The original vanity generator (CPU + OpenCL, regex) |
+| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | Vanity generator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | None | Multi-coin vanity generator (100+ coins; CPU / OpenCL) |
+| [oritwoen/vgen](https://github.com/oritwoen/vgen) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | None | Regex-driven vanity generator (Rust; wgpu or CPU) |
+| [allprivatekeys.com — vanity](https://allprivatekeys.com/vanity-address) | Vanity generator | ❌ | ✅ | ❌ | ✅ | ✅ | ❓ | ❌ | None | In-browser vanity generator; keys stay local (can run offline) |
+| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | Wallet recovery | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | Own wallet | Recover your own wallet password / BIP39 seed (optional AddressDb) |
+| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | Wallet recovery | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | Own wallet | Reconstruct your own damaged key / seed / address (GUI) |
+| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | Wallet recovery | ✅ | ❓ | ❌ | ❌ | ✅ | ✅ | ❌ | Own wallet | GPU brute-force of missing BIP39 words for a known address |
+| [JeanLucPons/BTCCollider](https://github.com/JeanLucPons/BTCCollider) | Research / collision | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | None | Find RIPEMD-160 address collisions (birthday paradox) |
+| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | Research / collision | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | None | Educational ECDSA nonce-reuse / discrete-log attack demos |
+| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | Novelty / utility | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | Target list | Random keys vs one user-supplied target address (novelty) |
+| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | Novelty / utility | ❌ | ✅ | ❌ | ❌ | ❓ | ✅ | ❌ | None | Web page to browse the whole key space (no balance check) |
+| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | Novelty / utility | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | None | GUI to import/export/convert wallet keys (no search) |
 
 ### Deep learning private key prediction
 An export of the full database can be used to predict private keys with deep learning. A funny idea: https://github.com/DRSZL/BitcoinTensorFlowPrivateKeyPrediction

--- a/README.md
+++ b/README.md
@@ -1877,48 +1877,49 @@ GPU **and** CPU generation, 100+ coins, and an **offline** check against a **loc
 addresses — is rare here: most others do just one of vanity generation, puzzle-solving, online balance
 lookups, or wallet recovery.
 
-**Legend:** ✅ yes · ❌ no · ❓ could not confirm. **Columns:** *GPU* / *CPU* = compute backend the user runs ·
-*Coins* = many non-Bitcoin coins · *DB* = checks derived addresses against a set of known/funded/target
-addresses · *Vanity* = pattern/prefix matching · *Offline* = the search runs without contacting a
-server/API · *OSS* = source publicly available.
+**Legend:** ✅ yes · ❌ no · ❓ could not confirm. **Columns:** *Category* = what the tool is for · *GPU* / *CPU* =
+compute backend the user runs · *Coins* = many non-Bitcoin coins · *Vanity* = pattern/prefix matching ·
+*Offline* = the search runs without contacting a server/API · *OSS* = source publicly available ·
+*Checks against* = what a derived address is matched against — `Local funded DB` · `Target list` (usually
+user-supplied) · `Online API` · `Puzzle target` · `Own wallet` · `None` (generate-only).
 
 > Flags verified 2026-07-20 against each project's repository or site; the few cells that stayed
-> unconfirmable are marked ❓ — corrections via PR are welcome. Categorisation is for orientation, not an
-> endorsement.
+> unconfirmable are marked ❓ — corrections via PR are welcome. Rows are grouped by *Category*
+> (BitcoinAddressFinder pinned first). Categorisation is for orientation, not an endorsement.
 
-| Project | GPU | CPU | Coins | DB | Vanity | Offline | OSS | Main goal |
-|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|---|
-| **[BitcoinAddressFinder](https://github.com/bernardladenthin/BitcoinAddressFinder)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Scan random/sequential keys for 100+ coins vs a local LMDB address database; optional vanity** |
-| [LBC](https://lbc.cryptoguru.org/) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❓ | Distributed pool scanning the hash160 space for funded-address collisions (legacy) |
-| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | In-browser random-key scanner against a hosted funded-address filter |
-| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | ❓ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Rent cloud GPUs to scan for the Bitcoin puzzle (pool) |
-| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | Browse server-generated key pages (BTC/BCH/BTG) with tx/balance flags |
-| [allprivatekeys.com — vanity](https://allprivatekeys.com/vanity-address) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❓ | In-browser vanity generator; keys stay local (can run offline) |
-| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Random keys, balances checked via the blockchain.info API (demo) |
-| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | CPU hunter with several modes (address, BSGS, xpoint) over a bit range |
-| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | GPU brute-force of a keyspace range for target addresses |
-| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | CUDA hunter for puzzle/target addresses over a range ([VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
-| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Educational ECDSA nonce-reuse / discrete-log attack demos |
-| [JeanLucPons/BTCCollider](https://github.com/JeanLucPons/BTCCollider) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Find RIPEMD-160 address collisions (birthday paradox) |
-| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | GPU/CPU vanity address generator (prefix + wildcards) |
-| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Random keys vs one user-supplied target address (novelty) |
-| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | ❌ | ✅ | ❌ | ❌ | ❌ | ❓ | ✅ | Web page to browse the whole key space (no balance check) |
-| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Random keys, balances checked via an online explorer API (demo) |
-| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Random keys vs a user-supplied local list of known-funded addresses |
-| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Random keys vs a bundled local ~123k-address list (linear scan) |
-| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Sequential keyspace walk vs a local funded-wallet DB (Bloom filter) |
-| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | BIP39 / seed hunt vs local Bloom-filter address databases |
-| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Random BIP39 wallets vs a local address list (offline GUI) |
-| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | ✅ | ❓ | ❌ | ✅ | ❌ | ✅ | ✅ | GPU brute-force of missing BIP39 words for a known address |
-| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | Pool client that drives BitCrack for the Bitcoin puzzle |
-| [btcpuzzle.info](https://btcpuzzle.info/) | ✅ | ❓ | ❌ | ❌ | ✅ | ❌ | ✅ | Solo-pool platform + open-source client for the Bitcoin puzzle |
-| [oritwoen/vgen](https://github.com/oritwoen/vgen) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | Regex-driven vanity generator (Rust; wgpu or CPU) |
-| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | Random/sequential keys vs a local address list (or online API) |
-| [samr7/vanitygen](https://github.com/samr7/vanitygen) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | The original vanity generator (CPU + OpenCL, regex) |
-| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | Multi-coin vanity generator (100+ coins; CPU / OpenCL) |
-| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | Recover your own wallet password / BIP39 seed (optional AddressDb) |
-| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Reconstruct your own damaged key / seed / address (GUI) |
-| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | GUI to import/export/convert wallet keys (no search) |
+| Project | Category | GPU | CPU | Coins | Vanity | Offline | OSS | Checks against | Main goal |
+|---|---|:-:|:-:|:-:|:-:|:-:|:-:|---|---|
+| **[BitcoinAddressFinder](https://github.com/bernardladenthin/BitcoinAddressFinder)** | **Address-DB scan** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **Local funded DB** | **Scan random/sequential keys for 100+ coins vs a local LMDB address database; optional vanity** |
+| [LBC](https://lbc.cryptoguru.org/) | Address-DB scan | ✅ | ✅ | ❌ | ❌ | ❌ | ❓ | Local funded DB | Distributed pool scanning the hash160 space for funded-address collisions (legacy) |
+| [privatekeys.pw — scanner](https://privatekeys.pw/scanner/bitcoin) | Address-DB scan | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | Local funded DB | In-browser random-key scanner against a hosted funded-address filter |
+| [allprivatekeys.com — get lucky](https://allprivatekeys.com/get-lucky) | Address-DB scan | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | Online API | Browse server-generated key pages (BTC/BCH/BTG) with tx/balance flags |
+| [treyyoder/bitcoin-wallet-finder](https://github.com/treyyoder/bitcoin-wallet-finder) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | Online API | Random keys, balances checked via the blockchain.info API (demo) |
+| [Frankenmint/PKGenerator_Checker](https://github.com/Frankenmint/PKGenerator_Checker) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | Online API | Random keys, balances checked via an online explorer API (demo) |
+| [Henshall/BitcoinPrivateKeyHunter](https://github.com/Henshall/BitcoinPrivateKeyHunter) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Target list | Random keys vs a user-supplied local list of known-funded addresses |
+| [Xefrok/BitBruteForce-Wallet](https://github.com/Xefrok/BitBruteForce-Wallet) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Local funded DB | Random keys vs a bundled local ~123k-address list (linear scan) |
+| [Isaacdelly/Plutus](https://github.com/Isaacdelly/Plutus) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Local funded DB | Sequential keyspace walk vs a local funded-wallet DB (Bloom filter) |
+| [Noname400/Hunt-to-Mnemonic](https://github.com/Noname400/Hunt-to-Mnemonic) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Local funded DB | BIP39 / seed hunt vs local Bloom-filter address databases |
+| [Py-Project/Bitcoin-wallet-cracker](https://github.com/Py-Project/Bitcoin-wallet-cracker) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Target list | Random BIP39 wallets vs a local address list (offline GUI) |
+| [vlnahp/KeyZero](https://github.com/vlnahp/KeyZero) | Address-DB scan | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Local funded DB | Random/sequential keys vs a local address list (or online API) |
+| [albertobsd/keyhunt](https://github.com/albertobsd/keyhunt) | Puzzle solver | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | Target list | CPU hunter with several modes (address, BSGS, xpoint) over a bit range |
+| [brichard19/BitCrack](https://github.com/brichard19/BitCrack) | Puzzle solver | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | Target list | GPU brute-force of a keyspace range for target addresses |
+| [kanhavishva/KeyHunt-Cuda](https://github.com/kanhavishva/KeyHunt-Cuda) | Puzzle solver | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | Target list | CUDA hunter for puzzle/target addresses over a range ([VanitySearch](https://github.com/JeanLucPons/VanitySearch)-based) |
+| [privatekeys.pw — cloud search](https://privatekeys.pw/cloud-search/) | Puzzle solver | ❓ | ❌ | ❌ | ❌ | ❌ | ❌ | Puzzle target | Rent cloud GPUs to scan for the Bitcoin puzzle (pool) |
+| [ilkerccom/bitcrackrandomiser](https://github.com/ilkerccom/bitcrackrandomiser) | Puzzle solver | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | Puzzle target | Pool client that drives BitCrack for the Bitcoin puzzle |
+| [btcpuzzle.info](https://btcpuzzle.info/) | Puzzle solver | ✅ | ❓ | ❌ | ✅ | ❌ | ✅ | Puzzle target | Solo-pool platform + open-source client for the Bitcoin puzzle |
+| [JeanLucPons/VanitySearch](https://github.com/JeanLucPons/VanitySearch) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | None | GPU/CPU vanity address generator (prefix + wildcards) |
+| [samr7/vanitygen](https://github.com/samr7/vanitygen) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | None | The original vanity generator (CPU + OpenCL, regex) |
+| [10gic/vanitygen-plusplus](https://github.com/10gic/vanitygen-plusplus) | Vanity generator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | None | Multi-coin vanity generator (100+ coins; CPU / OpenCL) |
+| [oritwoen/vgen](https://github.com/oritwoen/vgen) | Vanity generator | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | None | Regex-driven vanity generator (Rust; wgpu or CPU) |
+| [allprivatekeys.com — vanity](https://allprivatekeys.com/vanity-address) | Vanity generator | ❌ | ✅ | ❌ | ✅ | ✅ | ❓ | None | In-browser vanity generator; keys stay local (can run offline) |
+| [gurnec/btcrecover](https://github.com/gurnec/btcrecover) | Wallet recovery | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | Own wallet | Recover your own wallet password / BIP39 seed (optional AddressDb) |
+| [Coding-Enthusiast/FinderOuter](https://github.com/Coding-Enthusiast/FinderOuter) | Wallet recovery | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Own wallet | Reconstruct your own damaged key / seed / address (GUI) |
+| [johncantrell97/bip39-solver-gpu](https://github.com/johncantrell97/bip39-solver-gpu) | Wallet recovery | ✅ | ❓ | ❌ | ❌ | ✅ | ✅ | Own wallet | GPU brute-force of missing BIP39 words for a known address |
+| [JeanLucPons/BTCCollider](https://github.com/JeanLucPons/BTCCollider) | Research / collision | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | None | Find RIPEMD-160 address collisions (birthday paradox) |
+| [mvrc42/bitp0wn](https://github.com/mvrc42/bitp0wn) | Research / collision | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | None | Educational ECDSA nonce-reuse / discrete-log attack demos |
+| [JamieAcharya/Bitcoin-Private-Key-Finder](https://github.com/JamieAcharya/Bitcoin-Private-Key-Finder) | Novelty / utility | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | Target list | Random keys vs one user-supplied target address (novelty) |
+| [mingfunwong/all-bitcoin-private-key](https://github.com/mingfunwong/all-bitcoin-private-key) | Novelty / utility | ❌ | ✅ | ❌ | ❌ | ❓ | ✅ | None | Web page to browse the whole key space (no balance check) |
+| [prof7bit/wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) | Novelty / utility | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | None | GUI to import/export/convert wallet keys (no search) |
 
 ### Deep learning private key prediction
 An export of the full database can be used to predict private keys with deep learning. A funny idea: https://github.com/DRSZL/BitcoinTensorFlowPrivateKeyPrediction

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <groupId>net.ladenthin</groupId>
     <artifactId>bitcoinaddressfinder</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0</version>
     <packaging>jar</packaging>
 
     <name>bitcoinaddressfinder</name>


### PR DESCRIPTION
## Summary

Release-prep for **v1.7.0** plus a documentation improvement.

- **`chore(release)`: set version to `1.7.0`** — strip `-SNAPSHOT` in `pom.xml` and `CLAUDE.md`. The README release jar name and the `CHANGELOG.md` `[1.7.0] - 2026-07-20` section were already release-ready.
- **docs: Similar-projects comparison matrix** — the README "Similar projects" list is now a feature-comparison matrix with **BitcoinAddressFinder** pinned first, rows grouped by *Category*, and columns `GPU · CPU · Coins · Vanity · Offline · OSS · ≥10⁹ DB · Checks against · Main goal`. All third-party flags were **verified 2026-07-20** against each project's repo/site (research across all 30 tools); genuinely unconfirmable cells stay `❓`. Adds the eight previously-missing tools.

## Test plan

- [x] Docs + version-string only; no production code changed.
- [ ] CI green on this branch (runs on this PR).

## Release notes

This PR carries a **release version** (`1.7.0`, no `-SNAPSHOT`). Per the release process a `main` push never auto-publishes on its own. After merge:

1. Maintainer creates the **`v1.7.0`** tag on the merged commit and runs the publish workflow (manual gate).
2. A follow-up commit bumps the version to the next `-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YANSuv6zz6xk36j9cHuL2U
