### PR TITLE
Upgrade logback-classic from 1.5.32 to 1.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,7 +497,7 @@ No other sibling repo has OpenCL code, so this distinction is BAF-only.
 | `jeromq` | 0.6.0 | ZeroMQ producer |
 | `jspecify` | 1.0.0 | Nullness annotations |
 | `slf4j-api` | 2.0.18 | Logging facade |
-| `logback-classic` | 1.5.32 | SLF4J implementation |
+| `logback-classic` | 1.6.0 | SLF4J implementation |
 
 Test-only:
 | `junit-jupiter` | 6.0.3 | JUnit 6 (Jupiter) test framework |


### PR DESCRIPTION
## Summary

- Upgrade `logback-classic` dependency from 1.5.32 to 1.6.0 in CLAUDE.md
- This is a minor version bump that brings bug fixes and improvements to the SLF4J implementation

## Test plan

- [x] CI is green on this branch
- [x] No code changes required; dependency version update only

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_011AbombALVWxqqmYB7mF1kD