### PR TITLE
chore: update GitHub Actions to v7

### DIFF
--- a/.github/workflows/measurement-tools.yml
+++ b/.github/workflows/measurement-tools.yml
@@ -32,7 +32,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # The version matters: register_machine.py is written for a contributor's own machine, so it
       # must keep working on whatever Python a distribution ships, not only on the newest. 3.9 is the
@@ -40,7 +40,7 @@ jobs:
       # needs `from __future__ import annotations` to parse there — this matrix is what keeps that
       # true rather than assumed.
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v5 to v7
- Update `actions/setup-python` from v6 to v7

These are routine maintenance updates to keep CI dependencies current with the latest stable versions.

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

None

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01MeheJtyQwUzJGLcYpyWURD