### PR TITLE
test(lmdb): deterministic reproduction harness + manual Linux workflow for issue #50 (mdb_txn_renew0 SIGSEGV)

### DIFF
--- a/.github/workflows/issue50-lmdb-crash-repro.yml
+++ b/.github/workflows/issue50-lmdb-crash-repro.yml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# Manual reproduction harness for issue #50 — the sporadic native SIGSEGV in
+# LMDB's mdb_txn_renew0 under concurrent read transactions.
+#
+# This is a DIAGNOSTIC workflow, not part of the build pipeline: it runs only on
+# manual dispatch. It drives LmdbCrashReproDriverTest, which forks child JVMs
+# that hammer the read-only LMDB path with short-lived (reader-slot-churning)
+# threads and reports a "k crashes / N runs" rate. The Linux runner is the point:
+# the crash is a pthread-TLS reader-slot race that does not reproduce on Windows.
+# JaCoCo instrumentation (issue #50 comment 1's documented aggravator) is
+# forwarded into every child by default.
+#
+# The job NEVER fails on a reproduced crash — that is the goal. It goes red only
+# if the harness itself misbehaves. Inspect the "issue #50 repro rate: k/N ..."
+# line in the log and download the child-logs artifact (child .log, per-child
+# hs_err_*.log, and .jacoco.exec) to confirm the mdb_txn_renew0 stack.
+#
+# IMPORTANT sizing note: the driver test runs inside a single Surefire fork whose
+# whole-fork timeout is 240s (pom.xml forkedProcessTimeoutInSeconds, per class
+# with reuseForks=false). Keep runs_per_shard * (seconds + ~5s JVM start) well
+# under ~200s or the fork is killed ("timeout in the fork"). Multiply total
+# attempts through the parallel `shard` matrix, not by inflating one shard.
+# ---------------------------------------------------------------------------
+
+name: Issue #50 LMDB crash repro (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs_per_shard:
+        description: 'Forked child JVMs per shard (keep runs*(seconds+5) < ~200s per shard)'
+        type: string
+        default: '8'
+      concurrency:
+        description: 'Live short-lived reader threads per child'
+        type: string
+        default: '256'
+      seconds:
+        description: 'Churn duration per child (seconds)'
+        type: string
+        default: '15'
+      forward_jacoco:
+        description: 'Run children under the JaCoCo agent (issue #50 aggravator)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: '21'
+
+jobs:
+  repro:
+    name: Repro shard ${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Six parallel shards multiply total attempts (6 * runs_per_shard) while
+        # each shard's single Surefire fork stays under the 240s fork timeout.
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+          cache: maven
+      - name: Reproduce (LMDB enabled — do NOT disable LMDB here)
+        shell: bash
+        # No -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true: the whole
+        # point is to exercise the LMDB read path. The normal `mvn test` argLine
+        # puts the JaCoCo agent on the Surefire fork, which forwardJacoco forwards
+        # into each child.
+        run: |
+          mvn -e --batch-mode --no-transfer-progress test \
+            -Dtest=LmdbCrashReproDriverTest \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver=true \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.runs=${{ inputs.runs_per_shard }} \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.concurrency=${{ inputs.concurrency }} \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.seconds=${{ inputs.seconds }} \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.lookupsPerThread=1 \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.forwardJacoco=${{ inputs.forward_jacoco }} \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.logDir="${GITHUB_WORKSPACE}/child-logs"
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: issue50-child-logs-shard-${{ matrix.shard }}
+          path: |
+            child-logs/**
+            hs_err_pid*.log
+            target/surefire-reports/**
+          if-no-files-found: ignore

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbCrashReproDriverTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbCrashReproDriverTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -75,6 +76,13 @@ public class LmdbCrashReproDriverTest {
     public static final String PROP_LOOKUPS_PER_THREAD = PROP_ENABLE + ".lookupsPerThread";
     /** Optional directory for child JVM logs; defaults to a temp subdir that is auto-cleaned. */
     public static final String PROP_LOG_DIR = PROP_ENABLE + ".logDir";
+    /**
+     * When {@code true}, forward this (parent) JVM's JaCoCo {@code -javaagent} into every child so
+     * the churn runs under offline instrumentation — issue #50 comment 1's documented aggravator.
+     * The parent surefire fork already carries the agent via {@code argLine}; each child gets its
+     * own {@code destfile} so the coverage writes never collide.
+     */
+    public static final String PROP_FORWARD_JACOCO = PROP_ENABLE + ".forwardJacoco";
 
     private static final int DEFAULT_RUNS = 30;
     private static final int DEFAULT_CONCURRENCY = 128;
@@ -172,7 +180,19 @@ public class LmdbCrashReproDriverTest {
         List<String> command = new ArrayList<>();
         command.add(javaBinary());
         command.add("-Xmx512m");
+        // Write any fatal-error report next to this child's log so it is captured as an artifact.
+        command.add("-XX:ErrorFile=" + childLog + ".hs_err_%p.log");
         command.addAll(List.of(CHILD_MODULE_FLAGS));
+        if (Boolean.getBoolean(PROP_FORWARD_JACOCO)) {
+            String jacocoAgent = jacocoAgentArgForChild(childLog);
+            if (jacocoAgent != null) {
+                command.add(jacocoAgent);
+            } else {
+                LOGGER.warn(
+                        "{}=true but this JVM has no JaCoCo -javaagent to forward; child runs uninstrumented",
+                        PROP_FORWARD_JACOCO);
+            }
+        }
         command.add("-cp");
         command.add(buildChildClasspath());
         command.add(LmdbReaderSlotChurnStressTest.class.getName());
@@ -266,6 +286,24 @@ public class LmdbCrashReproDriverTest {
         } catch (URISyntaxException | RuntimeException e) {
             LOGGER.warn("could not resolve classpath root for {}", anchor.getName(), e);
         }
+    }
+
+    /**
+     * Finds this JVM's JaCoCo {@code -javaagent} (put there by surefire's {@code argLine}) and
+     * rewrites it for a child: same agent jar, but a per-child {@code destfile} with
+     * {@code append=false} so sequential children never clobber or grow a shared exec file.
+     * Returns {@code null} if no JaCoCo agent is present on this JVM.
+     */
+    @Nullable
+    private static String jacocoAgentArgForChild(Path childLog) {
+        for (String arg : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
+            if (arg.startsWith("-javaagent:") && arg.contains("jacoco")) {
+                int optionsAt = arg.indexOf('=');
+                String agentPath = optionsAt < 0 ? arg : arg.substring(0, optionsAt);
+                return agentPath + "=destfile=" + childLog + ".jacoco.exec,append=false";
+            }
+        }
+        return null;
     }
 
     private static String javaBinary() {

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbCrashReproDriverTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbCrashReproDriverTest.java
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence.lmdb;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.LMDBPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
+import net.ladenthin.bitcoinaddressfinder.util.NetworkParameterFactory;
+import org.bitcoinj.base.Network;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Opt-in loop-until-crash driver for issue #50. A native {@code SIGSEGV} in {@code mdb_txn_renew0}
+ * kills the JVM, so it can never be asserted from inside the test JVM — instead this driver
+ * <b>forks many child JVMs</b>, each running {@link LmdbReaderSlotChurnStressTest#main(String[])}
+ * (the prod-mode reader-slot churn against a shared read-only test LMDB), and counts how many die
+ * abnormally. The output is a reproduction <em>rate</em> ("k crashes / N runs") — the number that
+ * turns #50 from "sporadic and untestable" into "reproduced on demand", and the yardstick for
+ * validating a fix.
+ *
+ * <p><b>It never fails on a crash</b> (a crash is the goal, and it is probabilistic — asserting
+ * on it would be flaky). It only fails if the harness itself misbehaves: a child that could not be
+ * launched, or a run that neither finished nor crashed within its timeout. The crash rate is
+ * logged at {@code WARN}.
+ *
+ * <p><b>Enable and run:</b>
+ *
+ * <pre>
+ * mvn test -Dtest=LmdbCrashReproDriverTest \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver=true \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.runs=50 \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.concurrency=128 \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.seconds=8 \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.lookupsPerThread=1
+ * </pre>
+ *
+ * <p>Note: children are launched clean (no JaCoCo agent). Issue #50 comment 1 observes that
+ * JaCoCo offline instrumentation widens the race window; to reproduce the CI conditions more
+ * faithfully, a follow-up can attach the agent per child — left out here to keep each child
+ * self-contained and to avoid concurrent writers to a single {@code jacoco.exec}.
+ */
+public class LmdbCrashReproDriverTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LmdbCrashReproDriverTest.class);
+
+    /** System property that enables this opt-in driver. */
+    public static final String PROP_ENABLE = "net.ladenthin.bitcoinaddressfinder.lmdbCrashDriver";
+    /** Number of child JVMs to fork (default 30). */
+    public static final String PROP_RUNS = PROP_ENABLE + ".runs";
+    /** Per-child live-thread concurrency (default 128). */
+    public static final String PROP_CONCURRENCY = PROP_ENABLE + ".concurrency";
+    /** Per-child churn duration in seconds (default 8). */
+    public static final String PROP_SECONDS = PROP_ENABLE + ".seconds";
+    /** Per-child lookups-per-thread (default 1 → maximal thread churn). */
+    public static final String PROP_LOOKUPS_PER_THREAD = PROP_ENABLE + ".lookupsPerThread";
+    /** Optional directory for child JVM logs; defaults to a temp subdir that is auto-cleaned. */
+    public static final String PROP_LOG_DIR = PROP_ENABLE + ".logDir";
+
+    private static final int DEFAULT_RUNS = 30;
+    private static final int DEFAULT_CONCURRENCY = 128;
+    private static final int DEFAULT_SECONDS = 8;
+    private static final int DEFAULT_LOOKUPS_PER_THREAD = 1;
+
+    /**
+     * Runtime module flags the child JVM needs so lmdbjava's off-heap {@code ByteBufferProxy} can
+     * reflectively reach {@code sun.nio.ch.DirectBuffer} / {@code jdk.internal.ref.Cleaner}. Kept
+     * in lockstep with {@code .mvn/jvm.config} (the surefire fork gets these via {@code argLine}).
+     */
+    private static final String[] CHILD_MODULE_FLAGS = {
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED",
+        "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+        "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+    };
+
+    @TempDir
+    public Path folder;
+
+    private final Network network = new NetworkParameterFactory().getNetwork();
+    private final PersistenceUtils persistenceUtils = new PersistenceUtils(network);
+
+    /** Creates a new {@link LmdbCrashReproDriverTest}. */
+    public LmdbCrashReproDriverTest() {}
+
+    @Test
+    public void forkedChildren_reportCrashRate() throws Exception {
+        Assumptions.assumeTrue(
+                Boolean.getBoolean(PROP_ENABLE),
+                "opt-in LMDB crash-repro driver; enable with -D" + PROP_ENABLE + "=true");
+        new LMDBPlatformAssume().assumeLMDBExecution();
+
+        final int runs = Integer.getInteger(PROP_RUNS, DEFAULT_RUNS);
+        final int concurrency = Integer.getInteger(PROP_CONCURRENCY, DEFAULT_CONCURRENCY);
+        final int seconds = Integer.getInteger(PROP_SECONDS, DEFAULT_SECONDS);
+        final int lookupsPerThread = Integer.getInteger(PROP_LOOKUPS_PER_THREAD, DEFAULT_LOOKUPS_PER_THREAD);
+
+        // Build the shared read-only test LMDB once; every child opens it read-only.
+        File lmdbDirectory = LmdbReaderSlotChurnStressTest.buildTestLmdb(folder, persistenceUtils);
+        String logDirOverride = System.getProperty(PROP_LOG_DIR);
+        Path logDir = Files.createDirectories(
+                logDirOverride != null ? Path.of(logDirOverride) : folder.resolve("child-logs"));
+        LOGGER.info("child JVM logs: {}", logDir);
+
+        int clean = 0;
+        int nativeCrash = 0;
+        int javaError = 0;
+        int harnessFailure = 0;
+        List<String> crashLogs = new ArrayList<>();
+
+        for (int run = 0; run < runs; run++) {
+            Path childLog = logDir.resolve("child-" + run + ".log");
+            RunOutcome outcome = runChild(lmdbDirectory, childLog, concurrency, seconds, lookupsPerThread);
+            switch (outcome.classification) {
+                case CLEAN -> clean++;
+                case JAVA_ERROR -> javaError++;
+                case NATIVE_CRASH -> {
+                    nativeCrash++;
+                    crashLogs.add(childLog.toString());
+                }
+                case HARNESS_FAILURE -> harnessFailure++;
+            }
+            LOGGER.info(
+                    "run {}/{}: exit={} class={}{}",
+                    run + 1,
+                    runs,
+                    outcome.exitCode,
+                    outcome.classification,
+                    outcome.signature == null ? "" : " signature=\"" + outcome.signature + "\"");
+        }
+
+        LOGGER.warn(
+                "issue #50 repro rate: {}/{} native crashes ({} clean, {} java-error, {} harness-failure).{}",
+                nativeCrash,
+                runs,
+                clean,
+                javaError,
+                harnessFailure,
+                crashLogs.isEmpty() ? "" : " Crash logs: " + crashLogs);
+
+        // A crash is the GOAL, not a failure — do not assert on it (it is probabilistic).
+        // Only the harness misbehaving is a real test failure.
+        assertThat(
+                "every child JVM must either finish or crash within its timeout (no harness failures)",
+                harnessFailure,
+                is(equalTo(0)));
+    }
+
+    private RunOutcome runChild(File lmdbDirectory, Path childLog, int concurrency, int seconds, int lookupsPerThread)
+            throws IOException, InterruptedException {
+        List<String> command = new ArrayList<>();
+        command.add(javaBinary());
+        command.add("-Xmx512m");
+        command.addAll(List.of(CHILD_MODULE_FLAGS));
+        command.add("-cp");
+        command.add(buildChildClasspath());
+        command.add(LmdbReaderSlotChurnStressTest.class.getName());
+        command.add(lmdbDirectory.getAbsolutePath());
+        command.add(Integer.toString(concurrency));
+        command.add(Integer.toString(seconds));
+        command.add(Integer.toString(lookupsPerThread));
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(childLog.toFile());
+
+        Process process = pb.start();
+        // Generous ceiling: child churn duration + JVM start/stop + fixture open.
+        long timeoutSeconds = (long) seconds + 90L;
+        if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            process.waitFor(15, TimeUnit.SECONDS);
+            return new RunOutcome(Classification.HARNESS_FAILURE, -1, "timeout after " + timeoutSeconds + "s");
+        }
+        int exit = process.exitValue();
+        String signature = scanForCrashSignature(childLog);
+        return new RunOutcome(classify(exit, signature), exit, signature);
+    }
+
+    /**
+     * Classifies a child exit. {@code main} returns 0 (clean), 2 (usage — a harness bug), or 3
+     * (Java-level throwable caught in the churn). Any other non-zero exit, or a fatal-error
+     * signature in the log, is a native crash — the {@code mdb_txn_renew0} SIGSEGV we are hunting
+     * (Linux SIGSEGV → 139, JVM abort → 134, Windows access violation → 0xC0000005).
+     */
+    private static Classification classify(int exit, @Nullable String signature) {
+        if (signature != null) {
+            return Classification.NATIVE_CRASH;
+        }
+        return switch (exit) {
+            case 0 -> Classification.CLEAN;
+            case 2 -> Classification.HARNESS_FAILURE;
+            case 3 -> Classification.JAVA_ERROR;
+            default -> Classification.NATIVE_CRASH;
+        };
+    }
+
+    @Nullable
+    private static String scanForCrashSignature(Path childLog) throws IOException {
+        if (!Files.exists(childLog)) {
+            return null;
+        }
+        String text = Files.readString(childLog, StandardCharsets.UTF_8);
+        String[] signatures = {
+            "mdb_txn_renew0", "SIGSEGV", "EXCEPTION_ACCESS_VIOLATION", "A fatal error has been detected",
+        };
+        for (String signature : signatures) {
+            if (text.contains(signature)) {
+                return signature;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builds the child classpath robustly. Surefire commonly launches its fork through a
+     * manifest-only booter jar, so the parent's {@code java.class.path} may not carry the plain
+     * {@code target/classes} / {@code target/test-classes} output roots — which is exactly why a
+     * naive {@code -cp java.class.path} child could load this (test) class yet fail on a main
+     * class. So derive both output roots from the {@link java.security.CodeSource} of a known test
+     * class and a known main class, then append {@code java.class.path} for the dependency jars.
+     */
+    private static String buildChildClasspath() {
+        LinkedHashSet<String> entries = new LinkedHashSet<>();
+        addCodeSourceRoot(entries, LmdbReaderSlotChurnStressTest.class); // target/test-classes
+        addCodeSourceRoot(entries, NetworkParameterFactory.class); // target/classes
+        String parentClasspath = System.getProperty("java.class.path");
+        if (parentClasspath != null && !parentClasspath.isEmpty()) {
+            for (String entry : parentClasspath.split(File.pathSeparator)) {
+                if (!entry.isEmpty()) {
+                    entries.add(entry);
+                }
+            }
+        }
+        return String.join(File.pathSeparator, entries);
+    }
+
+    private static void addCodeSourceRoot(LinkedHashSet<String> entries, Class<?> anchor) {
+        try {
+            java.security.CodeSource codeSource = anchor.getProtectionDomain().getCodeSource();
+            if (codeSource == null) {
+                return;
+            }
+            entries.add(Path.of(codeSource.getLocation().toURI()).toString());
+        } catch (URISyntaxException | RuntimeException e) {
+            LOGGER.warn("could not resolve classpath root for {}", anchor.getName(), e);
+        }
+    }
+
+    private static String javaBinary() {
+        boolean windows =
+                System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+        return Path.of(System.getProperty("java.home"), "bin", windows ? "java.exe" : "java")
+                .toString();
+    }
+
+    private enum Classification {
+        CLEAN,
+        JAVA_ERROR,
+        NATIVE_CRASH,
+        HARNESS_FAILURE,
+    }
+
+    private static final class RunOutcome {
+        final Classification classification;
+        final int exitCode;
+
+        @Nullable
+        final String signature;
+
+        RunOutcome(Classification classification, int exitCode, @Nullable String signature) {
+            this.classification = classification;
+            this.exitCode = exitCode;
+            this.signature = signature;
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbReaderSlotChurnStressTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbReaderSlotChurnStressTest.java
@@ -1,0 +1,403 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence.lmdb;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import net.ladenthin.bitcoinaddressfinder.LMDBPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.configuration.CLMDBConfigurationReadOnly;
+import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
+import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
+import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
+import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesFiles;
+import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesLMDB;
+import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
+import net.ladenthin.bitcoinaddressfinder.util.KeyUtility;
+import net.ladenthin.bitcoinaddressfinder.util.NetworkParameterFactory;
+import org.bitcoinj.base.Network;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.lmdbjava.ByteBufferProxy;
+import org.lmdbjava.Dbi;
+import org.lmdbjava.Env;
+import org.lmdbjava.EnvFlags;
+import org.lmdbjava.Txn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Opt-in <b>thread-churn</b> reproduction harness for the native crash tracked in issue #50
+ * (and upstream lmdbjava/lmdbjava#253): a sporadic {@code SIGSEGV} in {@code mdb_txn_renew0}
+ * when read transactions are opened concurrently.
+ *
+ * <p><b>Why this differs from {@link LmdbConcurrentReadStressTest}.</b> That sibling harness
+ * uses a <em>fixed</em> thread pool: every worker thread lives for the whole run, so each grabs
+ * its LMDB reader slot exactly once and never exits mid-run. The {@code mdb_txn_renew0} crash
+ * lives in reader-slot (re)acquisition — without {@code MDB_NOTLS} a slot is bound to a thread
+ * via a pthread TLS key and freed by that key's destructor <em>when the thread exits</em>. A
+ * fixed pool therefore almost never exercises the slot free / realloc race, which is the leading
+ * theory for why the fixed-pool harness has never reproduced the crash. This harness instead
+ * <b>continuously spawns short-lived threads</b> (default: one lookup, then the thread dies),
+ * keeping {@code concurrency} of them live at once — maximising slot allocation racing thread-exit
+ * slot-freeing, the exact {@code mdb_txn_renew0} window.
+ *
+ * <p><b>This is a crash-provoker, not a normal assertion test.</b> A real reproduction is a
+ * native segfault that kills the JVM (uncatchable as a Java exception) and is probabilistic, so a
+ * <em>passing</em> in-JVM run proves nothing; only a crash is meaningful. That is why it is
+ * <b>off by default</b>. To get a reproduction <em>rate</em> across many forked JVMs, use
+ * {@code LmdbCrashReproDriverTest}, which forks {@link #main(String[])} below.
+ *
+ * <p><b>Enable and run (prod mode — reproduces the bug as shipped):</b>
+ *
+ * <pre>
+ * mvn test -Dtest=LmdbReaderSlotChurnStressTest \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbChurn=true \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbChurn.concurrency=128 \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbChurn.seconds=20 \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbChurn.lookupsPerThread=1
+ * </pre>
+ *
+ * <p><b>Raw mode</b> (Steps 2 &amp; 5 — bisect the trigger and validate the fix) opens its own
+ * {@link Env} against the same test database with tunable flags, bypassing the production flags
+ * that {@link LMDBPersistence} hardcodes. Set {@code .mode=raw} and toggle {@code .notls} /
+ * {@code .nolock} / {@code .maxReaders}. Expectation: {@code .notls=true} with
+ * {@code .maxReaders >= concurrency} removes the crash.
+ *
+ * <pre>
+ * mvn test -Dtest=LmdbReaderSlotChurnStressTest \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbChurn=true \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbChurn.mode=raw \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbChurn.notls=true \
+ *     -Dnet.ladenthin.bitcoinaddressfinder.lmdbChurn.maxReaders=256
+ * </pre>
+ */
+public class LmdbReaderSlotChurnStressTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LmdbReaderSlotChurnStressTest.class);
+
+    /** System property that enables this opt-in test. */
+    public static final String PROP_ENABLE = "net.ladenthin.bitcoinaddressfinder.lmdbChurn";
+    /** Max number of concurrently-live short-lived reader threads (default 128). */
+    public static final String PROP_CONCURRENCY = PROP_ENABLE + ".concurrency";
+    /** Run duration in seconds (default 20). */
+    public static final String PROP_SECONDS = PROP_ENABLE + ".seconds";
+    /** Lookups each short-lived thread performs before exiting (default 1 → maximal churn). */
+    public static final String PROP_LOOKUPS_PER_THREAD = PROP_ENABLE + ".lookupsPerThread";
+    /** {@code prod} (real {@code containsAddress}, shipped flags) or {@code raw} (own env). */
+    public static final String PROP_MODE = PROP_ENABLE + ".mode";
+    /** Raw mode only: add {@code EnvFlags.MDB_NOTLS} (default false). */
+    public static final String PROP_NOTLS = PROP_ENABLE + ".notls";
+    /** Raw mode only: add {@code EnvFlags.MDB_NOLOCK} (default true, mirrors production). */
+    public static final String PROP_NOLOCK = PROP_ENABLE + ".nolock";
+    /** Raw mode only: {@code Env.Builder.setMaxReaders} (default 0 → leave lmdbjava default). */
+    public static final String PROP_MAX_READERS = PROP_ENABLE + ".maxReaders";
+
+    private static final int DEFAULT_CONCURRENCY = 128;
+    private static final int DEFAULT_SECONDS = 20;
+    private static final int DEFAULT_LOOKUPS_PER_THREAD = 1;
+    private static final int CORPUS_SIZE = 256;
+    private static final int HASH160_BYTES = OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES;
+    private static final int DRAIN_AWAIT_SECONDS = 60;
+
+    /**
+     * Physical LMDB sub-database name, mirroring the private
+     * {@code LMDBPersistence.DB_NAME_HASH160_TO_COINT}. Duplicated (not shared) so this
+     * harness stays test-only; if the production name ever changes, raw mode fails loudly
+     * when opening the dbi.
+     */
+    private static final String DB_NAME_HASH160_TO_COINT = "hash160toCoin";
+
+    @TempDir
+    public Path folder;
+
+    private final Network network = new NetworkParameterFactory().getNetwork();
+    private final PersistenceUtils persistenceUtils = new PersistenceUtils(network);
+
+    @SuppressWarnings("unused")
+    private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
+
+    /** Creates a new {@link LmdbReaderSlotChurnStressTest}. */
+    public LmdbReaderSlotChurnStressTest() {}
+
+    @Test
+    public void readerSlotChurn_shortLivedThreads_noJavaLevelFailure() throws Exception {
+        Assumptions.assumeTrue(
+                Boolean.getBoolean(PROP_ENABLE),
+                "opt-in LMDB reader-slot churn test; enable with -D" + PROP_ENABLE + "=true");
+        new LMDBPlatformAssume().assumeLMDBExecution();
+
+        final int concurrency = Integer.getInteger(PROP_CONCURRENCY, DEFAULT_CONCURRENCY);
+        final int seconds = Integer.getInteger(PROP_SECONDS, DEFAULT_SECONDS);
+        final int lookupsPerThread = Integer.getInteger(PROP_LOOKUPS_PER_THREAD, DEFAULT_LOOKUPS_PER_THREAD);
+        final String mode = System.getProperty(PROP_MODE, "prod");
+
+        File lmdbDirectory = buildTestLmdb(folder, persistenceUtils);
+        byte[][] corpus = buildHash160Corpus(CORPUS_SIZE);
+
+        ChurnResult result;
+        if ("raw".equalsIgnoreCase(mode)) {
+            boolean notls = Boolean.getBoolean(PROP_NOTLS);
+            boolean nolock = System.getProperty(PROP_NOLOCK) == null || Boolean.getBoolean(PROP_NOLOCK);
+            int maxReaders = Integer.getInteger(PROP_MAX_READERS, 0);
+            LOGGER.info(
+                    "churn mode=raw notls={} nolock={} maxReaders={} concurrency={} seconds={} lookupsPerThread={}",
+                    notls,
+                    nolock,
+                    maxReaders,
+                    concurrency,
+                    seconds,
+                    lookupsPerThread);
+            result = runRawChurn(
+                    lmdbDirectory, corpus, notls, nolock, maxReaders, concurrency, seconds, lookupsPerThread);
+        } else {
+            LOGGER.info(
+                    "churn mode=prod concurrency={} seconds={} lookupsPerThread={}",
+                    concurrency,
+                    seconds,
+                    lookupsPerThread);
+            result = runProdChurn(lmdbDirectory, persistenceUtils, corpus, concurrency, seconds, lookupsPerThread);
+        }
+
+        LOGGER.info(
+                "LMDB reader-slot churn: {} reads, {} threads spawned, {} Java-level errors",
+                result.reads,
+                result.threadsSpawned,
+                result.errors.size());
+
+        assertThat(
+                "concurrent LMDB reads raised Java-level throwables: " + result.errors,
+                result.errors.isEmpty(),
+                is(equalTo(true)));
+        assertThat("expected the churn loop to perform reads", result.reads > 0L, is(equalTo(true)));
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Child-JVM entry point (forked by LmdbCrashReproDriverTest to get a crash rate).
+    // ------------------------------------------------------------------------------------------
+
+    /**
+     * Standalone entry point for a forked child JVM. Opens the (already-built) read-only LMDB at
+     * {@code args[0]} via the real {@link LMDBPersistence} (production flags — reproduces the bug
+     * as shipped) and runs the prod-mode churn. Exits 0 on a clean finish; a native
+     * {@code mdb_txn_renew0} crash kills this JVM with a non-zero / signal exit that the parent
+     * driver counts.
+     *
+     * <p>Args: {@code <lmdbDir> [concurrency] [seconds] [lookupsPerThread]}.
+     *
+     * @param args the child parameters
+     * @throws Exception if the LMDB cannot be opened
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.err.println("usage: LmdbReaderSlotChurnStressTest <lmdbDir> [concurrency] [seconds] [lookups]");
+            System.exit(2);
+            return;
+        }
+        File lmdbDirectory = new File(args[0]);
+        int concurrency = args.length > 1 ? Integer.parseInt(args[1]) : DEFAULT_CONCURRENCY;
+        int seconds = args.length > 2 ? Integer.parseInt(args[2]) : DEFAULT_SECONDS;
+        int lookupsPerThread = args.length > 3 ? Integer.parseInt(args[3]) : DEFAULT_LOOKUPS_PER_THREAD;
+
+        Network net = new NetworkParameterFactory().getNetwork();
+        PersistenceUtils utils = new PersistenceUtils(net);
+        byte[][] corpus = buildHash160Corpus(CORPUS_SIZE);
+
+        ChurnResult result = runProdChurn(lmdbDirectory, utils, corpus, concurrency, seconds, lookupsPerThread);
+        System.out.println("child churn done: reads=" + result.reads
+                + " threadsSpawned=" + result.threadsSpawned
+                + " javaErrors=" + result.errors.size());
+        System.exit(result.errors.isEmpty() ? 0 : 3);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Churn engines.
+    // ------------------------------------------------------------------------------------------
+
+    private static ChurnResult runProdChurn(
+            File lmdbDirectory,
+            PersistenceUtils persistenceUtils,
+            byte[][] corpus,
+            int concurrency,
+            int seconds,
+            int lookupsPerThread)
+            throws InterruptedException {
+        CLMDBConfigurationReadOnly config = new CLMDBConfigurationReadOnly();
+        config.lmdbDirectory = lmdbDirectory.getAbsolutePath();
+        LMDBPersistence persistence = new LMDBPersistence(config, persistenceUtils);
+        persistence.init();
+        try {
+            return churn(concurrency, seconds, lookupsPerThread, (key, random) -> {
+                key.rewind();
+                key.put(corpus[random.nextInt(corpus.length)]);
+                key.flip();
+                persistence.containsAddress(key);
+            });
+        } finally {
+            persistence.close();
+        }
+    }
+
+    private static ChurnResult runRawChurn(
+            File lmdbDirectory,
+            byte[][] corpus,
+            boolean notls,
+            boolean nolock,
+            int maxReaders,
+            int concurrency,
+            int seconds,
+            int lookupsPerThread)
+            throws InterruptedException {
+        List<EnvFlags> flags = new ArrayList<>();
+        flags.add(EnvFlags.MDB_RDONLY_ENV);
+        if (nolock) {
+            flags.add(EnvFlags.MDB_NOLOCK);
+        }
+        if (notls) {
+            flags.add(EnvFlags.MDB_NOTLS);
+        }
+        Env.Builder<ByteBuffer> builder =
+                Env.create(ByteBufferProxy.PROXY_OPTIMAL).setMaxDbs(1);
+        if (maxReaders > 0) {
+            builder.setMaxReaders(maxReaders);
+        }
+        try (Env<ByteBuffer> env = builder.open(lmdbDirectory, flags.toArray(new EnvFlags[0]))) {
+            Dbi<ByteBuffer> dbi = env.openDbi(DB_NAME_HASH160_TO_COINT);
+            return churn(concurrency, seconds, lookupsPerThread, (key, random) -> {
+                key.rewind();
+                key.put(corpus[random.nextInt(corpus.length)]);
+                key.flip();
+                try (Txn<ByteBuffer> txn = env.txnRead()) {
+                    dbi.get(txn, key);
+                }
+            });
+        }
+    }
+
+    /**
+     * The churn core: continuously spawn short-lived reader threads, keeping {@code concurrency}
+     * of them live at once, for {@code seconds}. Each thread performs {@code lookupsPerThread}
+     * lookups with its own thread-confined direct key buffer, then exits — so OS threads are
+     * created and destroyed at a high rate while concurrency stays saturated.
+     *
+     * <p>Deliberately uses raw {@link Thread} (not an executor): the whole point is to churn
+     * thread <em>lifecycles</em> so the pthread-TLS reader-slot destructor races slot allocation.
+     * A pooled executor would reuse threads and defeat the reproduction.
+     */
+    @SuppressWarnings("BusyWait")
+    private static ChurnResult churn(int concurrency, int seconds, int lookupsPerThread, Lookup lookup)
+            throws InterruptedException {
+        final Semaphore permits = new Semaphore(concurrency);
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        final AtomicLong reads = new AtomicLong();
+        final AtomicLong threadsSpawned = new AtomicLong();
+        final List<Throwable> errors = new CopyOnWriteArrayList<>();
+        final long deadlineNanos = System.nanoTime() + (long) seconds * 1_000_000_000L;
+
+        long seed = 0;
+        while (System.nanoTime() < deadlineNanos && errors.isEmpty()) {
+            permits.acquire();
+            if (System.nanoTime() >= deadlineNanos || !errors.isEmpty()) {
+                permits.release();
+                break;
+            }
+            final long threadSeed = seed++;
+            Thread worker = new Thread(
+                    () -> {
+                        final ByteBuffer key = ByteBuffer.allocateDirect(HASH160_BYTES);
+                        final Random random = new Random(threadSeed);
+                        try {
+                            for (int i = 0; i < lookupsPerThread && !stop.get(); i++) {
+                                lookup.run(key, random);
+                                reads.incrementAndGet();
+                            }
+                        } catch (Throwable t) {
+                            errors.add(t);
+                        } finally {
+                            permits.release();
+                        }
+                    },
+                    "lmdb-churn-" + threadSeed);
+            worker.setDaemon(true);
+            worker.start();
+            threadsSpawned.incrementAndGet();
+        }
+
+        stop.set(true);
+        // Drain: reacquire every permit → every spawned worker has finished and exited.
+        boolean drained = permits.tryAcquire(concurrency, DRAIN_AWAIT_SECONDS, TimeUnit.SECONDS);
+        if (!drained) {
+            errors.add(new IllegalStateException("churn workers did not drain within " + DRAIN_AWAIT_SECONDS + "s"));
+        }
+        return new ChurnResult(reads.get(), threadsSpawned.get(), errors);
+    }
+
+    /** A single thread-confined lookup: fill {@code key} from the corpus and query LMDB. */
+    @FunctionalInterface
+    private interface Lookup {
+        void run(ByteBuffer key, Random random) throws Exception;
+    }
+
+    private static final class ChurnResult {
+        final long reads;
+        final long threadsSpawned;
+        final List<Throwable> errors;
+
+        ChurnResult(long reads, long threadsSpawned, List<Throwable> errors) {
+            this.reads = reads;
+            this.threadsSpawned = threadsSpawned;
+            this.errors = errors;
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Fixtures.
+    // ------------------------------------------------------------------------------------------
+
+    /**
+     * Builds the small read-only test LMDB used by every mode.
+     *
+     * @param folder the temp directory to build into
+     * @param persistenceUtils the persistence helpers bound to the test network
+     * @return the LMDB directory
+     * @throws Exception if the fixture LMDB cannot be created
+     */
+    static File buildTestLmdb(Path folder, PersistenceUtils persistenceUtils) throws Exception {
+        TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
+        TestAddressesFiles testAddresses = new TestAddressesFiles(false);
+        return testAddressesLMDB.createTestLMDB(folder, testAddresses, true, false);
+    }
+
+    /**
+     * Builds a corpus of 20-byte hash160 values (a mix of compressed/uncompressed hashes from
+     * distinct private keys). Most are misses against the tiny test LMDB — fine, because every
+     * lookup still opens a read transaction and performs a {@code Dbi.get}, which is the crash
+     * path under test.
+     *
+     * @param count number of hash160 entries to generate
+     * @return the hash160 corpus
+     */
+    static byte[][] buildHash160Corpus(int count) {
+        byte[][] corpus = new byte[count][];
+        for (int i = 0; i < count; i++) {
+            PublicKeyBytes publicKeyBytes = PublicKeyBytes.fromPrivate(BigInteger.valueOf(1000L + i));
+            corpus[i] = (i % 2 == 0) ? publicKeyBytes.getUncompressedKeyHash() : publicKeyBytes.getCompressedKeyHash();
+        }
+        return corpus;
+    }
+}


### PR DESCRIPTION
## Summary

- **Adds a deterministic reproduction harness for issue #50** (sporadic native `SIGSEGV` in LMDB's `mdb_txn_renew0` under concurrent read transactions). Test-only — **no `src/main` changes**; both harnesses are opt-in and skipped by a normal `mvn test`.
- **`LmdbReaderSlotChurnStressTest`** — the repro engine. Unlike the existing `LmdbConcurrentReadStressTest` (fixed thread pool, never reproduced the crash), it continuously spawns **short-lived** reader threads (default: one lookup, then exit), so slot allocation races the thread-exit pthread-TLS reader-slot free — the exact `mdb_txn_renew0` window. Two modes: `prod` (real `LMDBPersistence.containsAddress`, shipped flags) and `raw` (own `Env` with tunable `MDB_NOTLS` / `MDB_NOLOCK` / `maxReaders`, to bisect the trigger and validate a fix). Also exposes `main()` for forking.
- **`LmdbCrashReproDriverTest`** — a native SIGSEGV kills the JVM and can't be asserted in-process, so this **forks N child JVMs**, classifies each exit (clean / java-error / native-crash / harness-failure), and logs a **`k crashes / N runs`** rate. It never fails on a crash (the goal, and probabilistic); only a harness fault is red. Optionally forwards the JaCoCo agent into children (#50 comment 1's aggravator) and points each child's `-XX:ErrorFile` at its log.
- **`.github/workflows/issue50-lmdb-crash-repro.yml`** — a `workflow_dispatch`-only Linux job that drives the above with LMDB enabled and uploads child logs / `hs_err` / `.jacoco.exec` as artifacts. **Linux is required**: the crash is a pthread-TLS reader-slot race and does not reproduce on Windows.

## Why the existing harness never reproduced it

The `mdb_txn_renew0` crash lives in reader-slot (re)acquisition. Without `MDB_NOTLS` a slot is bound to a thread via a pthread TLS key and freed by that key's destructor **when the thread exits**. A fixed thread pool grabs each slot once and never exits mid-run, so it essentially never exercises the slot free/realloc race — the leading theory for the null result. Thread *churn* is the missing ingredient.

## Test plan

- [x] `mvn test-compile` + `mvn spotless:check` clean
- [x] Prod-mode churn runs: ~34k threads spawned / 8s; driver forks children that churn the full duration and exit cleanly
- [x] Heavy Windows attempt: 8 forks x 256 threads x 15s (~500k thread create/destroy events) -> **0 crashes** (expected — Windows is not the vulnerable platform)
- [x] JaCoCo forwarding verified locally (child emits `.jacoco.exec`, still churns)
- [ ] **Linux crash rate** — pending: run the new manual workflow (or on a Linux box). This is the confirmation step that requires Linux and cannot be done on the Windows dev machine.
- N/A CHANGELOG (test/CI-only diagnostic, no shipped behaviour change)

## Related issues / PRs

Refs #50 (does not close it — reproduction/tracking; upstream lmdbjava/lmdbjava#253 remains open).

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

---

### Notes for review

- **How to run the repro** (from the PR branch): Actions -> "Issue #50 LMDB crash repro (manual)" -> Run workflow. Defaults: 6 shards x 8 runs = 48 attempts, 256 threads, 15s each, JaCoCo on. Inspect the `issue #50 repro rate: k/N ...` log line and download the `issue50-child-logs-shard-*` artifact.
- **Fork-timeout sizing**: each driver run executes in one Surefire fork bounded by `forkedProcessTimeoutInSeconds=240` (pom, per class). The workflow keeps `runs*(seconds+~5) < ~200s` per shard and multiplies attempts through the parallel `shard` matrix rather than inflating one shard. I intentionally did **not** touch the pom timeout.
- **`java.lang.management`** is used (via `ManagementFactory`) to forward the parent's JaCoCo agent. Test code never compiles in module mode, so it's always reachable; the only caveat is the documented stale-`module-info.class` local trap (`mvn test` after `package` without `clean`), which CI never hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
