### PR TITLE
quality: 0 SpotBugs findings + 100% PIT on the 1.7.0 filter/tuner/GPU code

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1137,4 +1137,136 @@ SPDX-License-Identifier: Apache-2.0
         <Bug pattern="SEO_SUBOPTIMAL_EXPRESSION_ORDER"/>
     </Match>
 
+    <!--
+        The 1.7.0 filter / tuner / GPU code adds the following findings that are by design or false
+        positives (SpotBugs runs at effort=Max, threshold=Low). Genuine issues were fixed in code;
+        only the by-design ones are suppressed here.
+    -->
+
+    <!-- Before/after baseline captures around a timed window: totalBatches(...) and getCheckedKeys()
+         are each invoked twice on purpose (baseline, then after the measurement window) to compute a
+         delta; caching either would corrupt the measurement. -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.command.TuneConfiguration"/>
+        <Method name="runArm"/>
+        <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS"/>
+    </Match>
+
+    <!-- By design: the tuner creates a short-lived local ExecutorService and shuts it down
+         (shutdownNow) in a finally block within run(). -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.command.TuneConfiguration"/>
+        <Method name="run"/>
+        <Bug pattern="HES_LOCAL_EXECUTOR_SERVICE"/>
+    </Match>
+
+    <!-- The LMDB directory comes from the operator's own tuner configuration
+         (lmdbConfigurationReadOnly.lmdbDirectory), not from untrusted external input. -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.command.TuneConfiguration"/>
+        <Method name="measureVerificationCostMicros"/>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+    </Match>
+
+    <!-- Pure style nag (instance fields declared before static fields). The field and Javadoc
+         ordering is intentional and documented; reordering carries no functional benefit. -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.command.TuneConfiguration"/>
+        <Bug pattern="IMC_IMMATURE_CLASS_WRONG_FIELD_ORDER"/>
+    </Match>
+
+    <!-- deduplicate(long[]) is a private in-class helper that dedups one array in place; varargs
+         would be semantically wrong and would invite accidental external callers. -->
+    <Match>
+        <Or>
+            <Class name="net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse8AddressPresence"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse16AddressPresence"/>
+        </Or>
+        <Method name="deduplicate"/>
+        <Bug pattern="UVA_USE_VAR_ARGS"/>
+    </Match>
+
+    <!-- tryBuild returns null as a meaningful sentinel: peeling failed for this seed, so the build()
+         retry loop re-attempts with a freshly mixed seed. That is distinct from a successfully built
+         (possibly empty) table, so a zero-length array cannot substitute for it. -->
+    <Match>
+        <Or>
+            <Class name="net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse8AddressPresence"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse16AddressPresence"/>
+        </Or>
+        <Method name="tryBuild"/>
+        <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
+    </Match>
+
+    <!-- Internal VRAM-upload DTOs: the primitive array (fingerprints / words) is deliberately shared
+         zero-copy with the OpenCL upload path. A defensive copy would double multi-GB memory and
+         defeat the design; these records are not a security or mutability boundary. -->
+    <Match>
+        <Or>
+            <Class name="net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse16GpuFilterData"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BlockedBloomGpuFilterData"/>
+        </Or>
+        <Or>
+            <Bug pattern="EI_EXPOSE_REP"/>
+            <Bug pattern="EI_EXPOSE_REP2"/>
+        </Or>
+    </Match>
+
+    <!-- Filter backend has identity semantics; value equality over a multi-GB bit array is
+         meaningless, so no equals()/hashCode() is provided by design. -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BlockedBloomAddressPresence"/>
+        <Bug pattern="IMC_IMMATURE_CLASS_NO_EQUALS"/>
+    </Match>
+
+    <!-- The constant indices access a fixed-layout long[] sample tuple
+         {timestampMillis, checkedKeys, generatedKeys}; those are semantic positional fields, not
+         List first/last, so getFirst()/getLast() do not apply. Scoped class-wide because the finding
+         lives in a synthetic lambda whose number churns; ConsumerJava has no other occurrence. -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.consumer.ConsumerJava"/>
+        <Bug pattern="CLI_CONSTANT_LIST_INDEX"/>
+    </Match>
+
+    <!-- resolved == null is the intentional "no compact-mode producer resolved yet" sentinel; the
+         GpuFilterType enum has no dedicated none or unset constant. -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.engine.Finder"/>
+        <Method name="resolveGpuFilterType"/>
+        <Bug pattern="ENMI_NULL_ENUM_VALUE"/>
+    </Match>
+
+    <!-- uploadedFilterType = null intentionally records "no GPU filter currently uploaded". -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenCLContext"/>
+        <Method name="releaseGpuFilter"/>
+        <Bug pattern="ENMI_NULL_ENUM_VALUE"/>
+    </Match>
+
+    <!-- Intentional leak-safe fail-fast: rethrows the caught RuntimeException after freeing the
+         first allocated buffer so no VRAM leaks on a partial allocation failure. -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenCLContext"/>
+        <Method name="allocateFilterBuffersFromPointer"/>
+        <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+    </Match>
+
+    <!-- Serialising the recommended configuration (a local in-memory POJO) to JSON can only fail on
+         a programming error, never on runtime input, so the checked JsonProcessingException is
+         deliberately wrapped in an IllegalStateException that carries the full winner context and the
+         cause. Declaring the checked type is not an option: the caller is Runnable.run(). -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.command.TuneConfiguration"/>
+        <Method name="buildRecommendedConfigurationJson"/>
+        <Bug pattern="EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS"/>
+    </Match>
+
+    <!-- PrngAddressIterable is a stateful, seed-driven address generator (an AddressIterable), not a
+         value object; equality over its running PRNG state is meaningless, so no equals()/hashCode()
+         is provided by design. -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.persistence.PrngAddressIterable"/>
+        <Bug pattern="IMC_IMMATURE_CLASS_NO_EQUALS"/>
+    </Match>
+
 </FindBugsFilter>

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfiguration.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfiguration.java
@@ -5,12 +5,14 @@ package net.ladenthin.bitcoinaddressfinder.command;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -31,6 +33,7 @@ import net.ladenthin.bitcoinaddressfinder.configuration.CProducerJava;
 import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
 import net.ladenthin.bitcoinaddressfinder.configuration.CTuneConfiguration;
 import net.ladenthin.bitcoinaddressfinder.configuration.GpuFilterType;
