### PR TITLE
Fix the CI failures from #320: SpotBugs findings and a GPU-only assumption on pocl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TuneConfiguration`); only the rendered field changed.
 
 ### Fixed
+- **CI on `main` was red after the multi-GPU merge** — two independent failures, both reachable
+  locally and neither run before merging. `spotbugs:check` reported 14 findings in the new code; ten
+  were fixed properly (a defensive copy in `DeviceSweep`, wider parameter types, exception messages
+  that name the device and the counts, literal format strings, an empty array instead of `null`) and
+  four are suppressed with rationale, following the precedent already in `spotbugs-exclude.xml`.
+  Separately, `run_noProducerConfiguredButGpuPresent_sweepsTheDetectedDevices` failed on the pocl CI
+  job: an OpenCL device is not necessarily a GPU, and auto-discovery deliberately sweeps GPUs only,
+  so the test asked the tuner to find something correctly filtered out. It now assumes a GPU-type
+  device via the existing `hasGpuOpenCLDevice()` helper.
 - **Auto-discovered devices are swept with the GPU pre-filter on** — they inherited
   `CProducerOpenCL`'s default of `false`, which caused three faults at once: the filter payload the
   tuner builds for `targetDatabaseEntries` was thrown away unused, the sweep measured full-transfer

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1322,4 +1322,38 @@ SPDX-License-Identifier: Apache-2.0
         <Bug pattern="IMC_IMMATURE_CLASS_NO_EQUALS"/>
     </Match>
 
+    <!--
+        EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS on
+        TuneConfiguration.templatesForDevices / giveEveryProducerItsOwnKeyProducer.
+        Both wrap Jackson's checked JsonProcessingException in an IllegalStateException.
+        They serialise and re-read configuration POJOs this project owns and populates
+        itself, with no external input involved, so a failure means the POJO shape and
+        the mapper have gone out of step: a programming error, not a runtime condition
+        a caller could handle. Declaring the checked exception would push it up through
+        the sweep into run(), which cannot do anything with it either. The messages name
+        the device and indices so the report says which copy failed.
+    -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.command.TuneConfiguration"/>
+        <Or>
+            <Method name="templatesForDevices"/>
+            <Method name="giveEveryProducerItsOwnKeyProducer"/>
+        </Or>
+        <Bug pattern="EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS"/>
+    </Match>
+
+    <!--
+        ENMI_ONE_ENUM_VALUE on ConsumerJava$AbsentAddressPresence.
+        A single-element enum is the standard way to express a stateless singleton in
+        Java: it is serialisation-safe and cannot be instantiated a second time. The
+        type answers "absent" for every address when address lookup is disabled and no
+        database is opened, so a second constant would have no meaning. Replacing it
+        with a static final field of an anonymous class would trade a documented idiom
+        for a weaker guarantee purely to satisfy the detector.
+    -->
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.consumer.ConsumerJava$AbsentAddressPresence"/>
+        <Bug pattern="ENMI_ONE_ENUM_VALUE"/>
+    </Match>
+
 </FindBugsFilter>

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfiguration.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfiguration.java
@@ -284,7 +284,20 @@ public class TuneConfiguration implements Runnable, Interruptable {
     public record DeviceSweep(
             String deviceLabel,
             List<ArmResult> arms,
-            @Nullable ArmResult winner) {}
+            @Nullable ArmResult winner) {
+
+        /**
+         * Copies the arm list so the record cannot be mutated through the reference it was built
+         * from — the sweep hands in a live slice of its own accumulator.
+         *
+         * @param deviceLabel how the device is identified in the report
+         * @param arms        the arms measured on this device, in measurement order
+         * @param winner      the best arm on this device, or {@code null} if none succeeded
+         */
+        public DeviceSweep {
+            arms = List.copyOf(arms);
+        }
+    }
 
     /**
      * Returns the per-arm results, one entry per swept candidate pair, in sweep order.
@@ -1121,7 +1134,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
      * @return the rendered section (terminated by a newline), or an empty string for a single device
      */
     @VisibleForTesting
