### PR TITLE
Upgrade pitest-maven to 1.25.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.7</version>
+                    <version>1.25.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
## Summary

- Bump `pitest-maven` plugin version from 1.25.7 to 1.25.8
- This is a patch-level update to the mutation testing tool used in the build pipeline

## Test plan

- [x] CI is green on this branch (dependency update only, no source code changes)
- [x] No code changes required; existing tests unaffected

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_011LoFAQdknHucxVxWymQunV