+import net.ladenthin.bitcoinaddressfinder.consumer.Consumer;
 import net.ladenthin.bitcoinaddressfinder.consumer.ConsumerJava;
 import net.ladenthin.bitcoinaddressfinder.core.FireAndForget;
 import net.ladenthin.bitcoinaddressfinder.core.Interruptable;
@@ -377,7 +380,9 @@ public class TuneConfiguration implements Runnable, Interruptable {
                 probe.put(PrngAddressIterable.addressAt(PROBE_SEED, i));
                 probe.flip();
                 long before = System.nanoTime();
-                boolean unused = lmdb.containsAddress(probe);
+                // The return value is intentionally discarded: the probe seed guarantees a non-member,
+                // so what is being timed is the cost of the lookup itself, not its boolean answer.
+                lmdb.containsAddress(probe);
                 totalNanos += System.nanoTime() - before;
             }
             double micros = totalNanos / (samples * 1_000.0d);
@@ -443,7 +448,6 @@ public class TuneConfiguration implements Runnable, Interruptable {
      *
      * @return the arm's result, carrying a failure description instead of a rate when it did not run
      */
-    @SuppressWarnings("FutureReturnValueIgnored")
     @FireAndForget("the arm's producer is stopped explicitly below via interrupt/waitTillProducerNotRunning")
     private ArmResult runArm(
             int batchSizeInBits,
@@ -471,7 +475,10 @@ public class TuneConfiguration implements Runnable, Interruptable {
             producer =
                     createProducer(template, consumer, keyUtility, keyProducer, bitHelper, runtimeStatistics, payload);
             producer.initProducer();
-            Object unused = producerExecutor.submit(producer);
+            // Fire-and-forget: the producer is a Runnable stopped explicitly in the finally block
+            // (interrupt + waitTillProducerNotRunning), so execute() (void) is used rather than
+            // submit() — there is no Future to observe.
+            producerExecutor.execute(producer);
 
             awaitSeconds(cTuneConfiguration.warmupSecondsPerArm);
 
@@ -533,7 +540,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
 
     private static Producer createProducer(
             CProducer template,
-            ConsumerJava consumer,
+            Consumer consumer,
             KeyUtility keyUtility,
             KeyProducer keyProducer,
             BitHelper bitHelper,
@@ -545,8 +552,11 @@ public class TuneConfiguration implements Runnable, Interruptable {
             payload.stageOn(producerOpenCL);
             return producerOpenCL;
         }
-        return new ProducerJava(
-                (CProducerJava) template, consumer, keyUtility, keyProducer, bitHelper, runtimeStatistics);
+        if (template instanceof CProducerJava cProducerJava) {
+            return new ProducerJava(cProducerJava, consumer, keyUtility, keyProducer, bitHelper, runtimeStatistics);
+        }
+        throw new IllegalArgumentException("Unsupported producer template type for the sweep: "
+                + template.getClass().getName() + "; expected a CProducerOpenCL or CProducerJava.");
     }
 
     private static long totalBatches(RuntimeStatistics runtimeStatistics) {
@@ -555,7 +565,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
                 .sum();
     }
 
-    private static @Nullable ArmResult pickWinner(List<ArmResult> results) {
+    private static @Nullable ArmResult pickWinner(Collection<ArmResult> results) {
         return results.stream()
                 .filter(ArmResult::succeeded)
                 .max((left, right) -> Double.compare(left.candidatesPerSecond(), right.candidatesPerSecond()))
@@ -778,8 +788,12 @@ public class TuneConfiguration implements Runnable, Interruptable {
             mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
             mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.PUBLIC_ONLY);
             return mapper.writeValueAsString(recommended);
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to serialise the recommended configuration to JSON", e);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(
+                    "Failed to serialise the recommended configuration to JSON (winner batchSizeInBits="
+                            + best.batchSizeInBits() + ", keysPerWorkItem=" + best.keysPerWorkItem()
+                            + ", recommendedFilterType=" + recommendedFilterType + "): " + e.getMessage(),
+                    e);
         }
     }
 
@@ -941,7 +955,9 @@ public class TuneConfiguration implements Runnable, Interruptable {
         }
         throw new IllegalArgumentException(
                 "tuneConfiguration.finder needs at least one producerOpenCL or producerJava entry to use as the "
-                        + "sweep template; the sweep varies its batchSizeInBits / keysPerWorkItem and carries every "
+                        + "sweep template, but both lists are empty (producerOpenCL=" + cFinder.producerOpenCL.size()
+                        + ", producerJava=" + cFinder.producerJava.size()
+                        + "); the sweep varies its batchSizeInBits / keysPerWorkItem and carries every "
                         + "other field through unchanged.");
     }
 

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
@@ -83,6 +83,9 @@ public class ConsumerJava implements Consumer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerJava.class);
 
