### PR TITLE
fix(lmdb): guard Env close against in-flight reads (issue #50 mdb_txn_renew0 SIGSEGV)

### DIFF
--- a/.github/workflows/issue50-lmdb-crash-repro.yml
+++ b/.github/workflows/issue50-lmdb-crash-repro.yml
@@ -4,13 +4,23 @@
 
 # ---------------------------------------------------------------------------
 # Manual reproduction harness for issue #50 — the sporadic native SIGSEGV in
-# LMDB's mdb_txn_renew0 under concurrent read transactions.
+# LMDB's mdb_txn_renew0.
 #
 # This is a DIAGNOSTIC workflow, not part of the build pipeline: it runs only on
-# manual dispatch. It drives LmdbCrashReproDriverTest, which forks child JVMs
-# that hammer the read-only LMDB path with short-lived (reader-slot-churning)
-# threads and reports a "k crashes / N runs" rate. The Linux runner is the point:
-# the crash is a pthread-TLS reader-slot race that does not reproduce on Windows.
+# manual dispatch. It drives LmdbCrashReproDriverTest, which forks child JVMs and
+# reports a "k crashes / N runs" rate. Two scenarios (see `scenario` input):
+#
+#   * closerace (DEFAULT, the ROOT CAUSE) — close the LMDB env while reads are
+#     still in flight, exactly the ConsumerJava.interrupt() path where
+#     awaitTermination times out and persistence.close() unmaps the mmap out from
+#     under a live reader. This is a genuine use-after-unmap and reproduces
+#     ON DEMAND and CROSS-PLATFORM (verified 5/5 on Windows). It is the scenario
+#     the LMDBPersistence read/write-lock fix closes; after the fix it reports 0/N.
+#   * churn — steady-state reader-slot churn (many short-lived reader threads,
+#     env kept open the whole run). This was the ORIGINAL hypothesis; it does NOT
+#     reproduce the crash (0/48 on Linux even with JaCoCo) because it never
+#     overlaps a close with a live read. Kept as the informative negative control.
+#
 # JaCoCo instrumentation (issue #50 comment 1's documented aggravator) is
 # forwarded into every child by default.
 #
@@ -31,18 +41,33 @@ name: Issue #50 LMDB crash repro (manual)
 on:
   workflow_dispatch:
     inputs:
+      scenario:
+        description: 'closerace = root-cause use-after-unmap (reproduces on demand); churn = negative control'
+        type: choice
+        options:
+          - closerace
+          - churn
+        default: closerace
       runs_per_shard:
         description: 'Forked child JVMs per shard (keep runs*(seconds+5) < ~200s per shard)'
         type: string
         default: '8'
       concurrency:
-        description: 'Live short-lived reader threads per child'
+        description: 'churn only: live short-lived reader threads per child'
         type: string
         default: '256'
       seconds:
-        description: 'Churn duration per child (seconds)'
+        description: 'churn only: churn duration per child (seconds)'
         type: string
         default: '15'
+      reader_threads:
+        description: 'closerace only: reader threads hammering containsAddress per child'
+        type: string
+        default: '128'
+      warmup_millis:
+        description: 'closerace only: warm-up before the env is closed (ms)'
+        type: string
+        default: '1000'
       forward_jacoco:
         description: 'Run children under the JaCoCo agent (issue #50 aggravator)'
         type: boolean
@@ -81,10 +106,13 @@ jobs:
           mvn -e --batch-mode --no-transfer-progress test \
             -Dtest=LmdbCrashReproDriverTest \
             -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver=true \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.scenario=${{ inputs.scenario }} \
             -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.runs=${{ inputs.runs_per_shard }} \
             -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.concurrency=${{ inputs.concurrency }} \
             -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.seconds=${{ inputs.seconds }} \
             -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.lookupsPerThread=1 \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.readerThreads=${{ inputs.reader_threads }} \
+            -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.warmupMillis=${{ inputs.warmup_millis }} \
             -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.forwardJacoco=${{ inputs.forward_jacoco }} \
             -Dnet.ladenthin.bitcoinaddressfinder.lmdbCrashDriver.logDir="${GITHUB_WORKSPACE}/child-logs"
       - uses: actions/upload-artifact@v7

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LMDBPersistence.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LMDBPersistence.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -72,6 +73,34 @@ public class LMDBPersistence implements Persistence, AddressIterable {
 
     @ToString.Exclude
     private @Nullable Dbi<ByteBuffer> lmdb_h160ToAmount;
+
+    /**
+     * Guards the native env/mmap lifecycle against the close-during-read race (issue #50). The
+     * short, bounded point-lookup reads ({@link #containsAddress} / {@link #getAmount}) take the
+     * READ lock for the whole duration of their native transaction; {@link #close()} takes the
+     * WRITE lock. Because a writer waits for every read lock to be released, {@code Env.close()}
+     * can never unmap the mmap while a reader is inside {@code mdb_txn_begin} /
+     * {@code mdb_txn_renew0} — the exact use-after-unmap that crashed a straggler
+     * {@code ConsumerJava} thread with {@code SIGSEGV (SEGV_MAPERR)} when
+     * {@code ConsumerJava.interrupt()} closed the env after {@code awaitTermination} timed out.
+     *
+     * <p>Deliberately scoped to the two point-lookup queries only. Those are the operations that
+     * run concurrently with {@code close()} on the scan path; the long full-database iterations
+     * ({@link #addresses()}, {@link #forEachAddress}, {@link #writeAllAmountsToAddressFile},
+     * {@link #count()}) execute during population/export, are never concurrent with a close from
+     * another thread, and must not hold the read lock for a whole-database scan (that would block
+     * shutdown for the entire scan). The write side (import) is single-threaded per instance.
+     */
+    @ToString.Exclude
+    private final ReentrantReadWriteLock envLifecycleLock = new ReentrantReadWriteLock();
+
+    /**
+     * Set to {@code true} under {@link #envLifecycleLock}'s write lock in {@link #close()} and
+     * read under its read lock by the point-lookup queries. A query that observes it already set
+     * returns "absent" instead of dereferencing the torn-down mmap — the benign side of the
+     * issue #50 race after the env has been closed during shutdown.
+     */
+    private volatile boolean closed = false;
 
     private final java.util.concurrent.atomic.AtomicLong increasedCounter =
             new java.util.concurrent.atomic.AtomicLong(0);
@@ -219,16 +248,35 @@ public class LMDBPersistence implements Persistence, AddressIterable {
             return;
         }
 
-        logStatsIfConfigured(false);
-        // The writable env runs with MDB_NOSYNC/MDB_NOMETASYNC/MDB_MAPASYNC: commits are NOT flushed to
-        // disk during the run (fast, but a crash may lose or corrupt data — acceptable for a rebuildable
-        // import DB). Force one full, durable flush here so a normal shutdown leaves everything on disk.
-        // Read-only envs have nothing to sync, so this only applies to the writable env.
-        if (lmdbConfigurationWrite != null) {
-            localEnv.sync(true);
+        // Take the WRITE lock so the mmap is unmapped only after every in-flight point-lookup read
+        // (each of which holds the READ lock across its whole native transaction) has finished, and
+        // so no new read can start against a half-closed env. Without this, a consumer thread still
+        // inside containsAddress -> mdb_txn_begin when Env.close() unmaps the mmap dereferences freed
+        // memory -> SIGSEGV (SEGV_MAPERR) in mdb_txn_renew0 (issue #50).
+        envLifecycleLock.writeLock().lock();
+        try {
+            if (closed) {
+                // Idempotent: a second close() (e.g. finally-block + explicit) is a no-op.
+                return;
+            }
+            // Publish "closed" before unmapping so any query that acquires the read lock after this
+            // point returns "absent" instead of touching the mmap we are about to tear down.
+            closed = true;
+
+            logStatsIfConfigured(false);
+            // The writable env runs with MDB_NOSYNC/MDB_NOMETASYNC/MDB_MAPASYNC: commits are NOT flushed
+            // to disk during the run (fast, but a crash may lose or corrupt data — acceptable for a
+            // rebuildable import DB). Force one full, durable flush here so a normal shutdown leaves
+            // everything on disk. Read-only envs have nothing to sync, so this only applies to the
+            // writable env.
+            if (lmdbConfigurationWrite != null) {
+                localEnv.sync(true);
+            }
+            localLmdb_h160ToAmount.close();
+            localEnv.close();
+        } finally {
+            envLifecycleLock.writeLock().unlock();
         }
-        localLmdb_h160ToAmount.close();
-        localEnv.close();
     }
 
     /**
@@ -251,12 +299,21 @@ public class LMDBPersistence implements Persistence, AddressIterable {
 
     @Override
     public Coin getAmount(ByteBuffer hash160) {
-        Dbi<ByteBuffer> localLmdb_h160ToAmount = Objects.requireNonNull(lmdb_h160ToAmount);
-        Env<ByteBuffer> localEnv = Objects.requireNonNull(env);
+        // READ lock spans the whole native transaction so close() cannot unmap the mmap mid-read.
+        envLifecycleLock.readLock().lock();
+        try {
+            if (closed) {
+                return Coin.ZERO;
+            }
+            Dbi<ByteBuffer> localLmdb_h160ToAmount = Objects.requireNonNull(lmdb_h160ToAmount);
+            Env<ByteBuffer> localEnv = Objects.requireNonNull(env);
 
-        try (Txn<ByteBuffer> txn = localEnv.txnRead()) {
-            ByteBuffer byteBuffer = localLmdb_h160ToAmount.get(txn, hash160);
-            return getCoinFromByteBuffer(byteBuffer);
+            try (Txn<ByteBuffer> txn = localEnv.txnRead()) {
+                ByteBuffer byteBuffer = localLmdb_h160ToAmount.get(txn, hash160);
+                return getCoinFromByteBuffer(byteBuffer);
+            }
+        } finally {
+            envLifecycleLock.readLock().unlock();
         }
     }
 
@@ -270,16 +327,29 @@ public class LMDBPersistence implements Persistence, AddressIterable {
     @Override
     public boolean containsAddress(ByteBuffer hash160) {
         CLMDBConfigurationReadOnly localLmdbConfigurationReadOnly = Objects.requireNonNull(lmdbConfigurationReadOnly);
-        Dbi<ByteBuffer> localLmdb_h160ToAmount = Objects.requireNonNull(lmdb_h160ToAmount);
-        Env<ByteBuffer> localEnv = Objects.requireNonNull(env);
 
         if (localLmdbConfigurationReadOnly.disableAddressLookup) {
             return false;
         }
 
-        try (Txn<ByteBuffer> txn = localEnv.txnRead()) {
-            ByteBuffer byteBuffer = localLmdb_h160ToAmount.get(txn, hash160);
-            return byteBuffer != null;
+        // READ lock spans the whole native transaction so close() cannot unmap the mmap mid-read.
+        envLifecycleLock.readLock().lock();
+        try {
+            if (closed) {
+                // The env was closed during shutdown. Treat as "absent" rather than dereferencing the
+                // unmapped mmap — the benign side of the issue #50 close-during-read race: a straggler
+                // consumer lookup after close() no longer crashes the JVM.
+                return false;
+            }
+            Dbi<ByteBuffer> localLmdb_h160ToAmount = Objects.requireNonNull(lmdb_h160ToAmount);
+            Env<ByteBuffer> localEnv = Objects.requireNonNull(env);
+
+            try (Txn<ByteBuffer> txn = localEnv.txnRead()) {
+                ByteBuffer byteBuffer = localLmdb_h160ToAmount.get(txn, hash160);
+                return byteBuffer != null;
+            }
+        } finally {
+            envLifecycleLock.readLock().unlock();
         }
     }
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LMDBPersistenceCloseDuringReadTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LMDBPersistenceCloseDuringReadTest.java
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.persistence.lmdb;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import net.ladenthin.bitcoinaddressfinder.LMDBPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.configuration.CLMDBConfigurationReadOnly;
+import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
+import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
+import net.ladenthin.bitcoinaddressfinder.util.NetworkParameterFactory;
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Network;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression tests for issue #50: the close-during-read use-after-unmap that crashed a straggler
+ * {@code ConsumerJava} thread with {@code SIGSEGV (SEGV_MAPERR)} in {@code mdb_txn_renew0} when
+ * {@code ConsumerJava.interrupt()} closed the LMDB env after {@code awaitTermination} timed out
+ * with a reader still inside {@code containsAddress -> mdb_txn_begin}.
+ *
+ * <p>The fix lives in {@link LMDBPersistence}: point-lookup reads take a read lock across their
+ * whole native transaction and {@link LMDBPersistence#close()} takes the write lock, so the mmap
+ * can never be unmapped while a reader is mid-native-call. A read that arrives after the close
+ * observes the {@code closed} flag under the read lock and returns "absent" instead of touching
+ * the torn-down mmap.
+ *
+ * <p>These tests run by default (gated only by {@link LMDBPlatformAssume}); the exhaustive
+ * crash-rate reproduction lives in the opt-in {@link LmdbReaderSlotChurnStressTest} /
+ * {@link LmdbCrashReproDriverTest} harness.
+ */
+public class LMDBPersistenceCloseDuringReadTest {
+
+    private static final int HASH160_BYTES = OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES;
+
+    /** Modest reader fleet — enough to overlap the close, small enough to stay fast. */
+    private static final int READER_THREADS = 16;
+
+    /** Let readers saturate the native read path before the close race. */
+    private static final int WARMUP_MILLIS = 200;
+
+    private static final int READER_JOIN_MILLIS = 2000;
+
+    @TempDir
+    public Path folder;
+
+    private final Network network = new NetworkParameterFactory().getNetwork();
+    private final PersistenceUtils persistenceUtils = new PersistenceUtils(network);
+
+    /** After {@link LMDBPersistence#close()} a lookup must return {@code false}, never crash or throw. */
+    @Test
+    public void containsAddress_afterClose_returnsFalseWithoutThrowing() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+        LMDBPersistence persistence = openReadOnly();
+        ByteBuffer key = keyBuffer(LmdbReaderSlotChurnStressTest.buildHash160Corpus(1)[0]);
+
+        persistence.close();
+
+        assertThat(persistence.containsAddress(key), is(equalTo(false)));
+    }
+
+    /** After close a value lookup must yield {@link Coin#ZERO}, never dereference the unmapped mmap. */
+    @Test
+    public void getAmount_afterClose_returnsZeroWithoutThrowing() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+        LMDBPersistence persistence = openReadOnly();
+        ByteBuffer key = keyBuffer(LmdbReaderSlotChurnStressTest.buildHash160Corpus(1)[0]);
+
+        persistence.close();
+
+        assertThat(persistence.getAmount(key), is(equalTo(Coin.ZERO)));
+    }
+
+    /** A second {@link LMDBPersistence#close()} is a no-op, not a double-free / native error. */
+    @Test
+    public void close_calledTwice_isIdempotent() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+        LMDBPersistence persistence = openReadOnly();
+
+        persistence.close();
+        persistence.close();
+    }
+
+    /**
+     * The actual issue #50 race, as a default-running regression: hammer {@code containsAddress}
+     * from many threads, then close the env <b>while reads are in flight</b>. Before the fix this
+     * crashed the JVM; with the read/write-lock coordination the close waits for in-flight native
+     * reads, later reads return "absent", and no thread raises an unexpected throwable.
+     *
+     * <p>Deliberately raw {@link Thread}s: the readers must be genuinely concurrent with the close,
+     * which is exactly the coordination {@link LMDBPersistence} now provides.
+     */
+    @Test
+    public void closeDuringConcurrentReads_survivesAndClosesCleanly() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+        LMDBPersistence persistence = openReadOnly();
+        byte[][] corpus = LmdbReaderSlotChurnStressTest.buildHash160Corpus(256);
+
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        final AtomicBoolean closing = new AtomicBoolean(false);
+        final AtomicLong reads = new AtomicLong();
+        final List<Throwable> unexpected = new CopyOnWriteArrayList<>();
+        final List<Thread> readers = new ArrayList<>(READER_THREADS);
+
+        for (int i = 0; i < READER_THREADS; i++) {
+            final long seed = i;
+            Thread reader = new Thread(
+                    () -> {
+                        final ByteBuffer key = ByteBuffer.allocateDirect(HASH160_BYTES);
+                        final Random random = new Random(seed);
+                        while (!stop.get()) {
+                            try {
+                                key.rewind();
+                                key.put(corpus[random.nextInt(corpus.length)]);
+                                key.flip();
+                                persistence.containsAddress(key);
+                                reads.incrementAndGet();
+                            } catch (Throwable t) {
+                                // Once close() has been requested the guarded lookup returns false
+                                // rather than throwing, so nothing is expected here even post-close;
+                                // record anything seen while the env is still open as a real defect.
+                                if (!closing.get()) {
+                                    unexpected.add(t);
+                                }
+                                return;
+                            }
+                        }
+                    },
+                    "lmdb-reader-" + seed);
+            reader.setDaemon(true);
+            reader.start();
+            readers.add(reader);
+        }
+
+        Thread.sleep(WARMUP_MILLIS);
+
+        // THE RACE: close the env out from under live readers (no drain first — that was the bug).
+        closing.set(true);
+        persistence.close();
+
+        stop.set(true);
+        for (Thread reader : readers) {
+            reader.join(READER_JOIN_MILLIS);
+        }
+
+        assertThat("readers should have exercised the native read path", reads.get() > 0L, is(equalTo(true)));
+        assertThat("close-during-read raised unexpected throwables: " + unexpected, unexpected.isEmpty(), is(true));
+        assertThat("env must be closed after close()", persistence.isClosed(), is(equalTo(true)));
+    }
+
+    private LMDBPersistence openReadOnly() throws Exception {
+        File lmdbDirectory = LmdbReaderSlotChurnStressTest.buildTestLmdb(folder, persistenceUtils);
+        CLMDBConfigurationReadOnly config = new CLMDBConfigurationReadOnly();
+        config.lmdbDirectory = lmdbDirectory.getAbsolutePath();
+        LMDBPersistence persistence = new LMDBPersistence(config, persistenceUtils);
+        persistence.init();
+        return persistence;
+    }
+
+    private static ByteBuffer keyBuffer(byte[] hash160) {
+        ByteBuffer key = ByteBuffer.allocateDirect(HASH160_BYTES);
+        key.put(hash160);
+        key.flip();
+        return key;
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbCrashReproDriverTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbCrashReproDriverTest.java
@@ -83,11 +83,19 @@ public class LmdbCrashReproDriverTest {
      * own {@code destfile} so the coverage writes never collide.
      */
     public static final String PROP_FORWARD_JACOCO = PROP_ENABLE + ".forwardJacoco";
+    /** Per-child scenario: {@code churn} (default) or {@code closerace} (the actual #50 crash). */
+    public static final String PROP_SCENARIO = PROP_ENABLE + ".scenario";
+    /** {@code closerace} only: reader threads per child (forwarded to the child). */
+    public static final String PROP_READER_THREADS = PROP_ENABLE + ".readerThreads";
+    /** {@code closerace} only: warm-up before close, in ms (forwarded to the child). */
+    public static final String PROP_WARMUP_MILLIS = PROP_ENABLE + ".warmupMillis";
 
     private static final int DEFAULT_RUNS = 30;
     private static final int DEFAULT_CONCURRENCY = 128;
     private static final int DEFAULT_SECONDS = 8;
     private static final int DEFAULT_LOOKUPS_PER_THREAD = 1;
+    private static final int DEFAULT_READER_THREADS = 128;
+    private static final int DEFAULT_WARMUP_MILLIS = 1000;
 
     /**
      * Runtime module flags the child JVM needs so lmdbjava's off-heap {@code ByteBufferProxy} can
@@ -123,6 +131,17 @@ public class LmdbCrashReproDriverTest {
         final int concurrency = Integer.getInteger(PROP_CONCURRENCY, DEFAULT_CONCURRENCY);
         final int seconds = Integer.getInteger(PROP_SECONDS, DEFAULT_SECONDS);
         final int lookupsPerThread = Integer.getInteger(PROP_LOOKUPS_PER_THREAD, DEFAULT_LOOKUPS_PER_THREAD);
+        final String scenario = System.getProperty(PROP_SCENARIO, "churn");
+        final int readerThreads = Integer.getInteger(PROP_READER_THREADS, DEFAULT_READER_THREADS);
+        final int warmupMillis = Integer.getInteger(PROP_WARMUP_MILLIS, DEFAULT_WARMUP_MILLIS);
+        LOGGER.info(
+                "driver scenario={} runs={} concurrency={} seconds={} readerThreads={} warmupMillis={}",
+                scenario,
+                runs,
+                concurrency,
+                seconds,
+                readerThreads,
+                warmupMillis);
 
         // Build the shared read-only test LMDB once; every child opens it read-only.
         File lmdbDirectory = LmdbReaderSlotChurnStressTest.buildTestLmdb(folder, persistenceUtils);
@@ -139,7 +158,15 @@ public class LmdbCrashReproDriverTest {
 
         for (int run = 0; run < runs; run++) {
             Path childLog = logDir.resolve("child-" + run + ".log");
-            RunOutcome outcome = runChild(lmdbDirectory, childLog, concurrency, seconds, lookupsPerThread);
+            RunOutcome outcome = runChild(
+                    lmdbDirectory,
+                    childLog,
+                    scenario,
+                    concurrency,
+                    seconds,
+                    lookupsPerThread,
+                    readerThreads,
+                    warmupMillis);
             switch (outcome.classification) {
                 case CLEAN -> clean++;
                 case JAVA_ERROR -> javaError++;
@@ -175,8 +202,17 @@ public class LmdbCrashReproDriverTest {
                 is(equalTo(0)));
     }
 
-    private RunOutcome runChild(File lmdbDirectory, Path childLog, int concurrency, int seconds, int lookupsPerThread)
+    private RunOutcome runChild(
+            File lmdbDirectory,
+            Path childLog,
+            String scenario,
+            int concurrency,
+            int seconds,
+            int lookupsPerThread,
+            int readerThreads,
+            int warmupMillis)
             throws IOException, InterruptedException {
+        boolean closeRace = "closerace".equalsIgnoreCase(scenario);
         List<String> command = new ArrayList<>();
         command.add(javaBinary());
         command.add("-Xmx512m");
@@ -193,6 +229,12 @@ public class LmdbCrashReproDriverTest {
                         PROP_FORWARD_JACOCO);
             }
         }
+        // Forward the scenario (and its close-race parameters) to the child via -D.
+        command.add("-D" + LmdbReaderSlotChurnStressTest.PROP_SCENARIO + "=" + scenario);
+        if (closeRace) {
+            command.add("-D" + LmdbReaderSlotChurnStressTest.PROP_READER_THREADS + "=" + readerThreads);
+            command.add("-D" + LmdbReaderSlotChurnStressTest.PROP_WARMUP_MILLIS + "=" + warmupMillis);
+        }
         command.add("-cp");
         command.add(buildChildClasspath());
         command.add(LmdbReaderSlotChurnStressTest.class.getName());
@@ -206,8 +248,10 @@ public class LmdbCrashReproDriverTest {
         pb.redirectOutput(childLog.toFile());
 
         Process process = pb.start();
-        // Generous ceiling: child churn duration + JVM start/stop + fixture open.
-        long timeoutSeconds = (long) seconds + 90L;
+        // Generous ceiling: churn runs for `seconds`; closerace is bounded by warm-up + close +
+        // reader join. Cover both plus JVM start/stop and fixture open.
+        long childWorkSeconds = closeRace ? (warmupMillis / 1000L) + 10L : seconds;
+        long timeoutSeconds = childWorkSeconds + 90L;
         if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
             process.destroyForcibly();
             process.waitFor(15, TimeUnit.SECONDS);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbReaderSlotChurnStressTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/persistence/lmdb/LmdbReaderSlotChurnStressTest.java
@@ -107,13 +107,27 @@ public class LmdbReaderSlotChurnStressTest {
     public static final String PROP_NOLOCK = PROP_ENABLE + ".nolock";
     /** Raw mode only: {@code Env.Builder.setMaxReaders} (default 0 → leave lmdbjava default). */
     public static final String PROP_MAX_READERS = PROP_ENABLE + ".maxReaders";
+    /**
+     * Scenario selector: {@code churn} (steady-state reader-slot churn, the default) or
+     * {@code closerace} (close the env while reads are in flight — the actual issue #50 crash,
+     * a use-after-unmap: a consumer thread's {@code containsAddress} → {@code mdb_txn_begin}
+     * dereferences the LMDB mmap after {@code Env.close()} has unmapped it during shutdown).
+     */
+    public static final String PROP_SCENARIO = PROP_ENABLE + ".scenario";
+    /** {@code closerace} only: number of reader threads hammering {@code containsAddress}. */
+    public static final String PROP_READER_THREADS = PROP_ENABLE + ".readerThreads";
+    /** {@code closerace} only: warm-up before the env is closed, in ms (default 1000). */
+    public static final String PROP_WARMUP_MILLIS = PROP_ENABLE + ".warmupMillis";
 
     private static final int DEFAULT_CONCURRENCY = 128;
     private static final int DEFAULT_SECONDS = 20;
     private static final int DEFAULT_LOOKUPS_PER_THREAD = 1;
+    private static final int DEFAULT_READER_THREADS = 128;
+    private static final int DEFAULT_WARMUP_MILLIS = 1000;
     private static final int CORPUS_SIZE = 256;
     private static final int HASH160_BYTES = OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES;
     private static final int DRAIN_AWAIT_SECONDS = 60;
+    private static final int READER_JOIN_MILLIS = 2000;
 
     /**
      * Physical LMDB sub-database name, mirroring the private
@@ -140,6 +154,9 @@ public class LmdbReaderSlotChurnStressTest {
         Assumptions.assumeTrue(
                 Boolean.getBoolean(PROP_ENABLE),
                 "opt-in LMDB reader-slot churn test; enable with -D" + PROP_ENABLE + "=true");
+        Assumptions.assumeFalse(
+                "closerace".equalsIgnoreCase(System.getProperty(PROP_SCENARIO, "churn")),
+                "scenario=closerace selects the close-during-read test instead");
         new LMDBPlatformAssume().assumeLMDBExecution();
 
         final int concurrency = Integer.getInteger(PROP_CONCURRENCY, DEFAULT_CONCURRENCY);
@@ -187,6 +204,46 @@ public class LmdbReaderSlotChurnStressTest {
         assertThat("expected the churn loop to perform reads", result.reads > 0L, is(equalTo(true)));
     }
 
+    /**
+     * The actual issue #50 crash: close the LMDB env while reader threads are mid-{@code
+     * containsAddress}. A reader inside the native {@code mdb_txn_begin} when {@code Env.close()}
+     * unmaps the mmap dereferences freed memory → {@code SIGSEGV (SEGV_MAPERR)} in {@code
+     * mdb_txn_renew0}. <b>A reproduction crashes this JVM</b>; run it under {@code
+     * LmdbCrashReproDriverTest} (scenario=closerace) for a crash rate instead of a killed fork.
+     */
+    @Test
+    public void closeDuringRead_race_reproducesUseAfterUnmap() throws Exception {
+        Assumptions.assumeTrue(
+                Boolean.getBoolean(PROP_ENABLE),
+                "opt-in LMDB close-during-read test; enable with -D" + PROP_ENABLE + "=true");
+        Assumptions.assumeTrue(
+                "closerace".equalsIgnoreCase(System.getProperty(PROP_SCENARIO, "churn")),
+                "enable with -D" + PROP_SCENARIO + "=closerace");
+        new LMDBPlatformAssume().assumeLMDBExecution();
+
+        final int readerThreads = Integer.getInteger(PROP_READER_THREADS, DEFAULT_READER_THREADS);
+        final int warmupMillis = Integer.getInteger(PROP_WARMUP_MILLIS, DEFAULT_WARMUP_MILLIS);
+
+        File lmdbDirectory = buildTestLmdb(folder, persistenceUtils);
+        byte[][] corpus = buildHash160Corpus(CORPUS_SIZE);
+        LOGGER.info("closerace readerThreads={} warmupMillis={}", readerThreads, warmupMillis);
+
+        ChurnResult result =
+                runCloseDuringReadRace(lmdbDirectory, persistenceUtils, corpus, readerThreads, warmupMillis);
+
+        // If this JVM survived, no native crash occurred this run (the race did not land). Only
+        // UNEXPECTED Java throwables (not the benign post-close AlreadyClosedException) are failures.
+        LOGGER.info(
+                "closerace survived: {} reads across {} readers, {} unexpected Java-level errors",
+                result.reads,
+                result.threadsSpawned,
+                result.errors.size());
+        assertThat(
+                "close-during-read raised unexpected Java-level throwables: " + result.errors,
+                result.errors.isEmpty(),
+                is(equalTo(true)));
+    }
+
     // ------------------------------------------------------------------------------------------
     // Child-JVM entry point (forked by LmdbCrashReproDriverTest to get a crash rate).
     // ------------------------------------------------------------------------------------------
@@ -198,7 +255,10 @@ public class LmdbReaderSlotChurnStressTest {
      * {@code mdb_txn_renew0} crash kills this JVM with a non-zero / signal exit that the parent
      * driver counts.
      *
-     * <p>Args: {@code <lmdbDir> [concurrency] [seconds] [lookupsPerThread]}.
+     * <p>Args: {@code <lmdbDir> [concurrency] [seconds] [lookupsPerThread]}. The scenario and its
+     * close-race parameters come from system properties ({@link #PROP_SCENARIO},
+     * {@link #PROP_READER_THREADS}, {@link #PROP_WARMUP_MILLIS}) so the driver can forward them
+     * as {@code -D} flags.
      *
      * @param args the child parameters
      * @throws Exception if the LMDB cannot be opened
@@ -210,19 +270,106 @@ public class LmdbReaderSlotChurnStressTest {
             return;
         }
         File lmdbDirectory = new File(args[0]);
-        int concurrency = args.length > 1 ? Integer.parseInt(args[1]) : DEFAULT_CONCURRENCY;
-        int seconds = args.length > 2 ? Integer.parseInt(args[2]) : DEFAULT_SECONDS;
-        int lookupsPerThread = args.length > 3 ? Integer.parseInt(args[3]) : DEFAULT_LOOKUPS_PER_THREAD;
-
         Network net = new NetworkParameterFactory().getNetwork();
         PersistenceUtils utils = new PersistenceUtils(net);
         byte[][] corpus = buildHash160Corpus(CORPUS_SIZE);
 
-        ChurnResult result = runProdChurn(lmdbDirectory, utils, corpus, concurrency, seconds, lookupsPerThread);
-        System.out.println("child churn done: reads=" + result.reads
-                + " threadsSpawned=" + result.threadsSpawned
-                + " javaErrors=" + result.errors.size());
+        String scenario = System.getProperty(PROP_SCENARIO, "churn");
+        ChurnResult result;
+        if ("closerace".equalsIgnoreCase(scenario)) {
+            int readerThreads = Integer.getInteger(PROP_READER_THREADS, DEFAULT_READER_THREADS);
+            int warmupMillis = Integer.getInteger(PROP_WARMUP_MILLIS, DEFAULT_WARMUP_MILLIS);
+            result = runCloseDuringReadRace(lmdbDirectory, utils, corpus, readerThreads, warmupMillis);
+            System.out.println("child closerace done: reads=" + result.reads
+                    + " readers=" + result.threadsSpawned
+                    + " unexpectedJavaErrors=" + result.errors.size());
+        } else {
+            int concurrency = args.length > 1 ? Integer.parseInt(args[1]) : DEFAULT_CONCURRENCY;
+            int seconds = args.length > 2 ? Integer.parseInt(args[2]) : DEFAULT_SECONDS;
+            int lookupsPerThread = args.length > 3 ? Integer.parseInt(args[3]) : DEFAULT_LOOKUPS_PER_THREAD;
+            result = runProdChurn(lmdbDirectory, utils, corpus, concurrency, seconds, lookupsPerThread);
+            System.out.println("child churn done: reads=" + result.reads
+                    + " threadsSpawned=" + result.threadsSpawned
+                    + " javaErrors=" + result.errors.size());
+        }
         System.exit(result.errors.isEmpty() ? 0 : 3);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Close-during-read race (the actual issue #50 crash).
+    // ------------------------------------------------------------------------------------------
+
+    /**
+     * Reproduces issue #50: start {@code readerThreads} threads hammering the real
+     * {@code containsAddress} in tight loops, let them reach steady state, then close the env
+     * <b>while reads are still in flight</b> — exactly the {@code ConsumerJava.interrupt()}
+     * path where {@code awaitTermination} times out and {@code persistence.close()} runs with
+     * live readers. A reader inside the native {@code mdb_txn_begin} when {@code Env.close()}
+     * unmaps the mmap crashes this JVM with {@code SIGSEGV (SEGV_MAPERR)} in
+     * {@code mdb_txn_renew0}. If no reader is mid-native-call at the instant of close, the JVM
+     * survives and readers see the benign {@code AlreadyClosedException} (ignored here).
+     *
+     * <p>Deliberately uses raw {@link Thread}: readers must be genuinely concurrent with the
+     * close call, and {@link LMDBPersistence#close()} performs no reader coordination — that
+     * missing coordination is the bug.
+     */
+    @SuppressWarnings("CatchAndPrintStackTrace")
+    private static ChurnResult runCloseDuringReadRace(
+            File lmdbDirectory, PersistenceUtils persistenceUtils, byte[][] corpus, int readerThreads, int warmupMillis)
+            throws InterruptedException {
+        CLMDBConfigurationReadOnly config = new CLMDBConfigurationReadOnly();
+        config.lmdbDirectory = lmdbDirectory.getAbsolutePath();
+        LMDBPersistence persistence = new LMDBPersistence(config, persistenceUtils);
+        persistence.init();
+
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        final AtomicBoolean closing = new AtomicBoolean(false);
+        final AtomicLong reads = new AtomicLong();
+        final List<Throwable> errors = new CopyOnWriteArrayList<>();
+        final List<Thread> readers = new ArrayList<>(readerThreads);
+
+        for (int i = 0; i < readerThreads; i++) {
+            final long seed = i;
+            Thread reader = new Thread(
+                    () -> {
+                        final ByteBuffer key = ByteBuffer.allocateDirect(HASH160_BYTES);
+                        final Random random = new Random(seed);
+                        while (!stop.get()) {
+                            try {
+                                key.rewind();
+                                key.put(corpus[random.nextInt(corpus.length)]);
+                                key.flip();
+                                persistence.containsAddress(key);
+                                reads.incrementAndGet();
+                            } catch (Throwable t) {
+                                // After close() the env is gone: AlreadyClosedException (and friends)
+                                // are the EXPECTED Java-level outcome, not a defect. Only throwables
+                                // seen while the env is still open count as unexpected.
+                                if (!closing.get()) {
+                                    errors.add(t);
+                                }
+                                return;
+                            }
+                        }
+                    },
+                    "lmdb-reader-" + seed);
+            reader.setDaemon(true);
+            reader.start();
+            readers.add(reader);
+        }
+
+        // Let readers saturate the native mdb_txn_begin path before the race.
+        Thread.sleep(warmupMillis);
+
+        // THE RACE: close the env out from under live readers (no drain first — that is the bug).
+        closing.set(true);
+        persistence.close();
+
+        stop.set(true);
+        for (Thread reader : readers) {
+            reader.join(READER_JOIN_MILLIS);
+        }
+        return new ChurnResult(reads.get(), readerThreads, errors);
     }
 
     // ------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause of issue #50 identified and fixed: a close-during-read use-after-unmap, not the long-suspected reader-slot race.** `ConsumerJava.interrupt()` calls `persistence.close()` even when `awaitTermination` times out with a consumer still live. `LMDBPersistence.close()` → `Env.close()` unmaps the mmap while that straggler is inside `containsAddress → mdb_txn_begin`, so `mdb_txn_renew0` dereferences freed memory → `SIGSEGV (SEGV_MAPERR)` on Linux / `EXCEPTION_ACCESS_VIOLATION (0xC0000005)` on Windows.
- **Fix in `LMDBPersistence`** (the resource owner where the missing coordination lived): a `ReentrantReadWriteLock` + `volatile closed`. Point-lookups (`containsAddress`/`getAmount`) take the **read** lock across their whole native transaction; `close()` takes the **write** lock (so it waits for in-flight native reads and blocks new ones) and is now idempotent. A lookup arriving after close returns *absent* instead of touching the torn-down mmap. Scoped to the two point-lookups — the only ops that race with close on the scan path; the long full-DB iterations are never concurrent with a close and must not hold the read lock for a whole scan.
- **Diagnostic harness completed**: the `closerace` scenario (the actual crash) is wired through `LmdbReaderSlotChurnStressTest` + `LmdbCrashReproDriverTest` and the manual CI workflow, alongside the pre-existing `churn` negative control.

**Repro rate — before vs after the fix (closerace, Windows):**

| | native crashes |
|---|---|
| before fix | **5/5** |
| after fix | **0/5** (all children exit 0 / `CLEAN`) |

## Test plan

- [x] Affected unit / integration tests pass locally — `LMDBPersistenceTest` 49/49, `ConsumerJavaTest` 32/32, new `LMDBPersistenceCloseDuringReadTest` 4/4
- [x] New default-running regression test (`LMDBPersistenceCloseDuringReadTest`, gated only by `LMDBPlatformAssume`): post-close `containsAddress`/`getAmount` return absent without throwing, `close()` is idempotent, and a concurrent close-during-read survives cleanly
- [x] `closerace` reproduction driver: **0/5** after the fix (was 5/5)
- [x] `mvn compile` clean under Error Prone + NullAway; `spotless:apply` run
- [ ] CI is green on this branch

## Related issues / PRs

Closes #50. Builds on the reproduction harness from #313.

Upstream courtesy note left on lmdbjava/lmdbjava#253 (this is an application-side lifecycle bug — closing the `Env` with live readers — not an lmdbjava defect; noted for the benefit of others who hit the same `mdb_txn_renew0` crash).

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes