### PR TITLE
chore(release): begin 1.8.0-SNAPSHOT + reconcile 1.7.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- **`LMDBDelta` command** — streams every address present in one or more source LMDB databases but
-  **not** in a reference database to a plaintext file (one mainnet Base58 `1…` address per line,
-  re-importable with `AddressFilesToLMDB`). It walks the key-ordered databases as a near-zero-memory
-  k-way cursor merge (memory is just one 20-byte key per cursor, independent of the delta size), logs a
-  per-source summary of how many delta addresses each source contained, and reports periodic progress
-  with rate/ETA. See `examples/config_LMDBDelta.json` and the `run_LMDBDelta` launchers.
-
-### Changed
-- **GPU example configs default to the inlined kernel** (`producerOpenCL.noInlineHelpers: false`) for
-  full runtime throughput — measured ~3.6× faster than the out-of-lined kernel on an AMD RX 7900 XTX
-  (RDNA3) and ~4.5× on NVIDIA; the trade-off is a one-time slow first compile on AMD (then
-  `comgr`-cached). The runtime auto-default is unchanged (out-of-line on AMD to keep CI compiles fast)
-  and now logs symmetric warnings so the compile-vs-speed trade-off is never silent.
-
-## [1.7.0] - 2026-07-21
+## [1.7.0] - 2026-07-23
 
 Major release centred on high-performance probabilistic address filters (in-memory and GPU-side),
 a self-tuning benchmark mode, a rebuilt runtime statistics log, and a reworked bulk-import pipeline.
@@ -69,6 +54,12 @@ a self-tuning benchmark mode, a rebuilt runtime statistics log, and a reworked b
 - **Durable LMDB flush on close** — the writable env keeps its fast sync-free write flags
   (`MDB_NOSYNC` / `MDB_MAPASYNC`) during the import for speed and now forces one full `env.sync(true)`
   when closing, so a normal shutdown leaves the whole database on disk.
+- **`LMDBDelta` command** — streams every address present in one or more source LMDB databases but
+  **not** in a reference database to a plaintext file (one mainnet Base58 `1…` address per line,
+  re-importable with `AddressFilesToLMDB`). It walks the key-ordered databases as a near-zero-memory
+  k-way cursor merge (memory is just one 20-byte key per cursor, independent of the delta size), logs a
+  per-source summary of how many delta addresses each source contained, and reports periodic progress
+  with rate/ETA. See `examples/config_LMDBDelta.json` and the `run_LMDBDelta` launchers.
 
 ### Changed
 - **`FUSE_16` is the recommended default GPU pre-filter** (best net end-to-end throughput; fits VRAM
@@ -81,6 +72,11 @@ a self-tuning benchmark mode, a rebuilt runtime statistics log, and a reworked b
 - Dependency bumps: `bcprov-jdk15to18` 1.84 → 1.85, plus routine updates to `junit-jupiter`,
   `jackson`, `logback-classic`, `nullaway`, `pitest-maven`, `spotless`, the Checker Framework, and CI
   actions.
+- **GPU example configs default to the inlined kernel** (`producerOpenCL.noInlineHelpers: false`) for
+  full runtime throughput — measured ~3.6× faster than the out-of-lined kernel on an AMD RX 7900 XTX
+  (RDNA3) and ~4.5× on NVIDIA; the trade-off is a one-time slow first compile on AMD (then
+  `comgr`-cached). The runtime auto-default is unchanged (out-of-line on AMD to keep CI compiles fast)
+  and now logs symmetric warnings so the compile-vs-speed trade-off is never silent.
 
 ### Fixed
 - **GPU Fuse-16 upload at the Full DB tier** — the `short[]` fingerprints were flattened into a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This document provides guidance for AI assistants working on the BitcoinAddressF
 
 - **Group ID:** `net.ladenthin`
 - **Artifact ID:** `bitcoinaddressfinder`
-- **Version:** 1.7.0
+- **Version:** 1.8.0-SNAPSHOT
 - **Java:** 21
 - **License:** Apache 2.0
 - **Author:** Bernard Ladenthin (Copyright 2017–2025)
@@ -513,7 +513,7 @@ Test-only:
 ./mvnw package -P assembly -DskipTests
 
 # Run (replace config path as needed)
-java -jar target/bitcoinaddressfinder-1.7.0-jar-with-dependencies.jar \
+java -jar target/bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
   examples/config_Find_8CPUProducer.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Copyright (c) 2017-2025 Bernard Ladenthin
     * lmdb
       * data.mdb
       * lock.mdb
-    * bitcoinaddressfinder-1.7.0-jar-with-dependencies.jar
+    * bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar
     * logbackConfiguration.xml
     * config_Find_1OpenCLDevice.js
     * run_Find_1OpenCLDevice.bat  *(Windows)* / run_Find_1OpenCLDevice.sh *(Linux/macOS)*

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <groupId>net.ladenthin</groupId>
     <artifactId>bitcoinaddressfinder</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>bitcoinaddressfinder</name>


### PR DESCRIPTION
## Summary

- **Begin the next development cycle: `1.8.0-SNAPSHOT`.** Bumps `pom.xml` (`1.7.0` → `1.8.0-SNAPSHOT`) and the jar-name / version references in `README.md` and `CLAUDE.md` to match the SNAPSHOT build artifact.
- **Reconcile the released `1.7.0` changelog.** `v1.7.0` was tagged on the #310 merge (`c8e696c`), so the `LMDBDelta` command and the inlined-kernel example default **shipped in 1.7.0** — but they were still sitting under `[Unreleased]`. Fold them into `[1.7.0]` (`### Added` / `### Changed`), empty `[Unreleased]`, and correct the `[1.7.0]` date `2026-07-21` → `2026-07-23` (the actual tag/merge date).

## Test plan

- [x] `mvn validate` passes with the new `1.8.0-SNAPSHOT` version; no source or test pins the version string (grep-checked)
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable — this PR *is* the changelog/version housekeeping

## Related issues / PRs

Follows #310 (which merged into the `v1.7.0` release) — no code/behaviour change here, only version + changelog housekeeping.

## Checklist

- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

---

### Notes for review

- No production code changes — `pom.xml`, `README.md`, `CLAUDE.md`, `CHANGELOG.md` only (+16 / −20).
- If you prefer the user-facing docs to keep the last **released** version (`1.7.0`) rather than `1.8.0-SNAPSHOT` in the run examples, the two jar-name references in `README.md` / `CLAUDE.md` can be reverted while keeping the pom bump.
- The `[1.7.0]` date was moved to `2026-07-23` to match the tag; revert to `2026-07-21` if you intended the earlier changelog-authoring date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