+    /** Cadence, in seconds, at which the throughput sampler records an odometer sample. */
+    private static final long RATE_SAMPLE_INTERVAL_SECONDS = 1L;
+
     private final KeyUtility keyUtility;
     /** Total number of address lookups performed. */
     protected final AtomicLong checkedKeys = new AtomicLong();
@@ -129,9 +132,6 @@ public class ConsumerJava implements Consumer {
      * scheduled-executor task that reads it on every tick (fb-contrib AT_NONATOMIC_64BIT_PRIMITIVE).
      */
     protected volatile long startTime = 0;
-
-    /** Cadence, in seconds, at which the throughput sampler records an odometer sample. */
-    private static final long RATE_SAMPLE_INTERVAL_SECONDS = 1L;
 
     /**
      * Trailing ring buffer of {@code [timestampMillis, checkedKeysSnapshot]} samples used to
@@ -598,7 +598,15 @@ public class ConsumerJava implements Consumer {
                     // come from the same trailing window.
                     rateSamples.addLast(new long[] {now, keysNow, runtimeStatistics.getGeneratedKeys()});
                     long cutoff = now - rateWindowMillis;
-                    while (rateSamples.size() > 1 && Objects.requireNonNull(rateSamples.peekFirst())[0] < cutoff) {
+                    // Split the compound guard into a nested test: keep at least one sample, and only
+                    // evict while the oldest is older than the cutoff. Written as an explicit break so
+                    // there is no boolean short-circuit ordering to reason about, and the null-guarded
+                    // peekFirst() (size > 1 guarantees non-null) is evaluated exactly once per turn.
+                    while (rateSamples.size() > 1) {
+                        long[] first = Objects.requireNonNull(rateSamples.peekFirst());
+                        if (first[0] >= cutoff) {
+                            break;
+                        }
                         rateSamples.removeFirst();
                     }
                 },

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -797,7 +797,13 @@ public class OpenCLContext implements ReleaseCLObject {
             int segCountLen) {
         final cl_context localContext = context;
         if (localContext == null || closed) {
-            throw new IllegalStateException("uploadGpuFilter called before init() or after close()");
+            throw new IllegalStateException("uploadGpuFilter called before init() or after close() (context="
+                    + (localContext == null ? "null" : "set")
+                    + ", closed="
+                    + closed
+                    + ", fingerprintByteSize="
+                    + fingerprintByteSize
+                    + ")");
         }
 
         // Release any previously uploaded filter so a re-upload does not leak device memory.
@@ -1173,7 +1179,10 @@ public class OpenCLContext implements ReleaseCLObject {
         final cl_command_queue localQueue = Objects.requireNonNull(commandQueue);
         final cl_kernel k = benchFilterKernel;
         if (k == null) {
-            throw new IllegalStateException("prepareBenchFilterProbe* must be called before runBenchFilterProbe()");
+            throw new IllegalStateException(
+                    "prepareBenchFilterProbe* must be called before runBenchFilterProbe() (benchFilterKernel=null, benchFilterProbeCount="
+                            + benchFilterProbeCount
+                            + ")");
         }
         clEnqueueNDRangeKernel(localQueue, k, 1, null, new long[] {benchFilterProbeCount}, null, 0, null, null);
         clFinish(localQueue);

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/FilterBuildProgress.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/FilterBuildProgress.java
@@ -76,6 +76,9 @@ public final class FilterBuildProgress {
     /** Inputs smaller than this (in units) emit no interim percentage lines. */
     public static final long MIN_ENTRIES = 1_000_000L;
 
+    /** Nanoseconds in one second. */
+    private static final long NANOS_PER_SECOND = 1_000_000_000L;
+
     private final LogSink sink;
     private final String phase;
     private final long total;
@@ -172,8 +175,22 @@ public final class FilterBuildProgress {
         } while (nextThreshold <= done);
     }
 