-    static String renderPerDeviceWinners(List<DeviceSweep> deviceSweeps) {
+    static String renderPerDeviceWinners(Collection<DeviceSweep> deviceSweeps) {
         if (deviceSweeps.size() < 2) {
             return "";
         }
@@ -1418,13 +1431,16 @@ public class TuneConfiguration implements Runnable, Interruptable {
      * @return one template per device, independent of the prototype and of each other
      */
     @VisibleForTesting
-    static List<CProducerOpenCL> templatesForDevices(List<DetectedDevice> devices, CProducerOpenCL prototype) {
+    static List<CProducerOpenCL> templatesForDevices(Iterable<DetectedDevice> devices, CProducerOpenCL prototype) {
         ObjectMapper mapper = configurationMapper();
         String serialisedPrototype;
         try {
             serialisedPrototype = mapper.writeValueAsString(prototype);
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Failed to copy the producer template for multi-device tuning", e);
+            throw new IllegalStateException(
+                    "Failed to serialise the producer template for multi-device tuning (platformIndex="
+                            + prototype.platformIndex + ", deviceIndex=" + prototype.deviceIndex + ")",
+                    e);
         }
         List<CProducerOpenCL> templates = new ArrayList<>();
         for (DetectedDevice device : devices) {
@@ -1435,7 +1451,10 @@ public class TuneConfiguration implements Runnable, Interruptable {
                 templates.add(copy);
             } catch (JsonProcessingException e) {
                 throw new IllegalStateException(
-                        "Failed to copy the producer template for device " + device.deviceName(), e);
+                        "Failed to copy the producer template for device " + device.deviceName()
+                                + " (platformIndex=" + device.platformIndex() + ", deviceIndex="
+                                + device.deviceIndex() + ")",
+                        e);
             }
         }
         return templates;
@@ -1536,7 +1555,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
      * lower bound, which is precisely what the extension exists to prevent. A single-GPU machine
      * cannot show this, because there the global winner and the device winner are the same arm.
      *
-     * @param deviceArms                  the arms measured on this device, in measurement order
+     * @param deviceArms                  the arms measured on this device
      * @param largestSweptKeysPerWorkItem the largest {@code keysPerWorkItem} measured on it
      * @param largestSweptBatchSizeInBits the largest {@code batchSizeInBits} measured on it
      * @param openCl                      whether the swept producer is GPU-backed
@@ -1544,7 +1563,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
      */
     @VisibleForTesting
     static @Nullable SweepExtension nextExtensionArmForDevice(
-            List<ArmResult> deviceArms,
+            Collection<ArmResult> deviceArms,
             int largestSweptKeysPerWorkItem,
             int largestSweptBatchSizeInBits,
             boolean openCl) {
@@ -1723,8 +1742,10 @@ public class TuneConfiguration implements Runnable, Interruptable {
         }
         throw new IllegalArgumentException(
                 "tuneConfiguration.finder has no producerOpenCL or producerJava entry and no OpenCL GPU could be"
-                        + " detected to sweep automatically. Configure a producer, or install an OpenCL runtime"
-                        + " and verify it with the OpenCLInfo command.");
+                        + " detected to sweep automatically (OpenCL native library loaded: "
+                        + OpenCLBuilder.isOpenClNativeLibraryLoaded()
+                        + "). Configure a producer, or install an OpenCL runtime and verify it with the OpenCLInfo"
+                        + " command.");
     }
 
     /**
@@ -1859,7 +1880,10 @@ public class TuneConfiguration implements Runnable, Interruptable {
         }
         throw new IllegalArgumentException(
                 "tuneConfiguration.finder needs at least one key producer (for example keyProducerJavaRandom) so the"
-                        + " automatically detected devices have a source of secrets to measure with.");
+                        + " automatically detected devices have a source of secrets to measure with. Configured:"
+                        + " keyProducerJavaRandom=" + cFinder.keyProducerJavaRandom.size()
+                        + ", keyProducerJavaIncremental=" + cFinder.keyProducerJavaIncremental.size()
+                        + ", keyProducerJavaBip39=" + cFinder.keyProducerJavaBip39.size() + ".");
     }
 
     /**

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDeviceTopology.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDeviceTopology.java
@@ -124,9 +124,10 @@ public final class OpenCLDeviceTopology {
      * @param device the device to query
      * @param param  the {@code cl_device_info} parameter name
      * @param bytes  the expected payload size
-     * @return the payload, or {@code null} when the driver rejected the query
+     * @return the payload, or an empty array when the driver rejected the query — the parsers below
+     *     reject it on length, so an empty array and a refusal are the same outcome without a null
      */
-    private static byte @Nullable [] query(OpenCLDevice device, int param, int bytes) {
+    private static byte[] query(OpenCLDevice device, int param, int bytes) {
         try {
             byte[] payload = new byte[bytes];
             // A length-1 array receives the number of bytes actually written; the value is unused,
@@ -137,7 +138,7 @@ public final class OpenCLDeviceTopology {
         } catch (RuntimeException | LinkageError e) {
             // Any driver/JOCL failure: treat the identity as unknown so the device is kept, never
             // merged. De-duplication is a best-effort optimisation, not a correctness requirement.
-            return null;
+            return new byte[0];
         }
     }
 

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/statistics/Statistics.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/statistics/Statistics.java
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.statistics;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -144,7 +145,17 @@ public class Statistics {
     private static String withSignificantDigits(double scaled) {
         int integerDigits = (int) Math.floor(Math.log10(scaled)) + 1;
         int decimals = Math.max(0, SIGNIFICANT_DIGITS - integerDigits);
-        return String.format(java.util.Locale.ROOT, "%." + decimals + "f", scaled);
+        // A literal format string per branch, rather than one assembled from `decimals` or looked up
+        // in an array. Both of those are still "computed" to a static analyser even when every input
+        // is our own arithmetic, and spelling the three cases out documents the only shapes this
+        // produces: a value scaled into its unit lies in [1, 1000), so it has one to three integer
+        // digits.
+        return switch (decimals) {
+            case 0 -> String.format(Locale.ROOT, "%.0f", scaled);
+            case 1 -> String.format(Locale.ROOT, "%.1f", scaled);
+            case 2 -> String.format(Locale.ROOT, "%.2f", scaled);
+            default -> String.format(Locale.ROOT, "%.3f", scaled);
+        };
     }
 
     /**
@@ -187,7 +198,7 @@ public class Statistics {
         if (total <= 0L) {
             return "";
         }
-        return String.format(java.util.Locale.ROOT, " (%.1f%%)", generated * 100.0d / total);
+        return String.format(Locale.ROOT, " (%.1f%%)", generated * 100.0d / total);
     }
 
     /**
@@ -228,6 +239,6 @@ public class Statistics {
             return "";
         }
         double prunedPercent = (1.0 - lookupsPerSecond / potentialLookups) * 100.0;
-        return String.format(java.util.Locale.ROOT, ", %.2f%% pre-filtered", prunedPercent);
+        return String.format(Locale.ROOT, ", %.2f%% pre-filtered", prunedPercent);
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfigurationTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfigurationTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.util.List;
@@ -140,6 +141,13 @@ public class TuneConfigurationTest extends LMDBBase {
     public void run_noProducerConfiguredButGpuPresent_sweepsTheDetectedDevices() {
         // arrange
         new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+        // An OpenCL device is not necessarily a GPU, and auto-discovery deliberately sweeps only
+        // GPUs — a CPU runtime duplicates producerJava. The project's own OpenCL CI job runs on
+        // pocl, which exposes exactly one CPU device, so without this the test asks the tuner to
+        // discover something that is correctly filtered out and fails on its own premise.
+        assumeTrue(
+                new OpenCLPlatformAssume().hasGpuOpenCLDevice(),
+                "auto-discovery sweeps GPUs only; this OpenCL runtime exposes no GPU device");
         CTuneConfiguration cTuneConfiguration = cpuTuneConfiguration();
         cTuneConfiguration.finder.producerJava.clear();
         cTuneConfiguration.batchSizeInBitsCandidates =


### PR DESCRIPTION
## Summary

Fixes the two failures that turned `main` red immediately after #320. They are unrelated to each other, and both were reachable on a developer machine — I verified #320 with `mvn test`, `spotless:check` and `reuse lint`, and never once with `spotbugs:check`.

- **SpotBugs: 14 findings → 0.** Ten are fixed rather than silenced; four are suppressed with rationale, following the precedent already in `spotbugs-exclude.xml`.
- **One test failed on the pocl CI job** because it assumed "an OpenCL device is available" where it needed "a GPU is available". Auto-discovery deliberately sweeps GPUs only — pocl exposes a CPU device — so the test asked the tuner to find something it correctly filters out.

## What was actually wrong

| Finding | The real defect |
|---|---|
| `EI_EXPOSE_REP` / `REP2` | `DeviceSweep` took a **live slice of the sweep's own accumulator** and handed the same list back out. Its compact constructor now copies. |
| `OCP_OVERLY_CONCRETE` ×3 | Parameters widened to `Collection` / `Iterable` — all the bodies ever needed. |
| `WEM_WEAK_EXCEPTION` ×3 | Exceptions now carry the device, the platform/device indices or the configured key-producer counts instead of a fixed sentence. |
| `FORMAT_STRING_MANIPULATION` | `withSignificantDigits` assembled `"%." + decimals + "f"`. A `switch` over literal formats also spells out that only three shapes exist. |
| `PZLA_PREFER_ZERO_LENGTH_ARRAYS` | The device-info query returned `null` on refusal; an empty array is rejected by the same length checks, so the `null` bought nothing. |

Suppressed with rationale: three `EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS` where Jackson's checked exception is wrapped while serialising POJOs this project owns end to end — a failure there means the POJO shape and the mapper have gone out of step, a programming error no caller could act on — and one `ENMI_ONE_ENUM_VALUE` for a stateless singleton, where a second constant would have no meaning.

## The test failure is the better lesson

`run_noProducerConfiguredButGpuPresent_sweepsTheDetectedDevices` was guarded only by *an OpenCL 2.0+ device is available*. But an OpenCL device is not necessarily a GPU, and excluding CPU runtimes from auto-discovery is deliberate and tested behaviour — a CPU runtime duplicates what `producerJava` already does. This project's own OpenCL CI job runs on **pocl**, which exposes exactly one **CPU** device.

So the test failed on its own premise, not on the behaviour under test. It now also assumes `hasGpuOpenCLDevice()` — a helper that already existed in `OpenCLPlatformAssume` and that I did not look for.

## Test plan

- [x] `spotbugs:check` reports **0 bugs** (was 14), reproduced locally with the same command the `code-style` job uses: `mvn -DskipTests -Denforcer.skip=true compile spotbugs:check`
- [x] 127 tests pass across `TuneConfigurationTest`, `StatisticsTest`, `OpenCLDeviceTopologyTest`, `ConsumerJavaTest`, `ConfigFixturesParseTest` and the architecture rules
- [x] `spotbugs-exclude.xml` parses as XML — a malformed filter silently disables *every* suppression
- [x] REUSE 487/487, `spotless:check` clean
- [ ] CI is green on this branch

Not verified here: the pocl job itself. There is no pocl runtime on this machine, so the assumption fix is reasoned from pocl exposing `CL_DEVICE_TYPE_CPU` and from the failure message, not observed. **This is exactly the class of gap that produced the bug**, so it is worth watching the `test-opencl` job on this branch rather than assuming.

## Related issues / PRs

Refs #320

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes
