### PR TITLE
ci(test): fix fork-channel corruption (Mockito/byte-buddy agent warning on native stderr)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -660,8 +660,19 @@ SPDX-License-Identifier: Apache-2.0
                         <!-- Fork just one JVM for test isolation -->
                         <forkCount>1</forkCount>
                         <reuseForks>false</reuseForks>
-                        <!-- Properly include JaCoCo agent and any other injected argLine -->
-                        <argLine>@{argLine}</argLine>
+                        <!-- @{argLine} injects the JaCoCo agent + the project argLine property.
+                             -XX:+EnableDynamicAgentLoading silences the JVM's "A Java agent has been
+                             loaded dynamically" warning that Mockito's inline mock maker triggers when
+                             it self-attaches byte-buddy at runtime. That warning is written to the
+                             *native* stderr (outside Surefire's wrapped System.err) and intermittently
+                             corrupted the encoded fork channel — surfacing as "Corrupted channel by
+                             directly writing to native stream" and then a bogus "There was a timeout in
+                             the fork", even though every test passed (flaky, seen on ubuntu). Enabling
+                             the flag removes the native write, so the channel stays clean. It is a
+                             -XX flag (test-fork only) and is deliberately NOT part of the module-flag
+                             list synchronised across pom/jvm.config/launchers by
+                             JvmModuleFlagConsistencyTest. -->
+                        <argLine>@{argLine} -XX:+EnableDynamicAgentLoading</argLine>
                         <!-- Whole-fork budget: with reuseForks=false this must cover JVM
                              startup + EVERY method of one test class + JVM shutdown.
                              60s was sporadically exceeded by socket-heavy classes


### PR DESCRIPTION
## Summary

Fix the recurring `There was a timeout in the fork` failure on the Surefire test job **at its source** — it is not a duration problem (the prior `180s → 240s` bump did not help).

**Root cause:** the failure is `Corrupted channel by directly writing to native stream in forked JVM 1`. Mockito's inline mock maker self-attaches the byte-buddy agent at runtime, so the JVM writes `A Java agent has been loaded dynamically` to the **native** stderr (outside Surefire's wrapped `System.err`), intermittently corrupting the encoded fork channel. Surefire then never receives a clean fork-end handshake and reports a **bogus timeout — even though all 2017 tests pass**. It is a race, hence flaky and platform-dependent (seen on ubuntu; windows green in the same run).

The mechanism predates the failures (Mockito has been `5.23.0` throughout); a timing/environment shift in the Jun 26 → Jul 3 window (`junit 6.1.0 → 6.1.1` and/or a GitHub-runner JDK image update) tipped the latent race into manifesting regularly.

**Fix:** add `-XX:+EnableDynamicAgentLoading` to the **test-fork** argLine. The JVM then treats dynamic agent loading as intended and stops writing the warning to native stderr, so the channel stays clean. Verified locally — a Mockito test no longer emits the "loaded dynamically" warning and passes. It is a `-XX` flag (test-fork only), deliberately **not** part of the module-flag list synchronised by `JvmModuleFlagConsistencyTest`. The `240s` budget from #305 stays as extra headroom.

## Test plan

- [x] `mvn validate` → BUILD SUCCESS.
- [x] Mockito test run with the flag: no `A Java agent has been loaded dynamically` warning; tests green.
- [ ] CI green on this branch (the real proof — the failure only reproduces under CI's fork/timing).

## Follow-up (optional, not in this PR)

The fully future-proof variant is loading byte-buddy/Mockito as a real `-javaagent` at startup (Mockito's official recommendation), which removes the self-attach entirely and survives a future JDK disabling dynamic agent loading by default. Can be added later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YANSuv6zz6xk36j9cHuL2U