-    /** Nanoseconds in one second. */
-    private static final long NANOS_PER_SECOND = 1_000_000_000L;
+    @Override
+    public String toString() {
+        return "FilterBuildProgress{phase="
+                + phase
+                + ", total="
+                + total
+                + ", lastDone="
+                + lastDone
+                + ", nextThreshold="
+                + nextThreshold
+                + ", step="
+                + step
+                + ", interimEnabled="
+                + interimEnabled
+                + '}';
+    }
 
     /**
      * Renders a throughput with a compact magnitude suffix, e.g. {@code "2.9M/s"}.

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/PrngAddressIterable.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/PrngAddressIterable.java
@@ -132,4 +132,9 @@ public final class PrngAddressIterable implements AddressIterable {
     public long count() {
         return count;
     }
+
+    @Override
+    public String toString() {
+        return "PrngAddressIterable{seed=" + seed + ", count=" + count + '}';
+    }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresence.java
@@ -328,10 +328,9 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
      * above ~716&nbsp;M keys (where {@code 3 * size} wraps past {@link Integer#MAX_VALUE}).
      *
      * @param arrayLength the number of fingerprint slots (positions); the exact capacity
-     * @param size        the number of keys being inserted; does not affect the capacity
      * @return {@code arrayLength} — always {@code >= arrayLength} and never overflowed
      */
