### PR TITLE
ci(test): raise Surefire fork timeout 180s -> 240s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ See `examples/config_*.json` for all configuration variants.
 
 - Tests use forked JVMs (1 fork, no reuse) for isolation.
 - There is **no JUnit per-test timeout**. The only hard bound is the Surefire
-  whole-fork timeout (`forkedProcessTimeoutInSeconds`, 180s in `pom.xml`): with
+  whole-fork timeout (`forkedProcessTimeoutInSeconds`, 240s in `pom.xml`): with
   `reuseForks=false` it must cover JVM startup + every method of one test class +
   JVM shutdown. A fork that exceeds it is killed and the build fails with
   "There was a timeout in the fork" — without per-test diagnostics. Test classes

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1772,7 +1772,7 @@ cost balance shifts):
 
 **Symptom.** On AMD GPUs (measured: Radeon RX 7900 XTX, `gfx1100`, RDNA3, Adrenalin 25.12.1,
 OpenCL 2.0 AMD-APP) the **first** `clBuildProgram` of the full kernel took **8–16+ minutes** —
-single-threaded, one core pinned, multi-GB RAM — and routinely blew past the 180 s Surefire fork
+single-threaded, one core pinned, multi-GB RAM — and routinely blew past the 240 s Surefire fork
 budget, so the OpenCL parity tests could not even run. A trivial `add` kernel compiles in **0.2 s** on
 the same device, so the OpenCL stack itself is healthy; the cost is specific to this one large kernel.
 NVIDIA (RTX 3070) builds the identical source in seconds.
@@ -1913,7 +1913,7 @@ follow-ups below.)
   (comb `point_mul_xy_comb`, `point_add`, `point_add_xy`, `inv_mod_safegcd`, `sha256_transform`,
   `ripemd160_transform`) via a `NOINLINE_HEAVY` marker — while keeping the field multiply
   (`mul_mod`/`fe10x26_mul`) inline — compiled in **~5.3 min** (vs ~16 min fully inlined, ~3 s blanket).
-  Still far over the 180 s test-fork budget, so it cannot serve as the AMD default. Root cause: the
+  Still far over the 240 s test-fork budget, so it cannot serve as the AMD default. Root cause: the
   **field multiply is both the compile bottleneck** (inlined into `point_add`/`point_add_xy`/conversions
   everywhere) **and the runtime-hottest function** — keep it inline and compile stays minutes;
   out-of-line it and runtime collapses toward the blanket's 3.3×. No split wins both, so the blanket

--- a/pom.xml
+++ b/pom.xml
@@ -665,10 +665,13 @@ SPDX-License-Identifier: Apache-2.0
                         <!-- Whole-fork budget: with reuseForks=false this must cover JVM
                              startup + EVERY method of one test class + JVM shutdown.
                              60s was sporadically exceeded by socket-heavy classes
-                             (e.g. KeyProducerJavaZmqTest) on loaded Windows runners,
-                             killing the fork with "There was a timeout in the fork"
-                             even though all tests passed. -->
-                        <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
+                             (e.g. KeyProducerJavaZmqTest) on loaded Windows runners, so it
+                             was raised to 180s; 180s was in turn occasionally exceeded on
+                             slow/overloaded CI runners (a ~2x-slow run plus the
+                             Lincheck/jcstress concurrency forks), killing the fork with
+                             "There was a timeout in the fork" even though all tests passed
+                             — hence 240s. -->
+                        <forkedProcessTimeoutInSeconds>240</forkedProcessTimeoutInSeconds>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary

Raise the Surefire whole-fork timeout **180s → 240s**.

180s was occasionally exceeded on slow / overloaded CI runners (a ~2×-slow run plus the Lincheck/jcstress concurrency forks), killing a fork with `There was a timeout in the fork` **even though all tests passed** (2017 run, 0 failures/0 errors). This gives the per-fork budget (`reuseForks=false` → JVM startup + every method of one class + shutdown) more headroom.

Kept fully in sync — the single source of truth is the Surefire `<configuration>` in `pom.xml` (no second execution, no CLI override), and the doc references that name the current budget move in lockstep:

- `pom.xml` — `<forkedProcessTimeoutInSeconds>240</...>` (comment now records the full `60s → 180s → 240s` progression).
- `CLAUDE.md` — "…, 240s in `pom.xml`".
- `docs/performance.md` (two AMD kernel-compile mentions) — 240 s; the compile times (8–16 min / ~5.3 min) still far exceed 240s, so those narratives stay accurate.

## Test plan

- [x] `mvn validate` → BUILD SUCCESS (pom well-formed).
- [x] `git grep` confirms no stale `180` fork-timeout reference remains.
- [ ] CI green on this branch.

## Note

This is a mitigation (more slack on slow runners), not a root-cause fix. If the fork timeout recurs, the underlying cause (a shutdown resource-leak vs. a native-stdout writer such as Lincheck/jcstress corrupting the Surefire channel) should be isolated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YANSuv6zz6xk36j9cHuL2U
