### PR TITLE
docs: clarify jqwik policy reference and Maven wrapper absence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ The central design separates **key production** from **address checking**:
 | `LMDBToAddressFile.java` | Exports LMDB database to address files |
 | `NetworkParameterFactory.java` | Creates BitcoinJ `NetworkParameters` for 100+ coins |
 | `SeparatorFormat.java` | Parses address file formats (various separators) |
-| `Shutdown.java` | Graceful shutdown logic with 30-second timeout |
+| `Shutdown.java` | Shutdown contract (marker interface, `void shutdown()`) implemented by components that need a graceful stop |
 
 ### Key Producer Strategies (`keyproducer/`)
 
@@ -324,7 +324,7 @@ See `examples/config_*.json` for all configuration variants.
   ```
   -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true
   ```
-- Test ratio is approximately 1.7:1 (test lines to source lines). New code should have corresponding tests.
+- Test ratio is approximately 1.5:1 (~1.55:1, test lines to source lines). New code should have corresponding tests.
 
 ### Test execution policy for AI assistants
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,8 @@ SPDX-License-Identifier: Apache-2.0
              coding agents at all." 1.9.3 is the last pre-disclosure release
              and is the pinned version for this repo. Any CI / Dependabot /
              contributor PR that bumps this MUST be rejected. See CLAUDE.md
-             section "jqwik prompt-injection in test output" for full context. -->
+             section "## jqwik Policy" (which defers to the workspace jqwik
+             policy) for full context. -->
         <jqwik.version>1.9.3</jqwik.version>
         <archunit.version>1.4.2</archunit.version>
         <spotbugs.version>4.10.3.0</spotbugs.version>
@@ -1154,8 +1155,9 @@ SPDX-License-Identifier: Apache-2.0
                 Builds the fat (jar-with-dependencies) jar for shipping the CLI.
                 Off by default because the assembly step is expensive and only
                 needed when packaging a runnable artifact, not during inner-loop
-                builds. Documented in CLAUDE.md "Build Commands" as
-                `./mvnw package -P assembly`.
+                builds. Documented in CLAUDE.md under "Build System" >
+                "Common Commands" as `mvn package -P assembly` (this repo
+                has no Maven wrapper, so `./mvnw` does not exist).
             -->
             <id>assembly</id>
             <build>


### PR DESCRIPTION
## Summary

- Updated `pom.xml` comment to reference the workspace jqwik policy section in CLAUDE.md (§ "## jqwik Policy") instead of a non-existent section title
- Corrected assembly profile documentation to reflect that this repo has no Maven wrapper (`./mvnw` does not exist; use `mvn` directly)
- Updated `CLAUDE.md` to clarify `Shutdown.java` as a marker interface contract rather than implementation details
- Refined test ratio metric from "approximately 1.7:1" to "approximately 1.5:1 (~1.55:1)" for accuracy

## Test plan

N/A — documentation and comment-only changes with no functional impact.

## Related issues / PRs

None

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_018WUx9TF8QGQf6efgG5TkHi