-    static int peelingQueueLength(int arrayLength, int size) {
+    static int peelingQueueLength(int arrayLength) {
         // Intentionally independent of size: max enqueues == arrayLength (each position at most once).
         return arrayLength;
     }
@@ -434,7 +433,7 @@ public final class BinaryFuse16AddressPresence implements AddressPresence {
 
         // Peeling queue of singleton positions; see peelingQueueLength for the exact-capacity /
         // no-overflow rationale (each position is enqueued at most once).
-        int[] queue = new int[peelingQueueLength(arrayLength, size)];
+        int[] queue = new int[peelingQueueLength(arrayLength)];
         int qHead = 0;
         int qTail = 0;
         for (int pos = 0; pos < arrayLength; pos++) {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresence.java
@@ -343,10 +343,9 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
      * above ~716&nbsp;M keys (where {@code 3 * size} wraps past {@link Integer#MAX_VALUE}).
      *
      * @param arrayLength the number of fingerprint slots (positions); the exact capacity
-     * @param size        the number of keys being inserted; does not affect the capacity
      * @return {@code arrayLength} — always {@code >= arrayLength} and never overflowed
      */
-    static int peelingQueueLength(int arrayLength, int size) {
+    static int peelingQueueLength(int arrayLength) {
         // Intentionally independent of size: max enqueues == arrayLength (each position at most once).
         return arrayLength;
     }
@@ -450,7 +449,7 @@ public final class BinaryFuse8AddressPresence implements AddressPresence {
 
         // Peeling queue of singleton positions; see peelingQueueLength for the exact-capacity /
         // no-overflow rationale (each position is enqueued at most once).
-        int[] queue = new int[peelingQueueLength(arrayLength, size)];
+        int[] queue = new int[peelingQueueLength(arrayLength)];
         int qHead = 0;
         int qTail = 0;
         for (int pos = 0; pos < arrayLength; pos++) {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/statistics/Statistics.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/statistics/Statistics.java
@@ -128,15 +128,14 @@ public class Statistics {
      */
     private static String describeFilterEffect(double generatedPerSecond, double lookupsPerSecond) {
         double potentialLookups = generatedPerSecond * 2.0; // compressed + uncompressed per candidate
-        if (potentialLookups <= 0.0 || lookupsPerSecond <= 0.0) {
+        // Report only once candidates are generated and some (but not all) survive to LMDB. The
+        // second test also covers the no-generation case (potentialLookups == 0, so any lookup rate
+        // is >= it) and the full-transfer case (lookups reach the full potential, nothing filtered),
+        // and it keeps the division safe: it runs only when 0 < lookupsPerSecond < potentialLookups.
+        if (lookupsPerSecond <= 0.0 || lookupsPerSecond >= potentialLookups) {
             return "";
         }
-        double reaching = lookupsPerSecond / potentialLookups;
-        double prunedPercent = (1.0 - reaching) * 100.0;
-        if (prunedPercent <= 0.0) {
-            // No pre-filter (full transfer): every candidate reaches LMDB, nothing to report here.
-            return "";
-        }
+        double prunedPercent = (1.0 - lookupsPerSecond / potentialLookups) * 100.0;
         return String.format(java.util.Locale.ROOT, ", %.2f%% pre-filtered", prunedPercent);
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresenceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse16AddressPresenceTest.java
@@ -172,8 +172,7 @@ class BinaryFuse16AddressPresenceTest {
     @Test
     void peelingQueueLength_billionScale_isSufficientAndDoesNotOverflow() {
         int arrayLength = 1_549_000_000;
-        int size = 1_377_000_000;
-        int capacity = BinaryFuse16AddressPresence.peelingQueueLength(arrayLength, size);
+        int capacity = BinaryFuse16AddressPresence.peelingQueueLength(arrayLength);
         assertThat("capacity must not overflow to a non-positive value", capacity, is(greaterThan(0)));
         assertThat(
                 "capacity must cover every position (>= arrayLength)", capacity, is(greaterThanOrEqualTo(arrayLength)));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresenceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/inmemory/BinaryFuse8AddressPresenceTest.java
@@ -189,8 +189,7 @@ class BinaryFuse8AddressPresenceTest {
     void peelingQueueLength_billionScale_isSufficientAndDoesNotOverflow() {
         // Full-DB scale (~1.377 B keys): arrayLength ~1.55 B (< Integer.MAX_VALUE), size ~1.38 B.
         int arrayLength = 1_549_000_000;
-        int size = 1_377_000_000;
-        int capacity = BinaryFuse8AddressPresence.peelingQueueLength(arrayLength, size);
+        int capacity = BinaryFuse8AddressPresence.peelingQueueLength(arrayLength);
         assertThat("capacity must not overflow to a non-positive value", capacity, is(greaterThan(0)));
         assertThat(
                 "capacity must cover every position (>= arrayLength)", capacity, is(greaterThanOrEqualTo(arrayLength)));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/statistics/StatisticsTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/statistics/StatisticsTest.java
@@ -4,6 +4,7 @@
 package net.ladenthin.bitcoinaddressfinder.statistics;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -105,6 +106,41 @@ public class StatisticsTest {
         assertThat(Statistics.formatRate(130_000_000.0), is(equalTo("130 M/s")));
         assertThat(Statistics.formatRate(1_500_000_000.0), is(equalTo("2 G/s")));
         assertThat(Statistics.formatRate(3_000.0), is(equalTo("3 k/s")));
+        // Exact scale boundaries: pin the >= comparisons in formatRate (a > mutant would drop each
+        // value into the next-smaller unit, e.g. 1_000_000_000 -> "1000 M/s" instead of "1 G/s").
+        assertThat(Statistics.formatRate(1_000_000_000.0), is(equalTo("1 G/s")));
+        assertThat(Statistics.formatRate(1_000_000.0), is(equalTo("1 M/s")));
+        assertThat(Statistics.formatRate(1_000.0), is(equalTo("1 k/s")));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="describeFilterEffect boundary">
+    /**
+     * Boundary guard for the pre-filter clause: when the LMDB-lookup rate is exactly zero (nothing
+     * has reached the consumer yet) the clause must be omitted, not printed as {@code 100.00%
+     * pre-filtered}. This pins the {@code lookupsPerSecond <= 0.0} boundary in describeFilterEffect.
+     */
+    @Test
+    public void createStatisticsMessage_zeroLookupRate_omitsPreFilterClause() {
+        Statistics statistics = new Statistics();
+
+        String result = statistics.createStatisticsMessage(
+                180_000L,
+                0L, // lookups lifetime
+                0.0, // lookup rate/s -> exactly the boundary
+                200_000_000L, // generated lifetime
+                100_000_000.0, // generation rate/s (> 0, so potentialLookups > 0)
+                60L,
+                0L,
+                new TreeMap<>(),
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L);
+
+        assertThat(result, containsString("[-> LMDB 0/s (0 M lookups total)] [rate window 60s]"));
     }
     // </editor-fold>
 }


### PR DESCRIPTION
## Summary

Green the two static-analysis / quality gates on the 1.7.0 filter / tuner / GPU code.

- **`style(spotbugs)`: resolve all 35 SpotBugs findings** (effort=Max, threshold=Low). ~13 genuine issues fixed in code; the by-design / false-positive findings suppressed in `spotbugs-exclude.xml`, each with a documented rationale. `spotbugs:check` now reports **0 bugs**.
  - Fixed: `instanceof` guard for the `CProducer` cast, two dead stores, `executor.execute()` (void) instead of `submit()` for the fire-and-forget arm producer, a narrowed JSON catch, dynamic exception messages, widened `createProducer`/`pickWinner` parameters, the sampler eviction loop, dynamic OpenCL exception detail, an unused param dropped from `peelingQueueLength`, and `toString()` / field-order on two small classes.
  - Suppressed (by design): `EI_EXPOSE_REP(2)` on the zero-copy GPU DTOs, `PZLA` null-sentinel, `UVA` private helper, `ENMI` null-enum sentinels, `THROWS` leak-safe rethrow, `EXS` should-never-happen JSON wrap, `HES` local tuner executor, `PATH_TRAVERSAL` config path, `PRMC` before/after baseline, `CLI` positional tuple, `IMC` no-equals / field-order.
- **`test(statistics)`: restore 100% PIT mutation coverage.** The new statistics log (`formatRate` / `describeFilterEffect`) had 5 surviving `ConditionalsBoundary` mutants. Added exact-boundary assertions for `formatRate` (1e9 / 1e6 / 1e3) and restructured `describeFilterEffect` behaviour-identically so no equivalent boundary mutant remains, plus a zero-lookup-rate test. **84/84 mutations killed (100%)**; the existing statistics-message tests are unchanged.

## Test plan

- [x] `mvn -DskipTests -Denforcer.skip=true compile spotbugs:check` → 0 bugs.
- [x] `mvn test-compile org.pitest:pitest-maven:mutationCoverage` → 84/84 killed (100%).
- [x] Touched classes' unit tests pass; Error-Prone `-Werror` compile clean; `spotless:apply` run.
- [ ] CI green on this branch.

## Notes

Version stays `1.7.0` (already release-set on `main`). The new `spotbugs-exclude.xml` `<Match>` blocks are scoped to exact class/method and contain no `--` in comment bodies (the XML pitfall noted in the suppressions policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YANSuv6zz6xk36j9cHuL2U
