### PR TITLE
feat: LWJGL OpenCL binding, a shutdown that terminates, and result broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Results can be broadcast, not just logged** — one message per *checked batch*, sent whether or
+  not anything was found. Reporting only hits would leave a client unable to tell "range checked,
+  nothing there" from "range never checked", which makes an automated from/to sweep unsafe: a range
+  still queued when the process stops looks exactly like a clean one. The event is emitted after the
+  batch has been checked, so it doubles as an exact completion signal. Available over all three
+  existing transports, each off by default (`broadcastResults`), and each with different limits — the
+  WebSocket serves both directions on one port and can catch up a client that connected early;
+  ZeroMQ needs a second address (a `PULL` socket cannot send) and cannot detect subscribers at all,
+  so it republishes the grid configuration periodically; plain TCP gets its own port and
+  newline-delimited framing, because its inbound side reads fixed-width records from a single peer.
+  **The payload contains private keys and every connected client receives every result.**
+- **`examples/websocket_scanner.html`** — the browser as the whole user interface: it produces the
+  ranges and displays the outcome over one connection. Defragmenter-style range map (in flight /
+  checked / hit) plus a 256-bit view showing the base bits and the swept batch bits. It derives its
+  step from the grid configuration the server announces, which is what keeps a systematic sweep from
+  silently rescanning one block: the server aligns every incoming base down to a multiple of
+  `2^batchSizeInBits`. Paired with `examples/config_Find_WebSocketUi.json`, which sets
+  `timeoutMillis: -1` so a pause in the UI does not end the run.
 - **Second contributed multi-GPU machine in the measurement registry** —
   `tuner_ryzen9800x3d_dualgpu.csv` carries all 73 arms of an RX 7900 XTX plus an integrated gfx1036,
   measured through the GPU-filtered pipeline with the shipped default candidates: **190.4 M keys/s**
@@ -70,6 +88,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single GPU.
 
 ### Changed
+- **The OpenCL binding moved from JOCL to LWJGL 3** (`org.lwjgl:lwjgl` + `lwjgl-opencl` 3.4.2);
+  `org.jocl` is gone from the build. Calls no longer reach the binding directly: a new
+  `opencl/binding/` package carries an instance-based `ClApi` (mockable, unlike the binding's static
+  surface), typed handle records restoring the per-object types LWJGL collapses into a bare `long`,
+  and explicit error checking — LWJGL only *returns* `cl_int` codes and never throws, so an unchecked
+  call would fail silently. Three consequences are worth knowing:
+  - **A stock Linux install would not have started.** LWJGL resolves the library by plain name, but
+    an OpenCL runtime package ships only the versioned SONAME `libOpenCL.so.1`; the unversioned
+    symlink comes from the separate development package. JOCL never noticed, its JNI shim being
+    linked against the SONAME. `OpenClLibraryLoader` therefore tries a fallback name chain,
+    reproduced in a container carrying `pocl-opencl-icd` and nothing else.
+  - **Host-to-device uploads are written in bounded slices** (`ClApi.writeBufferChunked`) instead of
+    a `CL_MEM_COPY_HOST_PTR` allocation. LWJGL cannot hand a Java array to the driver, so a
+    single-shot upload would need an off-heap staging copy the size of the payload — several
+    gigabytes for the Full-DB 16-bit filter, whose byte image does not even fit a Java `byte[]`.
+  - **The fat jar stays a single jar.** LWJGL ships one `natives-*` classifier per platform, but all
+    nine may sit on one classpath and it picks the match at runtime, so no classifier split is
+    needed.
 - **The documented iGPU interference figure is qualified, not a single number** — `docs/tuning-your-gpu.md`
   cited "~3×" from one laptop pair (Intel Arc next to an RTX 500 Ada). A desktop pair (AMD gfx1036 next
   to an RX 7900 XTX) measured ~1.5×. Both are now shown side by side with the advice to measure your
@@ -89,6 +125,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TuneConfiguration`); only the rendered field changed.
 
 ### Fixed
+- **A run fed by a blocking key producer could not be shut down** — `Finder.interrupt()` waited for
+  the producers to stop *before* waking the key producers. A producer waiting for its next secret is
+  parked inside the key producer, and one configured to block indefinitely (`timeoutMillis: -1`,
+  which is what an interactively driven source wants) only releases that wait when interrupted — so
+  the wake-up came after the wait it was supposed to end, and every shutdown stalled until
+  `shutdownTimeoutSeconds` ran out. Key producers are now interrupted first.
+- **A finished run logged `Main#run end.` and then never exited** — reported for incremental scans,
+  reproduced here for a GPU producer, for `runOnce`, and for a merely *configured* socket / websocket
+  / ZeroMQ key producer even on the CPU path. The completion path stopped the producers but never
+  released what they own, so a producer's result-reader pool and the key producers' reader threads —
+  all non-daemon — kept the JVM alive; a thread dump showed exactly `maxResultReaderThreads` idle
+  workers parked in `LinkedBlockingQueue.take()` with `DestroyJavaVM` waiting on them. Releasing them
+  happened only in `Finder.interrupt()`, which on that path was reached solely from the JVM shutdown
+  hook — and a shutdown hook cannot run until every non-daemon thread has already ended, so the
+  release that would have ended them was unreachable. The teardown now runs on the completion path
+  itself. Note that `runOnce` is not a workaround and never was: it runs `produceKeys()` once, which
+  is one *batch*, not one range.
+- **Two overlapping teardowns released the same producer twice** — surfaced by the fix above, since
+  the teardown now runs both on the completion path and from the shutdown hook, and a `Ctrl+C`
+  landing while a finished run releases its producers is enough to overlap them. Each caller read the
+  producer list before either had cleared it, and the second release of an OpenCL producer is
+  rejected by the driver with `CL_INVALID_MEM_OBJECT`, ending an otherwise successful run with a
+  fatal error. The "release each producer exactly once" guarantee was implicit in the order of a loop
+  and a list-clear; it is now an object of its own (`ProducerReleaser`, tracking producers by
+  identity), which is also what made it statable as a test.
 - **CI on `main` was red after the multi-GPU merge** — two independent failures, both reachable
   locally and neither run before merging. `spotbugs:check` reported 14 findings in the new code; ten
   were fixed properly (a defensive copy in `DeviceSweep`, wider parameter types, exception messages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ The central design separates **key production** from **address checking**:
 | `cli/Main.java` | Entry point; parses args, loads config, starts `Finder` |
 | `Finder.java` | Orchestrator; starts/stops producers and consumer |
 | `ProducerJava.java` | CPU-based key generator using `KeyProducer` strategies |
-| `ProducerOpenCL.java` | GPU-accelerated key generator via JOCL |
+| `ProducerOpenCL.java` | GPU-accelerated key generator via LWJGL |
 | `ProducerJavaSecretsFiles.java` | Reads keys from a secrets file |
 | `ConsumerJava.java` | Derives addresses, queries LMDB, logs hits |
 | `PublicKeyBytes.java` | Public key representation and address derivation |
@@ -445,7 +445,83 @@ OpenCL kernels live in `src/main/resources/` as `.cl` and `.h` files:
 | `inc_platform.cl` | Platform-specific abstractions |
 | `inc_types.h` | OpenCL type definitions |
 
-GPU code is bound through JOCL (`jocl` 2.0.6). `OpenCLBuilder` constructs the platform/device hierarchy; `OpenCLContext` manages kernel compilation and execution; `OpenClTask` processes a batch of keys on the GPU.
+GPU code is bound through **LWJGL 3** (`lwjgl` + `lwjgl-opencl` 3.4.2). Every call into the binding
+goes through the `opencl/binding/` seam — never directly:
+
+| Type | Role |
+|---|---|
+| `ClApi` / `LwjglClApi` | instance-based OpenCL surface; the only class calling `org.lwjgl` directly |
+| `ClHandle` + `ClContext`/`ClMem`/`ClKernel`/… | typed handle records; LWJGL models every OpenCL object as a bare `long`, so these restore the per-object types the compiler needs |
+| `ClErrorChecker` / `ClErrorCodeResolver` | LWJGL only *returns* `cl_int` codes and never throws, so every call is checked here and raised as `OpenClCallFailedException` |
+| `OpenClLibraryLoader` | loads the native library with a fallback name chain — a stock Linux runtime ships only `libOpenCL.so.1`, and LWJGL's plain-name lookup would fail on it |
+| `ClDeviceInfoFormatter` | renders `cl_device_type` / fp-config / queue-property bit fields, which LWJGL has no equivalent for |
+
+Above that seam: `OpenCLBuilder` constructs the platform/device hierarchy; `OpenCLContext` manages
+kernel compilation and execution; `OpenClTask` processes a batch of keys on the GPU.
+
+**Host-to-device transfers go through `ClApi.writeBufferChunked`, not `CL_MEM_COPY_HOST_PTR`.**
+LWJGL cannot pass a Java array to the driver — only direct NIO buffers — so a single-shot upload
+would need an off-heap staging copy as large as the payload. The fingerprint filters reach multiple
+gigabytes (the Full-DB 16-bit filter's byte image does not even fit a Java `byte[]`), so uploads are
+written in bounded slices through a small reusable staging buffer instead.
+
+---
+
+## Result broadcast (`core` seam + `keyproducer` transports)
+
+Results leave the process by two routes: the log, which stays the authoritative record, and an
+optional broadcast to connected clients.
+
+**One event per checked batch — reported whether or not anything was found.** That is the whole
+design decision. Reporting only hits would leave a client unable to tell *"range checked, nothing
+there"* from *"range never checked"*, and those two look identical after a shutdown drops a queued
+range. Because the event is emitted after the batch has been checked against the database, it is
+also an exact completion signal: no dispatch-ahead lag to compensate for.
+
+| Type | Layer | Role |
+|---|---|---|
+| `ResultListener` | `core` | the seam; one method, `onBatchChecked(BatchResult)` |
+| `BatchResult` / `Hit` | `core` | payload; plain JDK types only |
+| `QueuedBatch` | `consumer` | carries the batch's `secretBase` to the check |
+| `BatchResultJsonFormatter` | `keyproducer` | the wire format, defined once for all transports |
+| `WebSocketResultBroadcaster` | `keyproducer` | shares the key producer's server — one port, both directions |
+| `ZmqResultBroadcaster` | `keyproducer` | own `PUB` socket on its own address |
+| `SocketResultBroadcaster` | `keyproducer` | own accept loop, newline-delimited JSON |
+
+**Why the types live in `core` and the transports in `keyproducer`.** `Consumer` must not depend on
+`keyproducer` (layering), and `core` may not depend on `model` — so the payload is built from JDK
+types in `core`, which both sides may see. `Finder` constructs the transports and hands them to the
+consumer as `ResultListener`. No architecture rule had to be changed for any of this.
+
+**The grid configuration is announced late, on purpose.** A client needs `batchSizeInBits` to know
+its step: the server aligns every incoming base down to a multiple of `2^batchSizeInBits`, so a
+client stepping by less resubmits one block forever while the rest of its range is never touched —
+silently, since nothing rejects a misaligned base. But the servers accept connections in
+`startKeyProducer()`, before `configureProducer()` exists to say what the grid is. Each transport
+therefore catches up as best it can (see the table below). When producers disagree on
+`batchSizeInBits`, the largest is announced — the only value that cannot make ranges overlap.
+
+### What each transport can and cannot promise
+
+| | WebSocket | ZeroMQ | plain TCP |
+|---|---|---|---|
+| Directions on one port | **yes** | no — `PULL` cannot send, so a second address | no — different framing per direction |
+| Greet on connect | yes | **impossible** (`PUB` has no connect event) | yes, on accept |
+| Catch up an early client | yes | only by republishing (every 64 batches) | yes |
+| Late joiner | fine | **misses messages** (slow joiner) | fine |
+
+Delivery is best-effort everywhere: a client not connected when a batch completes misses that
+message and nothing replays it.
+
+**Security.** The payload contains **private keys**, and every connected client receives every
+result — including hits from ranges somebody else submitted. Each transport is off by default
+(`broadcastResults`).
+
+**Configuration.** `keyProducerJavaWebSocket.broadcastResults` (same port);
+`keyProducerJavaZmq.broadcastResults` + `publishAddress`; `keyProducerJavaSocket.broadcastResults` +
+`resultPort`. For an interactively fed run set `timeoutMillis: -1` — with a positive timeout a pause
+in the UI raises `NoMoreSecretsAvailableException`, which ends the producer permanently. See
+`examples/config_Find_WebSocketUi.json` and `examples/websocket_scanner.html`.
 
 ---
 
@@ -489,7 +565,7 @@ No other sibling repo has OpenCL code, so this distinction is BAF-only.
 | `jsr305` | 3.0.2 | Findbugs nullability annotations (bitcoinj transitive, runtime) |
 | `jcip-annotations` | 1.0 | JCIP concurrency annotations (bitcoinj transitive, runtime) |
 | `lmdbjava` | 0.9.3 | LMDB database bindings |
-| `jocl` | 2.0.6 | Java OpenCL bindings |
+| `lwjgl` / `lwjgl-opencl` | 3.4.2 | Java OpenCL bindings (plus per-platform `natives-*` classifiers) |
 | `jackson-databind` | 2.22.1 | JSON config parsing |
 | `jackson-dataformat-yaml` | 2.22.1 | YAML config parsing |
 | `guava` | 33.6.0-jre | Google core utilities |
@@ -602,7 +678,8 @@ Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:
 ## Fat-jar release assets
 
 The runnable fat jar (`bitcoinaddressfinder-<version>-jar-with-dependencies.jar`) is a
-**GitHub-Release asset only — never Maven Central** (a jocl-bundled single jar, so no classifier
+**GitHub-Release asset only — never Maven Central** (all LWJGL `natives-*` classifiers coexist on
+one classpath, so it stays a single jar with no classifier
 split), attached with a detached GPG `.asc`. The publish jobs build + sign it off-Central via a
 second `mvn -P release,assembly verify` (which stops before `deploy`, so `central-publishing` never
 uploads it). The cross-repo convention + per-repo shapes are documented in

--- a/README.md
+++ b/README.md
@@ -1357,6 +1357,8 @@ Useful for piping externally generated secrets (e.g., from Python, Go, etc.) dir
 | `timeoutMillis`               | number                           | `3000`        | Socket timeout in milliseconds, applied to accept (server), connect (client) and per-read. Must be non-negative |
 | `logReceivedSecret`           | boolean                          | `false`       | Whether to log each received private key as a hex string                            |
 | `connectRetryCount`           | number                           | `5`           | Number of times to retry establishing a socket connection (client mode)             |
+| `broadcastResults`            | boolean                          | `false`       | Serve the outcome of every checked batch on `resultPort` (see below)                |
+| `resultPort`                  | number                           | `5556`        | TCP port the result server binds to, used only when `broadcastResults` is set       |
 | `connectRetryDelayMillis`     | number                           | `1000`        | Delay between connection retry attempts (in milliseconds)                           |
 | `maxWorkSize`                 | number                           | `16777216`    | Maximum number of secrets to request in a single call                               |
 
@@ -1438,6 +1440,8 @@ Ideal for decoupled key streaming where producers push keys using ZeroMQ `PUSH` 
 | mode               | string enum (BIND, CONNECT)  | BIND                   | Whether this socket binds to or connects    |
 | timeoutMillis      | number                       | `-1`                   | Receive timeout in milliseconds:<br> `0` = non-blocking,<br> `-1` = infinite,<br> `>0` = wait that long |
 | logReceivedSecret  | boolean                      | false                  | Whether to log each received secret in hex  |
+| broadcastResults   | boolean                      | false                  | Publish the outcome of every checked batch (see below) |
+| publishAddress     | string                       | tcp://127.0.0.1:5558   | Address the result `PUB` socket binds to, used only when `broadcastResults` is set |
 
 Minimal:
 ```jsonc
@@ -1465,6 +1469,68 @@ Full:
 ],
 // ...
 ```
+
+
+#### 🌐 WebSocket (`keyProducerJavaWebSocket`)
+Receive raw private keys from a WebSocket server embedded in the finder. With
+`broadcastResults` enabled the same port also carries the results back, which is what lets a browser
+page act as the entire user interface: start `examples/run_Find_WebSocketUi.sh` (or `.bat`), then
+open `examples/websocket_scanner.html` in a browser.
+
+| JSON field         | Type    | Default | Description                                                        |
+|--------------------|---------|---------|--------------------------------------------------------------------|
+| keyProducerId      | string  | —       | Unique identifier for this key producer                             |
+| port               | number  | `8080`  | TCP port the WebSocket server binds to                              |
+| timeoutMillis      | number  | `1000`  | How long `createSecrets()` waits for a queued secret:<br> `-1` = block forever, `0` = return immediately, `>0` = wait that long |
+| logReceivedSecret  | boolean | `false` | Whether to log each received secret in hex                          |
+| broadcastResults   | boolean | `false` | Send the outcome of every checked batch back on this same port      |
+
+> **Set `timeoutMillis: -1` for an interactively driven run.** With a positive timeout, a pause of
+> that length — a user clicking *Stop*, a throttled browser tab — raises
+> `NoMoreSecretsAvailableException`, which ends the producer **permanently**.
+
+### 📢 Broadcasting results
+
+By default a hit only reaches the log. Every transport above can additionally report the outcome of
+each checked batch to connected clients.
+
+**Every batch is reported, hit or not.** That is deliberate: reporting only hits would leave a client
+unable to tell *"range checked, nothing there"* from *"range never checked"*, and those two are
+indistinguishable after a shutdown drops a queued range — an automated from/to sweep would then move
+past ground it never covered. The message is emitted after the batch has been checked, so it doubles
+as an exact completion signal.
+
+> ⚠️ **The payload contains private keys**, and every connected client receives every result —
+> including hits from ranges somebody else submitted. Each transport is off by default. Only enable
+> this on a port you control.
+
+| Transport | Enable with | Where results go | Limitations |
+|---|---|---|---|
+| WebSocket | `broadcastResults` | **the same port** | — |
+| ZeroMQ    | `broadcastResults` + `publishAddress` | a separate `PUB` socket | A `PULL` socket cannot send, hence the second address. A `PUB` socket cannot detect subscribers, so there is no greeting on connect: the grid configuration is republished every 64 batches instead, and a late subscriber misses whatever was published before it finished connecting. |
+| TCP socket | `broadcastResults` + `resultPort` | a separate port | The inbound side serves one peer and reads fixed-width records; results go to every listener as newline-delimited JSON, so they cannot share the stream. |
+
+Delivery is best-effort everywhere: a client that is not connected when a batch completes misses that
+message and nothing replays it. **The log remains the authoritative record of a hit.**
+
+#### Message format
+
+Two shapes, told apart by `type`. Big integers are hex without a prefix.
+
+```jsonc
+// sent once a client can be told which grid the producers use
+{"type":"config","batchSizeInBits":18,"batchUsePrivateKeyIncrement":true,"secretByteLength":32}
+
+// one per checked batch — "hits" is empty when nothing was found
+{"type":"batch","secretBase":"100000000","checkedCount":262144,"hits":[
+  {"privateKey":"49","hash160Hex":"aabb…","address":"1…","compressed":true,"vanity":false}
+]}
+```
+
+A client **must** advance by exactly `2^batchSizeInBits`. The finder aligns every incoming base down
+to a multiple of it, so a smaller step resubmits the same block over and over while the rest of the
+range is never touched — silently, because nothing rejects a misaligned base. The `config` message
+exists so a client can derive that step instead of guessing it.
 
 
 ##### Example: Python Socket Stream Server:
@@ -2097,7 +2163,7 @@ BitcoinAddressFinder stands on the shoulders of excellent open-source work. In p
   across the CPU path and as the reference for the GPU parity tests.
 - **[LMDB](https://www.symas.com/lmdb)** / **[lmdbjava](https://github.com/lmdbjava/lmdbjava)** — the
   high-performance memory-mapped address database.
-- **[JOCL](https://www.jocl.org/)** — Java bindings to OpenCL.
+- **[LWJGL](https://www.lwjgl.org/)** — Java bindings to OpenCL.
 - **Binary Fuse filters** — by [Thomas Mueller Graf and Daniel Lemire](https://github.com/FastFilter),
   with the [SipHash](https://github.com/veorq/SipHash) construction by Jean-Philippe Aumasson and
   Daniel J. Bernstein.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -24,6 +24,7 @@ path = [
     "examples/config_Find_GPU_Fuse16Cascade.json",
     "examples/config_Find_GPU_LowVram.json",
     "examples/config_LMDBDelta.json",
+    "examples/config_Find_WebSocketUi.json",
     "src/test/resources/testOpenCLInfo/config_OpenCLInfo.json",
     "src/test/resources/testRoundtrip/config_AddressFilesToLMDB.json",
     "src/test/resources/testRoundtrip/config_Find_1OpenCLDevice.json",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ We ask that reporters respect the embargo period and not disclose the vulnerabil
 
 **Out of scope:**
 
-- Vulnerabilities in upstream dependencies (e.g., `bitcoinj-core`, `lmdbjava`, `jocl`, `jackson-*`, `guava`). These are tracked automatically through GitHub Dependabot and CodeQL alerts; please report them upstream.
+- Vulnerabilities in upstream dependencies (e.g., `bitcoinj-core`, `lmdbjava`, `lwjgl`, `jackson-*`, `guava`). These are tracked automatically through GitHub Dependabot and CodeQL alerts; please report them upstream.
 - Issues that require an attacker to already control the host running the tool (the tool is a local key-search utility; it deliberately processes private-key material).
 - Findings against forks or third-party redistributions.
 

--- a/TEST_WRITING_GUIDE.md
+++ b/TEST_WRITING_GUIDE.md
@@ -127,7 +127,7 @@ Available assume classes:
 
 A test must be annotated with `@OpenCLTest` and call `assumeOpenCLLibraryLoadableAndOneOpenCL2_0OrGreaterDeviceAvailable()` as its **first statement** when the test body invokes OpenCL API functions:
 
-- `CL.stringFor_*` or any `CL.*` native call
+- Any method on a real `ClApi` (`LwjglClApi`, or an instance from `OpenClBinding`)
 - `OpenCLBuilder.build()` or methods that load/query the OpenCL runtime
 - Any code path triggering native library loading
 
@@ -138,7 +138,7 @@ A test must be annotated with `@OpenCLTest` and call `assumeOpenCLLibraryLoadabl
 
 ### When `@OpenCLTest` + assume is NOT required
 
-Tests that **only** use JOCL wrapper types (`cl_device_id`, `cl_context_properties`, `cl_platform_id`) as plain Java objects — without calling native OpenCL API functions — do **not** need `@OpenCLTest`.
+Tests that **only** use the handle records (`ClDeviceId`, `ClPlatformId`, `ClContext`, …) as plain Java values, or that drive a mocked/stubbed `ClApi`, do **not** need `@OpenCLTest` — no native function is invoked. This is what the `ClApi` seam buys: the pure helpers around it (`ClDeviceInfoFormatter`, `ClErrorChecker`, `ClErrorCodeResolver`) are testable on any machine.
 
 **Decision rule:** "Does this test call any method that invokes a native OpenCL function?" If yes → `@OpenCLTest` + assume. If no → no annotation needed.
 

--- a/TODO.md
+++ b/TODO.md
@@ -756,10 +756,22 @@ Until the investigation settles on a toolkit, no UI code should be added to the 
 
 ### OpenCL backend abstraction & multi-device coverage (migrated from GitHub issues)
 
-- **Pluggable OpenCL backend behind a small device/library abstraction** (migrated from GitHub issue #22 "Can jogamp be used to improve OpenCL handling?"). Today the GPU layer is bound directly to **JOCL** (`org.jocl`, `jocl 2.0.6`): `opencl/OpenCLBuilder` enumerates platforms/devices via raw `org.jocl.CL` calls, `opencl/OpenCLContext` compiles/runs the kernel, `opencl/OpenClTask` sets kernel args, and `opencl/OpenCLDevice` is a hand-written value type. The goal is a **tiny internal API** (interface) for "list platforms/devices" + "build a context / run the kernel grid" so the OpenCL implementation can be **switched between backends** without touching producers/config.
-  - **Step 1 — define the abstraction over the existing JOCL impl.** Extract a minimal interface set (e.g. an `OpenClBackend` / device-enumeration + context-and-grid-execution contract) and make the current JOCL code the first implementation behind it. No behaviour change; pure introduction of the seam. Keep `jocl` confined to the `opencl` package (already enforced by the `joclConfinedToOpencl` ArchUnit rule).
-  - **Step 2 — wire a second backend behind the same API.** Add **JogAmp JOCL** (`com.jogamp.opencl`, OO `CLPlatform`/`CLDevice`/`CLContext`) as an alternative implementation selectable at runtime/config, so the two bindings can be A/B'd (device enumeration, kernel build/run, native-lib packaging). Decide based on results whether JogAmp simplifies the layer enough to become the default or stays optional.
-  - Open questions to settle when picked up: where the backend is selected (new `configuration` field vs auto-detect), how kernel source/args map across the two APIs, and the native-library/packaging impact of adding JogAmp.
+- **✅ DONE — Pluggable OpenCL backend behind a small device/library abstraction** (migrated from
+  GitHub issue #22 "Can jogamp be used to improve OpenCL handling?"). The abstraction exists as
+  `opencl/binding/` (`ClApi` + `LwjglClApi`, typed handle records, `ClErrorChecker`,
+  `OpenClLibraryLoader`, `ClDeviceInfoFormatter`); `OpenCLBuilder`, `OpenCLContext`, `OpenClTask` and
+  `OpenCLDeviceTopology` all consume it and no longer name a binding library.
+  - **Step 1 (define the seam over the existing impl) and Step 2 (swap the backend) were done in one
+    move, and the outcome differs from the original plan:** JOCL was **replaced by LWJGL 3**, not
+    joined by JogAmp as a selectable second backend. Two findings drove that. First, OpenCL handles
+    cannot cross a binding boundary — JOCL's `cl_platform_id` / `cl_device_id` / `cl_context` are
+    `NativePointerObject` subclasses that cannot be built from a `long` — so discovery, context
+    creation and kernel execution form one indivisible migration unit and a "both backends at once"
+    runtime switch would have meant duplicating that whole unit. Second, with the seam in place the
+    remaining value of a second backend is a config flag nobody asked for. Adding a JogAmp
+    implementation later is now a matter of writing one more `ClApi`.
+  - All nine LWJGL `natives-*` classifiers are declared, so the single fat jar still runs on every
+    supported platform.
 
 - **Add a test exercising two OpenCL devices simultaneously** (migrated from GitHub issue #6). Current OpenCL coverage drives a **single** device (`ProbeAddressesOpenCLTest`, gated by `OpenCLPlatformAssume`). Add a test that runs **two `producerOpenCL` instances concurrently** (the multi-device path the project supports via multiple `producerOpenCL` entries) and asserts both produce and feed the consumer correctly at the same time.
   - **Scope: two _physical_ OpenCL devices** — e.g. a machine with two GPUs, or one GPU plus a CPU that exposes an OpenCL device. (Not two logical handles to the same device.) Each `producerOpenCL` targets a distinct `(platformIndex, deviceIndex)`.

--- a/examples/config_Find_WebSocketUi.json
+++ b/examples/config_Find_WebSocketUi.json
@@ -1,0 +1,45 @@
+{
+  "command": "Find",
+  "finder": {
+    "keyProducerJavaWebSocket": [
+      {
+        "keyProducerId": "browser",
+        "logReceivedSecret": false,
+        "port": 8080,
+        "timeoutMillis": -1,
+        "broadcastResults": true
+      }
+    ],
+    "consumerJava": {
+      "lmdbConfigurationReadOnly": {
+        "lmdbDirectory": "lmdb",
+        "useProxyOptimal": true,
+        "useNoReadAhead": false,
+        "logStatsOnInit": true,
+        "logStatsOnClose": false
+      },
+      "printStatisticsEveryNSeconds": 10,
+      "statisticsRateWindowSeconds": 60,
+      "threads": 4,
+      "queuePollTimeoutMillis": 50,
+      "queueSize": 4,
+      "awaitQueueEmptySeconds": 60,
+      "runtimePublicKeyCalculationCheck": false,
+      "enableVanity": false,
+      "vanityPattern": "1[Ee][Mm][Ii][Ll].*"
+    },
+    "awaitTerminateSeconds": 31536000000,
+    "producerJava": [
+      {
+        "keyProducerId": "browser",
+        "batchSizeInBits": 18,
+        "batchUsePrivateKeyIncrement": true,
+        "logSecretBase": false,
+        "runOnce": false,
+        "shutdownTimeoutSeconds": 300
+      }
+    ],
+    "producerJavaSecretsFiles": [],
+    "producerOpenCL": []
+  }
+}

--- a/examples/run_Find_WebSocketUi.bat
+++ b/examples/run_Find_WebSocketUi.bat
@@ -1,0 +1,41 @@
+REM SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+REM
+REM SPDX-License-Identifier: Apache-2.0
+
+REM Starts a finder whose only input and output is a WebSocket on port 8080.
+REM Open websocket_scanner.html in a browser afterwards; it submits the bases
+REM and renders every checked batch.
+
+rem start /low java ^
+java ^
+--add-opens java.base/java.lang=ALL-UNNAMED ^
+--add-opens java.base/java.io=ALL-UNNAMED ^
+--add-opens java.base/java.nio=ALL-UNNAMED ^
+--add-opens java.base/jdk.internal.ref=ALL-UNNAMED ^
+--add-opens java.base/jdk.internal.misc=ALL-UNNAMED ^
+--add-opens java.base/sun.nio.ch=ALL-UNNAMED ^
+--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED ^
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED ^
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED ^
+--add-exports java.base/java.lang=ALL-UNNAMED ^
+--add-exports java.base/java.io=ALL-UNNAMED ^
+--add-exports java.base/java.nio=ALL-UNNAMED ^
+--add-exports java.base/jdk.internal.ref=ALL-UNNAMED ^
+--add-exports java.base/jdk.internal.misc=ALL-UNNAMED ^
+--add-exports java.base/sun.nio.ch=ALL-UNNAMED ^
+--add-exports jdk.management/com.sun.management.internal=ALL-UNNAMED ^
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED ^
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED ^
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED ^
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED ^
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED ^
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED ^
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED ^
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED ^
+-Xms512M ^
+-Xmx16G ^
+-Dlogback.configurationFile=logbackConfiguration.xml ^
+-jar ^
+bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+config_Find_WebSocketUi.json
+rem >> log_Find_WebSocketUi.txt 2>&1

--- a/examples/run_Find_WebSocketUi.sh
+++ b/examples/run_Find_WebSocketUi.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Starts a finder whose only input and output is a WebSocket on port 8080.
+# Open websocket_scanner.html in a browser afterwards; it submits the bases
+# and renders every checked batch.
+
+# start /low java \
+java \
+--add-opens java.base/java.lang=ALL-UNNAMED \
+--add-opens java.base/java.io=ALL-UNNAMED \
+--add-opens java.base/java.nio=ALL-UNNAMED \
+--add-opens java.base/jdk.internal.ref=ALL-UNNAMED \
+--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+--add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+--add-exports java.base/java.lang=ALL-UNNAMED \
+--add-exports java.base/java.io=ALL-UNNAMED \
+--add-exports java.base/java.nio=ALL-UNNAMED \
+--add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
+--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+--add-exports java.base/sun.nio.ch=ALL-UNNAMED \
+--add-exports jdk.management/com.sun.management.internal=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+-Xms512M \
+-Xmx16G \
+-Dlogback.configurationFile=logbackConfiguration.xml \
+-jar \
+bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+config_Find_WebSocketUi.json
+# >> log_Find_WebSocketUi.txt 2>&1

--- a/examples/websocket_scanner.html
+++ b/examples/websocket_scanner.html
@@ -1,0 +1,326 @@
+<!--
+SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BitcoinAddressFinder – WebSocket Scanner</title>
+  <style>
+    body { font-family: monospace; background:#f4f4f4; padding:1.5rem; }
+    h1 { text-align:center; margin-bottom:0.2rem; }
+    .sub { text-align:center; color:#666; margin-top:0; }
+    .panel { max-width:1000px; margin:1rem auto; background:#fff; border:1px solid #ccc; padding:1rem; }
+    label { display:inline-block; min-width:9rem; }
+    input, select { font-family:monospace; }
+    input[type=text] { width:34rem; }
+    button { margin:0.25rem 0.25rem 0.25rem 0; padding:0.4rem 0.9rem; }
+    .row { margin:0.35rem 0; }
+    .warn { background:#fff3cd; border:1px solid #e0c060; padding:0.6rem; margin-top:0.6rem; }
+    .danger { background:#f8d7da; border:1px solid #d09a9f; padding:0.6rem; margin-top:0.6rem; }
+
+    /* Defragmenter-style map: one cell per batch of the swept range. */
+    .map { display:flex; flex-wrap:wrap; gap:2px; margin-top:0.6rem; }
+    .blk { width:12px; height:12px; background:#d8d8d8; border-radius:2px; }
+    .blk.pending { background:#9ec5ff; }
+    .blk.flash   { background:#ffffff; box-shadow:0 0 4px 2px #7fd0ff; }
+    .blk.done    { background:#2f7d32; }
+    .blk.hit     { background:#c62828; }
+
+    /* 256-bit view: leading bits are the base, trailing batch bits are swept. */
+    .bits { margin-top:0.6rem; line-height:1.5rem; word-break:break-all; }
+    .bits .b { color:#111; }
+    .bits .x { color:#b8860b; background:#fff8dc; font-weight:bold; }
+
+    .stats span { display:inline-block; min-width:11rem; }
+    #results { max-height:16rem; overflow:auto; background:#111; color:#eee; padding:0.6rem; }
+    #results div { white-space:pre-wrap; }
+    #results .h { color:#ff8a80; font-weight:bold; }
+  </style>
+</head>
+<body>
+
+<h1>BitcoinAddressFinder – WebSocket Scanner</h1>
+<p class="sub">The browser is the key producer and the display. One connection carries ranges in and results back.</p>
+
+<div class="panel">
+  <div class="row">
+    <label>Server</label>
+    <input type="text" id="wsUrl" value="ws://127.0.0.1:8080" />
+    <button id="btnConnect">Connect</button>
+    <button id="btnDisconnect" disabled>Disconnect</button>
+  </div>
+  <div class="row" id="configLine">Not connected. The server announces its grid size on connect.</div>
+  <div id="configWarning"></div>
+</div>
+
+<div class="panel">
+  <div class="row">
+    <label>Mode</label>
+    <select id="mode">
+      <option value="sequential">Sequential (from / to)</option>
+      <option value="random">Random</option>
+    </select>
+  </div>
+  <div class="row"><label>From (hex)</label><input type="text" id="fromHex" value="0000000000000000000000000000000000000000000000000000000100000000" /></div>
+  <div class="row"><label>To (hex)</label><input type="text" id="toHex"   value="0000000000000000000000000000000000000000000000000000000108000000" /></div>
+  <div class="row">
+    <label>Lookahead</label>
+    <input type="number" id="lookahead" value="4" min="1" max="64" style="width:5rem" />
+    <span>batches kept in flight — see the note below</span>
+  </div>
+  <div class="row">
+    <button id="btnStart" disabled>Start</button>
+    <button id="btnStop" disabled>Stop</button>
+  </div>
+  <div class="row stats">
+    <span>sent: <b id="statSent">0</b></span>
+    <span>checked: <b id="statChecked">0</b></span>
+    <span>keys: <b id="statKeys">0</b></span>
+    <span>hits: <b id="statHits">0</b></span>
+  </div>
+</div>
+
+<div class="panel">
+  <b>Range map</b> — one block per batch. Blue = in flight, green = checked and empty, red = hit.
+  <div class="map" id="map"></div>
+</div>
+
+<div class="panel">
+  <b>Current base (256 bit)</b> — leading bits are the base; the trailing
+  <span id="bitsLabel">n</span> bits are the batch the device sweeps, shown as
+  <span class="x">X</span>.
+  <div class="bits" id="bits"></div>
+</div>
+
+<div class="panel">
+  <b>Results</b>
+  <div id="results"></div>
+</div>
+
+<script>
+"use strict";
+
+const KEY_BYTES = 32;
+const KEY_BITS = 256;
+
+let ws = null;
+let running = false;
+let config = null;          // {batchSizeInBits, batchUsePrivateKeyIncrement, secretByteLength}
+let step = 0n;              // 2^batchSizeInBits — the only correct increment, see note below
+let fromBase = 0n;
+let toBase = 0n;
+let nextBase = 0n;
+let inFlight = 0;
+let sent = 0, checked = 0, hits = 0, keys = 0;
+let blocks = new Map();     // base (string) -> cell element
+
+const $ = (id) => document.getElementById(id);
+
+function log(text, isHit) {
+  const div = document.createElement("div");
+  if (isHit) div.className = "h";
+  div.textContent = text;
+  $("results").prepend(div);
+}
+
+/** Renders a 256-bit big integer, with the swept low bits marked instead of printed. */
+function renderBits(base) {
+  const bits = base.toString(2).padStart(KEY_BITS, "0");
+  const sweptBits = config ? config.batchSizeInBits : 0;
+  const fixed = bits.slice(0, KEY_BITS - sweptBits);
+  let html = '<span class="b">' + fixed + '</span>';
+  if (sweptBits > 0) html += '<span class="x">' + "X".repeat(sweptBits) + '</span>';
+  $("bits").innerHTML = html;
+}
+
+function toFixedBytes(value) {
+  let hex = value.toString(16).padStart(KEY_BYTES * 2, "0");
+  if (hex.length > KEY_BYTES * 2) hex = hex.slice(-KEY_BYTES * 2);
+  const out = new Uint8Array(KEY_BYTES);
+  for (let i = 0; i < KEY_BYTES; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  return out;
+}
+
+/**
+ * The server aligns every incoming base down to a multiple of 2^batchSizeInBits. Sending a base
+ * that is not aligned means the same block is swept again while the rest of the range is never
+ * touched — silently, because nothing rejects it. So align here and advance by exactly one grid.
+ */
+function alignDown(value) {
+  return step === 0n ? value : (value / step) * step;
+}
+
+function buildMap() {
+  const map = $("map");
+  map.innerHTML = "";
+  blocks = new Map();
+  if (step === 0n || toBase <= fromBase) return;
+  const total = (toBase - fromBase) / step;
+  const capped = total > 4000n ? 4000n : total;   // a map, not a pixel-per-key rendering
+  for (let i = 0n; i < capped; i++) {
+    const cell = document.createElement("div");
+    cell.className = "blk";
+    const base = fromBase + i * step;
+    cell.title = base.toString(16);
+    map.appendChild(cell);
+    blocks.set(base.toString(16), cell);
+  }
+}
+
+function markBlock(baseHex, cls) {
+  const cell = blocks.get(baseHex);
+  if (!cell) return;
+  cell.classList.remove("pending", "flash");
+  cell.classList.add(cls);
+}
+
+function flashBlock(baseHex) {
+  const cell = blocks.get(baseHex);
+  if (!cell) return;
+  cell.classList.add("flash");
+  setTimeout(() => { cell.classList.remove("flash"); cell.classList.add("pending"); }, 90);
+}
+
+function randomBase() {
+  const raw = new Uint8Array(KEY_BYTES);
+  crypto.getRandomValues(raw);
+  let hex = "";
+  for (const b of raw) hex += b.toString(16).padStart(2, "0");
+  return alignDown(BigInt("0x" + hex));
+}
+
+/** Keeps `lookahead` batches in flight so the server's queue never runs dry between batches. */
+function pump() {
+  if (!running || !ws || ws.readyState !== WebSocket.OPEN) return;
+  const lookahead = parseInt($("lookahead").value, 10) || 1;
+  while (inFlight < lookahead) {
+    let base;
+    if ($("mode").value === "random") {
+      base = randomBase();
+    } else {
+      if (nextBase >= toBase) {
+        if (inFlight === 0) { log("Range complete."); stop(); }
+        return;
+      }
+      base = nextBase;
+      nextBase += step;
+    }
+    ws.send(toFixedBytes(base));
+    sent++; inFlight++;
+    $("statSent").textContent = sent;
+    renderBits(base);
+    flashBlock(base.toString(16));
+  }
+}
+
+function onBatch(msg) {
+  checked++;
+  keys += msg.checkedCount || 0;
+  inFlight = Math.max(0, inFlight - 1);
+  $("statChecked").textContent = checked;
+  $("statKeys").textContent = keys;
+
+  if (msg.secretBase) {
+    const hex = BigInt("0x" + msg.secretBase).toString(16);
+    markBlock(hex, msg.hits && msg.hits.length ? "hit" : "done");
+  }
+  if (msg.hits && msg.hits.length) {
+    hits += msg.hits.length;
+    $("statHits").textContent = hits;
+    for (const h of msg.hits) {
+      log("HIT  address=" + h.address + "  compressed=" + h.compressed +
+          "\n     privateKey=" + h.privateKey, true);
+    }
+  }
+  pump();
+}
+
+function onConfig(msg) {
+  config = msg;
+  step = 1n << BigInt(msg.batchSizeInBits);
+  $("bitsLabel").textContent = msg.batchSizeInBits;
+  $("configLine").textContent =
+      "Server grid: batchSizeInBits=" + msg.batchSizeInBits +
+      " (" + step.toString() + " keys per message), secretByteLength=" + msg.secretByteLength;
+  const warn = $("configWarning");
+  if (!msg.batchUsePrivateKeyIncrement) {
+    warn.className = "danger";
+    warn.textContent =
+        "This server runs with batchUsePrivateKeyIncrement=false. It then wants one secret per " +
+        "candidate instead of one base per grid, which this page cannot feed at a useful rate. " +
+        "Set it to true in the producer configuration.";
+    $("btnStart").disabled = true;
+  } else {
+    warn.className = "";
+    warn.textContent = "";
+    $("btnStart").disabled = false;
+  }
+}
+
+function connect() {
+  ws = new WebSocket($("wsUrl").value);
+  ws.binaryType = "arraybuffer";
+  ws.onopen = () => {
+    $("btnConnect").disabled = true;
+    $("btnDisconnect").disabled = false;
+    $("configLine").textContent = "Connected. Waiting for the server to announce its grid size…";
+  };
+  ws.onmessage = (event) => {
+    let msg;
+    try { msg = JSON.parse(event.data); } catch (e) { return; }
+    if (msg.type === "config") onConfig(msg);
+    else if (msg.type === "batch") onBatch(msg);
+  };
+  ws.onclose = () => {
+    stop();
+    $("btnConnect").disabled = false;
+    $("btnDisconnect").disabled = true;
+    $("btnStart").disabled = true;
+    $("configLine").textContent = "Disconnected.";
+  };
+  ws.onerror = () => log("WebSocket error — is the server running and is broadcastResults enabled?");
+}
+
+function start() {
+  if (!config) { log("No server configuration yet."); return; }
+  fromBase = alignDown(BigInt("0x" + $("fromHex").value.trim().replace(/^0x/, "")));
+  toBase   = alignDown(BigInt("0x" + $("toHex").value.trim().replace(/^0x/, "")));
+  nextBase = fromBase;
+  sent = checked = hits = keys = 0; inFlight = 0;
+  $("statSent").textContent = $("statChecked").textContent = $("statHits").textContent = $("statKeys").textContent = 0;
+  buildMap();
+  running = true;
+  $("btnStart").disabled = true;
+  $("btnStop").disabled = false;
+  pump();
+}
+
+function stop() {
+  running = false;
+  $("btnStart").disabled = !config;
+  $("btnStop").disabled = true;
+}
+
+$("btnConnect").onclick = connect;
+$("btnDisconnect").onclick = () => { if (ws) ws.close(); };
+$("btnStart").onclick = start;
+$("btnStop").onclick = stop;
+</script>
+
+<div class="panel warn">
+  <b>Notes.</b>
+  One message carries one <i>base</i>, not one key: the device expands it into
+  2<sup>batchSizeInBits</sup> candidates, so a few dozen messages per second are enough to keep a GPU
+  busy. The lookahead exists because the server's queue is unbounded — keep it small, since anything
+  still queued when the process stops was never checked, and only the batches reported back here are
+  known to be done. Results are broadcast to <b>every</b> connected client and
+  <b>contain private keys</b>.
+</div>
+
+</body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: Apache-2.0
         <guava.version>33.6.0-jre</guava.version>
         <jackson.version>2.22.1</jackson.version>
         <lmdbjava.version>0.9.3</lmdbjava.version>
-        <jocl.version>2.0.6</jocl.version>
+        <lwjgl.version>3.4.2</lwjgl.version>
         <commons-io.version>2.22.0</commons-io.version>
         <commons-codec.version>1.22.1</commons-codec.version>
         <maven-artifact.version>3.9.16</maven-artifact.version>
@@ -950,10 +950,86 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>lmdbjava</artifactId>
             <version>${lmdbjava.version}</version>
         </dependency>
+        <!--
+            LWJGL 3: the core module carries the JNI shim (lwjgl.dll / liblwjgl.so) and the
+            MemoryStack/PointerBuffer plumbing; lwjgl-opencl is a pure binding jar with no
+            natives of its own (OpenCL itself is reached through the driver's system ICD).
+            Only the core module therefore needs natives-* classifier jars. They may all sit on
+            one classpath at once - LWJGL picks the matching one at runtime - which is what keeps
+            this project on a SINGLE fat jar even though the binding ships per-platform natives.
+        -->
         <dependency>
-            <groupId>org.jocl</groupId>
-            <artifactId>jocl</artifactId>
-            <version>${jocl.version}</version>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl-opencl</artifactId>
+            <version>${lwjgl.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-windows</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-windows-x86</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-windows-arm64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-linux</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-linux-arm64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-linux-arm32</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-macos</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-macos-arm64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+            <classifier>natives-freebsd</classifier>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -130,7 +130,18 @@ SPDX-License-Identifier: Apache-2.0
         the PREDICTABLE_RANDOM suppression above.
     -->
     <Match>
-        <Class name="net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaSocket"/>
+        <Or>
+            <Class name="net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaSocket"/>
+            <!--
+                SocketResultBroadcaster is the outbound half of the same channel and runs under the
+                same deployment assumption: localhost or a trusted LAN, as part of an operator's own
+                batch-scan setup. Note it carries MORE than the inbound side does - the results
+                include private keys - so the assumption is doing real work here. Accepted
+                deliberately; if this ever has to cross an untrusted network it needs a tunnel or
+                TLS, not a wider suppression.
+            -->
+            <Class name="net.ladenthin.bitcoinaddressfinder.keyproducer.SocketResultBroadcaster"/>
+        </Or>
         <Or>
             <Bug pattern="UNENCRYPTED_SOCKET"/>
             <Bug pattern="UNENCRYPTED_SERVER_SOCKET"/>
@@ -189,10 +200,6 @@ SPDX-License-Identifier: Apache-2.0
             Bech32.Bech32Bytes.witnessProgram / witnessVersion are
             protected; both are needed for SegWit address decoding
             paths that bitcoinj does not expose publicly.
-          - OpenCLBuilder.isOpenClNativeLibraryLoaded: JOCL exposes
-            no public probe for whether its native lib loaded.
-            Needed for graceful CPU-only fallback on hosts without
-            GPU drivers.
           - LMDBPersistence.getApproximateSizeBytes: Guava's
             BloomFilter does not expose its in-memory size. We read
             the private backing array length for diagnostics.
@@ -208,10 +215,6 @@ SPDX-License-Identifier: Apache-2.0
                     <Method name="invokeConvertBitsStatic"/>
                     <Method name="invokeProtectedMethod"/>
                 </Or>
-            </And>
-            <And>
-                <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenCLBuilder"/>
-                <Method name="isOpenClNativeLibraryLoaded"/>
             </And>
             <And>
                 <Class name="net.ladenthin.bitcoinaddressfinder.persistence.lmdb.LMDBPersistence"/>
@@ -405,7 +408,7 @@ SPDX-License-Identifier: Apache-2.0
 
         1. Hot-path byte[] / ByteBuffer ownership transfer.
            PublicKeyBytes, AddressToCoin.hash160,
-           OpenClTask$CLByteBufferPointerArgument.byteBuffer,
+           OpenClTask$SourceArgument.byteBuffer,
            OpenCLGridResult.result, and the cached read-only
            PersistenceUtils.zeroByteBuffer are passed across the
            GPU/CPU key-derivation pipeline at millions of operations
@@ -415,11 +418,20 @@ SPDX-License-Identifier: Apache-2.0
            PersistenceUtils.zeroByteBuffer is additionally pinned as
            asReadOnlyBuffer() to defeat mutation.
 
-        2. JOCL native handles. cl_context, cl_mem, cl_device_id,
-           cl_context_properties, and Pointer are opaque native
-           resource references. They cannot be cloned; the Java owner
-           must retain the reference to release the resource via
-           clRelease*.
+        2. OpenCL handles and the binding seam. The ClContext, ClMem,
+           ClDeviceId, ClCommandQueue, ... records wrap an opaque
+           native pointer; they cannot be cloned, and the Java owner
+           must keep the reference to release the resource via
+           clRelease*. The ClApi they are used through is the single
+           seam the whole OpenCL layer talks to the driver over, so
+           OpenCLBuilder, OpenCLContext, OpenCLDeviceTopology and
+           OpenClTask all deliberately share one instance — handing
+           out a copy would defeat the injection point tests
+           substitute at. OpenClTask$SourceArgument.getByteBuffer
+           exposes the host buffer for the same reason as category 1
+           and one stronger one: the device buffer is created OVER
+           that exact allocation, so a copy would be memory the GPU
+           never reads.
 
         3. Effectively-immutable bitcoinj Coin. AddressToCoin.coin
            holds a Coin instance which is a value-class style
@@ -444,7 +456,10 @@ SPDX-License-Identifier: Apache-2.0
             <Class name="net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes"/>
             <Class name="net.ladenthin.bitcoinaddressfinder.model.AddressToCoin"/>
             <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenClTask"/>
-            <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenClTask$CLByteBufferPointerArgument"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenClTask$SourceArgument"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenCLBuilder"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenCLContext"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDeviceTopology"/>
             <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenCLGridResult"/>
             <Class name="net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils"/>
             <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDevice"/>
@@ -891,7 +906,7 @@ SPDX-License-Identifier: Apache-2.0
         initProducer/produceKeys and on ConsumerJava.initLMDB.
 
         Producer is the abstract contract every producer impl honours. Concrete
-        impls throw a heterogeneous mix (LmdbException, JOCL CLException,
+        impls throw a heterogeneous mix (LmdbException, OpenClCallFailedException,
         IOException from socket binds, NoMoreSecretsAvailableException, etc.)
         with no shared checked-exception supertype. Narrowing the throws clause
         would require either (a) wrapping every impl's exception into a single
@@ -977,19 +992,6 @@ SPDX-License-Identifier: Apache-2.0
     <Match>
         <Class name="net.ladenthin.bitcoinaddressfinder.constants.Secp256k1Constants"/>
         <Bug pattern="HARD_CODE_KEY"/>
-    </Match>
-
-    <!--
-        NP_LOAD_OF_KNOWN_NULL_VALUE on OpenClTask.executeKernel — false
-        positive on the JOCL API contract. clEnqueueNDRangeKernel takes
-        explicit null arguments for the global_work_offset, event_wait_list,
-        and event return-pointer when the caller has nothing to provide; the
-        nulls are not a defensive omission, they are the JOCL spec.
-    -->
-    <Match>
-        <Class name="net.ladenthin.bitcoinaddressfinder.opencl.OpenClTask"/>
-        <Method name="executeKernel"/>
-        <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE"/>
     </Match>
 
     <!--
@@ -1354,6 +1356,87 @@ SPDX-License-Identifier: Apache-2.0
     <Match>
         <Class name="net.ladenthin.bitcoinaddressfinder.consumer.ConsumerJava$AbsentAddressPresence"/>
         <Bug pattern="ENMI_ONE_ENUM_VALUE"/>
+    </Match>
+
+
+    <!--
+        ==========================================================================================
+        Result broadcast + OpenCL binding seam (added with the LWJGL migration and the result
+        broadcast). Each entry below is a deliberate design decision, not a deferred cleanup.
+        ==========================================================================================
+
+        EI_EXPOSE_REP / EI_EXPOSE_REP2 - KeyProducerJavaWebSocket hands out the very
+        WebSocketEndpoint the broadcaster must send on, because one port serves both directions;
+        a copy would be a second, unbound server. This is the same design intent as category 4
+        ("deliberate dependency injection") in the main EI_EXPOSE_REP block above, where the
+        OpenCL classes are listed.
+
+        DLS_DEAD_LOCAL_STORE - the "Object unused = executor.submit(...)" form used to satisfy
+        Error Prone's FutureReturnValueIgnored for a deliberately fire-and-forget task. Both sites
+        carry @FireAndForget naming the lifecycle that replaces the Future.
+
+        EXS_EXCEPTION_SOFTENING_* - both sites soften on purpose. OpenClLibraryLoader turns an
+        UnsatisfiedLinkError from a failed library-name probe into a domain exception that names
+        every candidate tried; SocketResultBroadcaster.writeTo turns a broken pipe into "false" so
+        the dead peer is dropped and the remaining listeners keep being served.
+
+        MDM_THREAD_YIELD - awaitClientCount polls for a registration that happens on the accept
+        thread. It exists for tests only (a client's socket is connected before the accept loop has
+        registered it), and polling is the honest primitive for that.
+
+        IMC_IMMATURE_CLASS_NO_EQUALS - OpenClCallFailedException is an exception; exceptions are
+        identified by their stack, not compared by value. Same rationale as the existing entries.
+
+        PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS - LwjglClApi calls the (trivial, final) record accessor
+        handle() on two different handles in one method; there is nothing to hoist.
+    -->
+    <Match>
+        <Or>
+            <Class name="net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaWebSocket"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.keyproducer.WebSocketResultBroadcaster"/>
+        </Or>
+        <Or>
+            <Bug pattern="EI_EXPOSE_REP"/>
+            <Bug pattern="EI_EXPOSE_REP2"/>
+        </Or>
+    </Match>
+
+    <Match>
+        <Or>
+            <Class name="net.ladenthin.bitcoinaddressfinder.keyproducer.SocketResultBroadcaster"/>
+            <Class name="net.ladenthin.bitcoinaddressfinder.keyproducer.WebSocketEndpoint"/>
+        </Or>
+        <Bug pattern="DLS_DEAD_LOCAL_STORE"/>
+    </Match>
+
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClLibraryLoader"/>
+        <Bug pattern="EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS"/>
+    </Match>
+
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.keyproducer.SocketResultBroadcaster"/>
+        <Or>
+            <Bug pattern="EXS_EXCEPTION_SOFTENING_RETURN_FALSE"/>
+            <Bug pattern="MDM_THREAD_YIELD"/>
+        </Or>
+    </Match>
+
+    <Match>
+        <Or>
+            <Class name="net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClCallFailedException"/>
+            <!--
+                ProducerReleaser is a stateful collaborator that owns a release history, not a value:
+                two releasers are never interchangeable, so equality has no meaning for it.
+            -->
+            <Class name="net.ladenthin.bitcoinaddressfinder.producer.ProducerReleaser"/>
+        </Or>
+        <Bug pattern="IMC_IMMATURE_CLASS_NO_EQUALS"/>
+    </Match>
+
+    <Match>
+        <Class name="net.ladenthin.bitcoinaddressfinder.opencl.binding.LwjglClApi"/>
+        <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS"/>
     </Match>
 
 </FindBugsFilter>

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfiguration.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfiguration.java
@@ -68,8 +68,8 @@ import net.ladenthin.bitcoinaddressfinder.util.KeyUtility;
 import net.ladenthin.bitcoinaddressfinder.util.MultilineLogger;
 import net.ladenthin.bitcoinaddressfinder.util.NetworkParameterFactory;
 import org.bitcoinj.base.Network;
-import org.jocl.CL;
 import org.jspecify.annotations.Nullable;
+import org.lwjgl.opencl.CL10;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -746,7 +746,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
             // 24) and can exceed what a smaller card allocates. Such an arm must be recorded as
             // unusable and the sweep must continue to the next candidate.
             //
-            // The device rejection surfaces as a JOCL CLException — a RuntimeException carrying a
+            // The device rejection surfaces as an OpenClCallFailedException — a RuntimeException carrying a
             // status such as CL_INVALID_BUFFER_SIZE / CL_MEM_OBJECT_ALLOCATION_FAILURE — which
             // catch (Exception) already covers. This was confirmed on real hardware, not assumed:
             // OpenCLContextAllocationFailureTest requests an impossible allocation and asserts the
@@ -1302,7 +1302,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
          * @return {@code true} if the device reports the GPU type bit
          */
         public boolean isGpu() {
-            return (deviceType & CL.CL_DEVICE_TYPE_GPU) != 0L;
+            return (deviceType & CL10.CL_DEVICE_TYPE_GPU) != 0L;
         }
     }
 
@@ -1316,6 +1316,8 @@ public class TuneConfiguration implements Runnable, Interruptable {
     @VisibleForTesting
     static List<DetectedDevice> gpuDevicesOf(List<OpenCLPlatform> platforms) {
         List<DetectedDevice> devices = new ArrayList<>();
+        // Hoisted: the resolver is stateless, so building one per device was pure allocation.
+        final OpenCLDeviceTopology topology = new OpenCLDeviceTopology();
         for (int platformIndex = 0; platformIndex < platforms.size(); platformIndex++) {
             List<OpenCLDevice> platformDevices = platforms.get(platformIndex).openCLDevices();
             for (int deviceIndex = 0; deviceIndex < platformDevices.size(); deviceIndex++) {
@@ -1328,7 +1330,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
                             deviceIndex,
                             device.deviceName(),
                             device.deviceType(),
-                            OpenCLDeviceTopology.physicalDeviceFingerprintOf(device)));
+                            topology.physicalDeviceFingerprintOf(device)));
                 }
             }
         }
@@ -1743,7 +1745,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
         throw new IllegalArgumentException(
                 "tuneConfiguration.finder has no producerOpenCL or producerJava entry and no OpenCL GPU could be"
                         + " detected to sweep automatically (OpenCL native library loaded: "
-                        + OpenCLBuilder.isOpenClNativeLibraryLoaded()
+                        + new OpenCLBuilder().isOpenClLibraryAvailable()
                         + "). Configure a producer, or install an OpenCL runtime and verify it with the OpenCLInfo"
                         + " command.");
     }
@@ -1756,7 +1758,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
      * @return a template per detected GPU, empty when none could be detected
      */
     private List<CProducerOpenCL> discoverTemplates(CFinder cFinder) {
-        if (!OpenCLBuilder.isOpenClNativeLibraryLoaded()) {
+        if (!new OpenCLBuilder().isOpenClLibraryAvailable()) {
             return Collections.emptyList();
         }
         List<DetectedDevice> devices = gpuDevicesOf(new OpenCLBuilder().build());
@@ -1849,7 +1851,7 @@ public class TuneConfiguration implements Runnable, Interruptable {
      * @param configuredCount how many OpenCL producers the configuration names
      */
     private void hintAtUndetectedDevices(int configuredCount) {
-        if (!OpenCLBuilder.isOpenClNativeLibraryLoaded()) {
+        if (!new OpenCLBuilder().isOpenClLibraryAvailable()) {
             return;
         }
         int detected = gpuDevicesOf(new OpenCLBuilder().build()).size();

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CKeyProducerJavaSocket.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CKeyProducerJavaSocket.java
@@ -32,6 +32,22 @@ public class CKeyProducerJavaSocket extends CKeyProducerJavaReceiver {
     /** Port number to connect to or listen on */
     public int port = 12345;
 
+    /**
+     * Serve the outcome of every checked batch to TCP clients on {@link #resultPort}.
+     *
+     * <p><b>The messages contain private keys</b>, and every connected client receives every result —
+     * including hits from ranges somebody else submitted. Off by default.
+     *
+     * <p>Results are served on a port of their own rather than on this producer's connection: the
+     * inbound side handles exactly one peer and reads fixed-width records, while results go to every
+     * listener as newline-delimited JSON. Mixing both framings on one socket would make the stream
+     * ambiguous.
+     */
+    public boolean broadcastResults = false;
+
+    /** TCP port the result server binds to, used only when {@link #broadcastResults} is set. */
+    public int resultPort = 5556;
+
     /** Operating mode: client or server */
     public Mode mode = Mode.SERVER;
 

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CKeyProducerJavaWebSocket.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CKeyProducerJavaWebSocket.java
@@ -41,6 +41,20 @@ public class CKeyProducerJavaWebSocket extends CKeyProducerJavaReceiver {
     public int port = 8080;
 
     /**
+     * Send the outcome of every checked batch back to all connected clients on this same port.
+     *
+     * <p>Turns the WebSocket into a two-way channel: ranges go in, results come back. That is what
+     * lets a browser page act as the whole user interface with a single connection, and what lets an
+     * automated client tell "range checked, nothing there" from "range never checked" — reporting
+     * only hits would make those two indistinguishable.
+     *
+     * <p><b>The messages contain private keys, and every connected client receives every result</b>
+     * — including hits from ranges somebody else submitted. Off by default; only enable it on a port
+     * you control.
+     */
+    public boolean broadcastResults = false;
+
+    /**
      * Returns the configured port number.
      *
      * @return the configured port number

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CKeyProducerJavaZmq.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CKeyProducerJavaZmq.java
@@ -33,6 +33,28 @@ public class CKeyProducerJavaZmq extends CKeyProducerJavaReceiver {
     public Mode mode = Mode.BIND;
 
     /**
+     * Send the outcome of every checked batch to ZeroMQ subscribers.
+     *
+     * <p><b>The messages contain private keys</b>, and every subscriber receives every result —
+     * including hits from ranges somebody else submitted. Off by default.
+     */
+    public boolean broadcastResults = false;
+
+    /**
+     * Address the result publisher binds to, used only when {@link #broadcastResults} is set.
+     *
+     * <p>A second address is unavoidable: results go out over a {@code PUB} socket while secrets
+     * arrive on a {@code PULL} socket, and two socket types cannot share one endpoint. Unlike the
+     * WebSocket, which serves both directions on one port, ZeroMQ needs both configured.
+     *
+     * <p>Note for subscribers: {@code PUB}/{@code SUB} drops what is published before a subscriber
+     * has finished connecting (the "slow joiner" problem), and the socket cannot tell when someone
+     * subscribes. The grid configuration is therefore republished periodically rather than on
+     * connect - see the publisher for the interval.
+     */
+    public String publishAddress = "tcp://127.0.0.1:5558";
+
+    /**
      * Timeout for receiving secrets, in milliseconds.
      *
      * <p>This timeout is applied consistently to:

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.configuration;
 
-import static org.jocl.CL.CL_DEVICE_TYPE_ALL;
+import static org.lwjgl.opencl.CL10.CL_DEVICE_TYPE_ALL;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/Consumer.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/Consumer.java
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.consumer;
 
+import java.math.BigInteger;
 import net.ladenthin.bitcoinaddressfinder.core.Interruptable;
 import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Receives batches of derived public keys from producers and matches them against the database.
@@ -14,10 +16,16 @@ public interface Consumer extends Interruptable {
     /**
      * Hands off a batch of public keys to the consumer.
      *
+     * <p>The batch travels as one unit all the way to the check, which is what allows the consumer
+     * to report the outcome per batch. The secret base is carried along for that report: it
+     * identifies the swept range to whoever submitted it.
+     *
      * @param publicKeyBytes the batch of public keys derived by a producer
+     * @param secretBase     the aligned start of the swept grid, or {@code null} when the batch is a
+     *                       set of independent secrets rather than one expanded range
      * @throws InterruptedException if the calling thread is interrupted while enqueueing
      */
-    void consumeKeys(PublicKeyBytes[] publicKeyBytes) throws InterruptedException;
+    void consumeKeys(PublicKeyBytes[] publicKeyBytes, @Nullable BigInteger secretBase) throws InterruptedException;
 
     /**
      * Starts the internal consumer thread(s).

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJava.java
@@ -4,6 +4,7 @@
 package net.ladenthin.bitcoinaddressfinder.consumer;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,8 +26,11 @@ import net.ladenthin.bitcoinaddressfinder.configuration.CConsumerJava;
 import net.ladenthin.bitcoinaddressfinder.configuration.CLMDBConfigurationReadOnly;
 import net.ladenthin.bitcoinaddressfinder.configuration.GpuFilterType;
 import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
 import net.ladenthin.bitcoinaddressfinder.core.FireAndForget;
+import net.ladenthin.bitcoinaddressfinder.core.Hit;
 import net.ladenthin.bitcoinaddressfinder.core.InterruptedRuntimeException;
+import net.ladenthin.bitcoinaddressfinder.core.ResultListener;
 import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressIterable;
 import net.ladenthin.bitcoinaddressfinder.persistence.AddressPresence;
@@ -48,6 +52,7 @@ import net.ladenthin.bitcoinaddressfinder.statistics.SlidingWindowRate;
 import net.ladenthin.bitcoinaddressfinder.statistics.Statistics;
 import net.ladenthin.bitcoinaddressfinder.util.KeyUtility;
 import org.apache.commons.codec.binary.Hex;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.ECKey;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -204,7 +209,14 @@ public class ConsumerJava implements Consumer {
      * batch would be log-killing.
      */
     @ToString.Exclude
-    protected final LinkedBlockingQueue<PublicKeyBytes[]> keysQueue;
+    protected final LinkedBlockingQueue<QueuedBatch> keysQueue;
+
+    /**
+     * Sinks notified once per checked batch. Empty unless something was configured, in which case
+     * nothing about the pipeline changes.
+     */
+    @ToString.Exclude
+    private final List<ResultListener> resultListeners;
 
     /** Total number of vanity-pattern hits found so far. */
     protected final AtomicLong vanityHits = new AtomicLong();
@@ -254,6 +266,54 @@ public class ConsumerJava implements Consumer {
     }
 
     /**
+     * Creates a new consumer with the shared metrics sink and the result listeners.
+     *
+     * @param consumerJava      consumer configuration
+     * @param keyUtility        cryptographic helper
+     * @param persistenceUtils  persistence helper used to construct the LMDB layer
+     * @param runtimeStatistics shared runtime metrics sink (also written by the producers)
+     * @param resultListeners   sinks notified once per checked batch
+     */
+    public ConsumerJava(
+            CConsumerJava consumerJava,
+            KeyUtility keyUtility,
+            PersistenceUtils persistenceUtils,
+            RuntimeStatistics runtimeStatistics,
+            List<ResultListener> resultListeners) {
+        this(
+                consumerJava,
+                keyUtility,
+                persistenceUtils,
+                runtimeStatistics,
+                Executors.newSingleThreadScheduledExecutor(),
+                Executors.newFixedThreadPool(consumerJava.threads),
+                resultListeners);
+    }
+
+    /**
+     * Creates a new consumer that reports every checked batch to the given listeners.
+     *
+     * @param consumerJava     consumer configuration
+     * @param keyUtility       cryptographic helper
+     * @param persistenceUtils persistence helper used to construct the LMDB layer
+     * @param resultListeners  sinks notified once per checked batch
+     */
+    public ConsumerJava(
+            CConsumerJava consumerJava,
+            KeyUtility keyUtility,
+            PersistenceUtils persistenceUtils,
+            List<ResultListener> resultListeners) {
+        this(
+                consumerJava,
+                keyUtility,
+                persistenceUtils,
+                new RuntimeStatistics(),
+                Executors.newSingleThreadScheduledExecutor(),
+                Executors.newFixedThreadPool(consumerJava.threads),
+                resultListeners);
+    }
+
+    /**
      * Production constructor that injects the shared {@link RuntimeStatistics} so the
      * statistics line can report per-producer batch counts and the running-producer gauge.
      *
@@ -273,7 +333,8 @@ public class ConsumerJava implements Consumer {
                 persistenceUtils,
                 runtimeStatistics,
                 Executors.newSingleThreadScheduledExecutor(),
-                Executors.newFixedThreadPool(consumerJava.threads));
+                Executors.newFixedThreadPool(consumerJava.threads),
+                List.of());
     }
 
     /**
@@ -298,8 +359,38 @@ public class ConsumerJava implements Consumer {
             RuntimeStatistics runtimeStatistics,
             ScheduledExecutorService scheduledExecutorService,
             ExecutorService consumeKeysExecutorService) {
+        this(
+                consumerJava,
+                keyUtility,
+                persistenceUtils,
+                runtimeStatistics,
+                scheduledExecutorService,
+                consumeKeysExecutorService,
+                List.of());
+    }
+
+    /**
+     * Full constructor: injects the executors and the result listeners.
+     *
+     * @param consumerJava              consumer configuration
+     * @param keyUtility                cryptographic helper
+     * @param persistenceUtils          persistence helper used to construct the LMDB layer
+     * @param runtimeStatistics         shared runtime metrics sink
+     * @param scheduledExecutorService  scheduler used for the periodic stats logger
+     * @param consumeKeysExecutorService pool used for the worker threads that drain the keys queue
+     * @param resultListeners           sinks notified once per checked batch
+     */
+    ConsumerJava(
+            CConsumerJava consumerJava,
+            KeyUtility keyUtility,
+            PersistenceUtils persistenceUtils,
+            RuntimeStatistics runtimeStatistics,
+            ScheduledExecutorService scheduledExecutorService,
+            ExecutorService consumeKeysExecutorService,
+            List<ResultListener> resultListeners) {
         this.consumerJava = consumerJava;
         this.keysQueue = new LinkedBlockingQueue<>(consumerJava.queueSize);
+        this.resultListeners = List.copyOf(resultListeners);
         this.keyUtility = keyUtility;
         this.persistenceUtils = persistenceUtils;
         this.runtimeStatistics = runtimeStatistics;
@@ -700,7 +791,7 @@ public class ConsumerJava implements Consumer {
         // Wait for the next batch instead of an unconditional sleep — wakes the instant a
         // producer enqueues, so queuePollTimeoutMillis is the max idle wait window per
         // cycle, not a fixed back-off.
-        PublicKeyBytes[] next = keysQueue.poll(consumerJava.queuePollTimeoutMillis, TimeUnit.MILLISECONDS);
+        QueuedBatch next = keysQueue.poll(consumerJava.queuePollTimeoutMillis, TimeUnit.MILLISECONDS);
         if (next != null) {
             processBatch(next, threadLocalReuseableByteBuffer);
         }
@@ -721,7 +812,7 @@ public class ConsumerJava implements Consumer {
     long consumeKeys(ByteBuffer threadLocalReuseableByteBuffer) {
         LOGGER.trace("consumeKeys");
         long drained = 0;
-        PublicKeyBytes[] publicKeyBytesArray = keysQueue.poll();
+        QueuedBatch publicKeyBytesArray = keysQueue.poll();
         while (publicKeyBytesArray != null) {
             processBatch(publicKeyBytesArray, threadLocalReuseableByteBuffer);
             drained++;
@@ -736,10 +827,13 @@ public class ConsumerJava implements Consumer {
      * batch returned by its timed wait between drain cycles without re-entering the
      * non-blocking drain loop in {@link #consumeKeys(ByteBuffer)}.
      *
-     * @param publicKeyBytesArray              the batch to process
+     * @param queuedBatch                      the batch to process, with the base it was expanded from
      * @param threadLocalReuseableByteBuffer   thread-local buffer reused across address lookups
      */
-    private void processBatch(PublicKeyBytes[] publicKeyBytesArray, ByteBuffer threadLocalReuseableByteBuffer) {
+    private void processBatch(QueuedBatch queuedBatch, ByteBuffer threadLocalReuseableByteBuffer) {
+        final PublicKeyBytes[] publicKeyBytesArray = queuedBatch.keys();
+        // Collected rather than only logged, so the batch can be reported as a whole below.
+        final List<Hit> batchHits = new ArrayList<>();
         for (PublicKeyBytes publicKeyBytes : publicKeyBytesArray) {
             if (publicKeyBytes.isOutsidePrivateKeyRange()) {
                 continue;
@@ -763,6 +857,7 @@ public class ConsumerJava implements Consumer {
                         publicKeyBytes.getSecretKey().toByteArray(), publicKeyBytes.getUncompressed());
                 String hitMessageUncompressed = HIT_PREFIX + keyUtility.createKeyDetails(ecKeyUncompressed);
                 LOGGER.info(hitMessageUncompressed);
+                batchHits.add(toHit(publicKeyBytes, hash160Uncompressed, ecKeyUncompressed, false, false));
             }
 
             if (containsAddressCompressed) {
@@ -773,6 +868,7 @@ public class ConsumerJava implements Consumer {
                         publicKeyBytes.getSecretKey().toByteArray(), publicKeyBytes.getCompressed());
                 String hitMessageCompressed = HIT_PREFIX + keyUtility.createKeyDetails(ecKeyCompressed);
                 LOGGER.info(hitMessageCompressed);
+                batchHits.add(toHit(publicKeyBytes, hash160Compressed, ecKeyCompressed, true, false));
             }
 
             if (consumerJava.enableVanity) {
@@ -788,6 +884,7 @@ public class ConsumerJava implements Consumer {
                     String vanityHitMessageUncompressed =
                             VANITY_HIT_PREFIX + keyUtility.createKeyDetails(ecKeyUncompressed);
                     LOGGER.info(vanityHitMessageUncompressed);
+                    batchHits.add(toHit(publicKeyBytes, hash160Uncompressed, ecKeyUncompressed, false, true));
                 }
 
                 String compressedKeyHashAsBase58 = publicKeyBytes.getCompressedKeyHashAsBase58(keyUtility);
@@ -801,6 +898,7 @@ public class ConsumerJava implements Consumer {
                     String vanityHitMessageCompressed =
                             VANITY_HIT_PREFIX + keyUtility.createKeyDetails(ecKeyCompressed);
                     LOGGER.info(vanityHitMessageCompressed);
+                    batchHits.add(toHit(publicKeyBytes, hash160Compressed, ecKeyCompressed, true, true));
                 }
             }
 
@@ -816,6 +914,48 @@ public class ConsumerJava implements Consumer {
                     String missMessageCompressed = MISS_PREFIX + keyUtility.createKeyDetails(ecKeyCompressed);
                     LOGGER.trace(missMessageCompressed);
                 }
+            }
+        }
+
+        // One event per batch, emitted after the checks so it is exact. Reported even when
+        // nothing was found: a client sweeping a range needs 'checked, empty' to be
+        // distinguishable from 'never checked'.
+        notifyResultListeners(new BatchResult(queuedBatch.secretBase(), publicKeyBytesArray.length, batchHits));
+    }
+
+    /**
+     * Builds the reportable form of a hit.
+     *
+     * @param publicKeyBytes the candidate that matched
+     * @param hash160        the matching address hash
+     * @param ecKey          the key pair for the matching representation
+     * @param compressed     whether the compressed representation matched
+     * @param vanity         whether this was a vanity-pattern match rather than a database hit
+     * @return the hit as reported to the result listeners
+     */
+    private Hit toHit(PublicKeyBytes publicKeyBytes, byte[] hash160, ECKey ecKey, boolean compressed, boolean vanity) {
+        return new Hit(
+                publicKeyBytes.getSecretKey(),
+                Hex.encodeHexString(hash160),
+                ecKey.toAddress(ScriptType.P2PKH, keyUtility.network()).toString(),
+                compressed,
+                vanity);
+    }
+
+    /**
+     * Reports a checked batch to every configured listener.
+     *
+     * <p>A listener that throws must not take the scan down with it: this runs on the worker thread
+     * that drains the key queue, and the batch has already been checked by the time we get here.
+     *
+     * @param batchResult the outcome to report
+     */
+    private void notifyResultListeners(BatchResult batchResult) {
+        for (ResultListener resultListener : resultListeners) {
+            try {
+                resultListener.onBatchChecked(batchResult);
+            } catch (RuntimeException e) {
+                LOGGER.error("Result listener failed; continuing the scan.", e);
             }
         }
     }
@@ -882,7 +1022,8 @@ public class ConsumerJava implements Consumer {
     }
 
     @Override
-    public void consumeKeys(PublicKeyBytes[] publicKeyBytes) throws InterruptedException {
+    public void consumeKeys(PublicKeyBytes[] publicKeyBytes, @Nullable BigInteger secretBase)
+            throws InterruptedException {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("keysQueue.put(publicKeyBytes) with length: " + publicKeyBytes.length);
         }
@@ -893,7 +1034,7 @@ public class ConsumerJava implements Consumer {
             // the bottleneck (cannot drain as fast as producers generate).
             producerBlockedCount.incrementAndGet();
         }
-        keysQueue.put(publicKeyBytes);
+        keysQueue.put(new QueuedBatch(publicKeyBytes, secretBase));
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("keysQueue.size(): " + keysQueue.size());

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/QueuedBatch.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/consumer/QueuedBatch.java
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.consumer;
+
+import java.math.BigInteger;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One producer batch on its way through the consumer queue.
+ *
+ * <p>Exists so the batch keeps its identity all the way to the check. A producer already hands over
+ * exactly one array per batch, so the boundary was always there — it simply had nothing attached to
+ * it, which is why the outcome could not be reported per range.
+ *
+ * <p>Deliberately a plain class rather than a record: the candidate array holds up to
+ * {@code 2^batchSizeInBits} entries, and a record would either compare it by reference (misleading)
+ * or force a defensive copy of a multi-megabyte array on the hot path. This type is only ever moved
+ * through a queue and never compared, so identity semantics are exactly right.
+ */
+@ToString
+final class QueuedBatch {
+
+    @ToString.Exclude
+    private final PublicKeyBytes[] keys;
+
+    private final @Nullable BigInteger secretBase;
+
+    /**
+     * Creates a queued batch.
+     *
+     * @param keys       the candidates of this batch, taken over as-is
+     * @param secretBase the aligned start of the swept grid, or {@code null} when the batch is a set
+     *                   of independent secrets rather than one expanded range
+     */
+    QueuedBatch(PublicKeyBytes[] keys, @Nullable BigInteger secretBase) {
+        this.keys = keys;
+        this.secretBase = secretBase;
+    }
+
+    /**
+     * Returns the candidates of this batch.
+     *
+     * @return the candidate array, not copied
+     */
+    PublicKeyBytes[] keys() {
+        return keys;
+    }
+
+    /**
+     * Returns the aligned start of the swept grid.
+     *
+     * @return the base, or {@code null} when this batch has none
+     */
+    @Nullable
+    BigInteger secretBase() {
+        return secretBase;
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/core/BatchResult.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/core/BatchResult.java
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.core;
+
+import java.math.BigInteger;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The outcome of one checked batch — reported whether or not anything was found.
+ *
+ * <p>Reporting the empty case is the point. A client sweeping a range needs to distinguish "checked,
+ * nothing there" from "never checked"; if only hits were reported the two would look identical, and
+ * a range dropped when the process stopped would silently be recorded as clean. Because this is
+ * emitted after the batch has been checked against the database, it is also an exact completion
+ * signal: no dispatch-ahead lag that a client would have to compensate for.
+ *
+ * @param secretBase   the aligned start of the swept grid, or {@code null} when the batch was a set
+ *                     of independent secrets rather than one expanded range
+ * @param checkedCount how many candidates this batch carried
+ * @param hits         everything found, empty when nothing matched
+ */
+public record BatchResult(@Nullable BigInteger secretBase, int checkedCount, List<Hit> hits) {
+
+    /**
+     * Creates a batch result with an unmodifiable hit list.
+     *
+     * @param secretBase   the aligned start of the swept grid, or {@code null}
+     * @param checkedCount how many candidates this batch carried
+     * @param hits         everything found, empty when nothing matched
+     */
+    public BatchResult {
+        hits = List.copyOf(hits);
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/core/Hit.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/core/Hit.java
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.core;
+
+import java.math.BigInteger;
+
+/**
+ * One address found in the database, together with the key that produced it.
+ *
+ * <p><b>Contains the private key.</b> A hit is the thing this program exists to find, and anything
+ * that forwards one — a log file, a broadcast to connected listeners — hands over full control of
+ * the funds. Treat every sink for this type as a place where key material leaves the process.
+ *
+ * <p>Deliberately built from plain JDK types rather than the project's address value objects: this
+ * package sits below the model layer, and keeping the payload primitive also keeps it stable as a
+ * wire format for external consumers. The hash is carried hex-encoded rather than as a byte array so
+ * the record keeps value semantics and needs no defensive copying.
+ *
+ * @param privateKey   the private key that derives this address
+ * @param hash160Hex   the RIPEMD-160 hash of the public key, hex-encoded
+ * @param address      the encoded address
+ * @param compressed   whether the address was derived from the compressed public key
+ * @param vanity       whether this is a vanity-pattern match rather than a database hit
+ */
+public record Hit(BigInteger privateKey, String hash160Hex, String address, boolean compressed, boolean vanity) {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/core/ResultListener.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/core/ResultListener.java
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.core;
+
+/**
+ * Receives the outcome of every checked batch.
+ *
+ * <p>This is the seam that lets results leave the process by some route other than the log. It
+ * carries no transport of its own on purpose: the consumer knows only this interface, and whatever
+ * forwards the results — a socket, a WebSocket, ZeroMQ — is wired in from above. That keeps the
+ * network libraries out of the consumer entirely.
+ *
+ * <p><b>Implementations must not block and must not throw.</b> They are invoked on the consumer's
+ * worker threads, directly in the path that drains the key queue; a slow or failing listener would
+ * stall or break the scan itself. Buffer, drop, or log — but return promptly.
+ */
+public interface ResultListener {
+
+    /**
+     * Called once per batch, after it has been checked against the database.
+     *
+     * @param batchResult what the batch contained and what was found in it, possibly nothing
+     */
+    void onBatchChecked(BatchResult batchResult);
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/Finder.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/Finder.java
@@ -5,6 +5,7 @@ package net.ladenthin.bitcoinaddressfinder.engine;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -13,6 +14,9 @@ import java.util.function.*;
 import lombok.ToString;
 import net.ladenthin.bitcoinaddressfinder.configuration.CConsumerJava;
 import net.ladenthin.bitcoinaddressfinder.configuration.CFinder;
+import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaSocket;
+import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaWebSocket;
+import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaZmq;
 import net.ladenthin.bitcoinaddressfinder.configuration.CProducer;
 import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
 import net.ladenthin.bitcoinaddressfinder.configuration.GpuFilterType;
@@ -20,6 +24,7 @@ import net.ladenthin.bitcoinaddressfinder.consumer.Consumer;
 import net.ladenthin.bitcoinaddressfinder.consumer.ConsumerJava;
 import net.ladenthin.bitcoinaddressfinder.core.FireAndForget;
 import net.ladenthin.bitcoinaddressfinder.core.Interruptable;
+import net.ladenthin.bitcoinaddressfinder.core.ResultListener;
 import net.ladenthin.bitcoinaddressfinder.core.Startable;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducer;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerIdIsNotUniqueException;
@@ -31,6 +36,9 @@ import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaRandom;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaSocket;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaWebSocket;
 import net.ladenthin.bitcoinaddressfinder.keyproducer.KeyProducerJavaZmq;
+import net.ladenthin.bitcoinaddressfinder.keyproducer.SocketResultBroadcaster;
+import net.ladenthin.bitcoinaddressfinder.keyproducer.WebSocketResultBroadcaster;
+import net.ladenthin.bitcoinaddressfinder.keyproducer.ZmqResultBroadcaster;
 import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse16GpuFilterData;
 import net.ladenthin.bitcoinaddressfinder.persistence.inmemory.BinaryFuse8GpuFilterData;
@@ -38,6 +46,7 @@ import net.ladenthin.bitcoinaddressfinder.producer.Producer;
 import net.ladenthin.bitcoinaddressfinder.producer.ProducerJava;
 import net.ladenthin.bitcoinaddressfinder.producer.ProducerJavaSecretsFiles;
 import net.ladenthin.bitcoinaddressfinder.producer.ProducerOpenCL;
+import net.ladenthin.bitcoinaddressfinder.producer.ProducerReleaser;
 import net.ladenthin.bitcoinaddressfinder.producer.ProducerState;
 import net.ladenthin.bitcoinaddressfinder.statistics.RuntimeStatistics;
 import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
@@ -86,6 +95,24 @@ public class Finder implements Interruptable {
     // ExecutorService toString is verbose pool internals — not useful in aggregate logs.
     @ToString.Exclude
     private final ExecutorService producerExecutorService;
+
+    /**
+     * Result broadcasters built from the configured key producers, kept so the grid configuration
+     * can be announced to them once the producers are known and so they can be closed on shutdown.
+     */
+    @ToString.Exclude
+    private final List<ResultBroadcaster> resultBroadcasters = new ArrayList<>();
+
+    /** ZeroMQ publishers, kept so their context can be closed on shutdown. */
+    @ToString.Exclude
+    private final List<ZmqResultBroadcaster> zmqBroadcasters = new ArrayList<>();
+
+    /** Result servers, kept so their listening socket can be closed on shutdown. */
+    @ToString.Exclude
+    private final List<SocketResultBroadcaster> socketBroadcasters = new ArrayList<>();
+
+    /** Guarantees each producer is released exactly once, even when two teardowns overlap. */
+    private final ProducerReleaser producerReleaser = new ProducerReleaser();
 
     private final KeyUtility keyUtility;
     private final PersistenceUtils persistenceUtils;
@@ -200,8 +227,8 @@ public class Finder implements Interruptable {
         LOGGER.info("startConsumer");
         CConsumerJava localCConsumerJava = Objects.requireNonNull(finder.consumerJava);
 
-        final ConsumerJava localConsumerJava =
-                new ConsumerJava(localCConsumerJava, keyUtility, persistenceUtils, runtimeStatistics);
+        final ConsumerJava localConsumerJava = new ConsumerJava(
+                localCConsumerJava, keyUtility, persistenceUtils, runtimeStatistics, createResultListeners());
         consumerJava = localConsumerJava;
         // Decide up-front whether the GPU pre-filter is needed so initLMDB() can build it while
         // LMDB is still open — a self-contained backend closes the env at the end of initLMDB().
@@ -210,6 +237,145 @@ public class Finder implements Interruptable {
         localConsumerJava.initLMDB();
         localConsumerJava.startConsumer();
         localConsumerJava.startStatisticsTimer();
+    }
+
+    /**
+     * Builds the result listeners for every key producer configured to broadcast.
+     *
+     * <p>Wired here rather than inside the consumer because only this class knows both sides: the
+     * consumer must not depend on the key-producer layer, and the transport lives there. The
+     * consumer sees nothing but the {@code ResultListener} contract.
+     *
+     * @return the listeners to notify for every checked batch, possibly empty
+     */
+    private List<ResultListener> createResultListeners() {
+        final List<ResultListener> listeners = new ArrayList<>();
+        addWebSocketBroadcasters(listeners);
+        addZmqBroadcasters(listeners);
+        addSocketBroadcasters(listeners);
+        return listeners;
+    }
+
+    /**
+     * Adds a broadcaster for every WebSocket key producer configured to report results.
+     *
+     * <p>Shares the key producer's server, so ranges in and results out travel one port.
+     *
+     * @param listeners the list to add to
+     */
+    private void addWebSocketBroadcasters(List<ResultListener> listeners) {
+        for (CKeyProducerJavaWebSocket config : finder.keyProducerJavaWebSocket) {
+            if (!config.broadcastResults) {
+                continue;
+            }
+            final String keyProducerId = config.keyProducerId;
+            if (keyProducerId == null) {
+                // An id-less entry never started a key producer; startKeyProducer already rejected it.
+                continue;
+            }
+            final KeyProducer keyProducer = keyProducers.get(keyProducerId);
+            if (!(keyProducer instanceof KeyProducerJavaWebSocket webSocketKeyProducer)) {
+                LOGGER.warn(
+                        "broadcastResults is set for keyProducerId {} but no WebSocket key producer was started;"
+                                + " results will not be broadcast.",
+                        keyProducerId);
+                continue;
+            }
+            final WebSocketResultBroadcaster broadcaster =
+                    new WebSocketResultBroadcaster(webSocketKeyProducer.getEndpoint());
+            resultBroadcasters.add(broadcaster::announceConfiguration);
+            listeners.add(broadcaster);
+            LOGGER.info("Broadcasting results on the WebSocket of keyProducerId {}", keyProducerId);
+        }
+    }
+
+    /**
+     * Adds a publisher for every ZeroMQ key producer configured to report results.
+     *
+     * <p>Needs an address of its own: secrets arrive on a {@code PULL} socket, which cannot send.
+     *
+     * @param listeners the list to add to
+     */
+    private void addZmqBroadcasters(List<ResultListener> listeners) {
+        for (CKeyProducerJavaZmq config : finder.keyProducerJavaZmq) {
+            if (!config.broadcastResults) {
+                continue;
+            }
+            final ZmqResultBroadcaster broadcaster = new ZmqResultBroadcaster(config.publishAddress);
+            resultBroadcasters.add(broadcaster::announceConfiguration);
+            zmqBroadcasters.add(broadcaster);
+            listeners.add(broadcaster);
+            LOGGER.info("Publishing results on {}", config.publishAddress);
+        }
+    }
+
+    /**
+     * Adds a result server for every plain-socket key producer configured to report results.
+     *
+     * <p>Serves on a port of its own, because the inbound side handles a single peer with a
+     * different framing.
+     *
+     * @param listeners the list to add to
+     */
+    private void addSocketBroadcasters(List<ResultListener> listeners) {
+        for (CKeyProducerJavaSocket config : finder.keyProducerJavaSocket) {
+            if (!config.broadcastResults) {
+                continue;
+            }
+            final SocketResultBroadcaster broadcaster = new SocketResultBroadcaster(config.resultPort);
+            try {
+                broadcaster.start();
+            } catch (IOException e) {
+                LOGGER.error("Could not serve results on port {}; continuing without it.", config.resultPort, e);
+                continue;
+            }
+            resultBroadcasters.add(broadcaster::announceConfiguration);
+            socketBroadcasters.add(broadcaster);
+            listeners.add(broadcaster);
+        }
+    }
+
+    /**
+     * Tells the connected clients which grid the running producers expand a base into.
+     *
+     * <p>Called once the producers are configured, which is necessarily later than the moment the
+     * WebSocket started accepting connections. A client cannot derive its step without it: every
+     * incoming base is aligned down to a multiple of {@code 2^batchSizeInBits}, so a client stepping
+     * by less would resubmit the same block and never cover the rest of its range.
+     *
+     * <p>When producers disagree on the grid size the largest is announced, which is the only choice
+     * that cannot make ranges overlap.
+     */
+    private void announceGridConfigurationToBroadcasters() {
+        if (resultBroadcasters.isEmpty()) {
+            return;
+        }
+        final List<Producer> allProducers = getAllProducers();
+        if (allProducers.isEmpty()) {
+            return;
+        }
+        int batchSizeInBits = 0;
+        boolean batchUsePrivateKeyIncrement = true;
+        for (CProducer cProducer : configuredProducerConfigs()) {
+            batchSizeInBits = Math.max(batchSizeInBits, cProducer.batchSizeInBits);
+            batchUsePrivateKeyIncrement &= cProducer.batchUsePrivateKeyIncrement;
+        }
+        for (ResultBroadcaster broadcaster : resultBroadcasters) {
+            broadcaster.announceConfiguration(batchSizeInBits, batchUsePrivateKeyIncrement);
+        }
+    }
+
+    /**
+     * Returns the configuration of every producer that was actually created.
+     *
+     * @return the producer configurations backing the running producers
+     */
+    private List<CProducer> configuredProducerConfigs() {
+        final List<CProducer> configs = new ArrayList<>();
+        configs.addAll(finder.producerJava);
+        configs.addAll(finder.producerJavaSecretsFiles);
+        configs.addAll(finder.producerOpenCL);
+        return configs;
     }
 
     /**
@@ -305,6 +471,8 @@ public class Finder implements Interruptable {
         // only to the producers that remain in compact mode.
         applyVanityFullTransferOverride();
         uploadGpuFilterToProducers();
+        // Only now is the grid known; clients that connected earlier are caught up here.
+        announceGridConfigurationToBroadcasters();
     }
 
     /**
@@ -511,6 +679,19 @@ public class Finder implements Interruptable {
         producerExecutorService.shutdown();
         producerExecutorService.awaitTermination(finder.awaitTerminateSeconds, TimeUnit.SECONDS);
 
+        // The producers have stopped, but stopping them does not release what they own: a
+        // ProducerOpenCL still holds its result-reader pool, and the key producers still hold the
+        // reader threads behind their socket / websocket / ZeroMQ sources. Those threads are
+        // non-daemon, so leaving them running keeps the JVM alive after Main#run has returned — the
+        // process then logs its completion and never exits.
+        //
+        // Releasing them from the JVM shutdown hook, which is where interrupt() used to be reached
+        // on this path, cannot work: a shutdown hook only starts once every non-daemon thread has
+        // already ended, so the release that would end them would never be reached. The teardown
+        // therefore belongs here, on the completion path itself. interrupt() is idempotent (it frees
+        // the collections it walks), so the hook calling it again later is harmless.
+        interrupt();
+
         // no producers are running anymore, the consumer can be interrupted
         final ConsumerJava localConsumerJava = consumerJava;
         if (localConsumerJava != null) {
@@ -521,26 +702,46 @@ public class Finder implements Interruptable {
         LOGGER.info("consumerJava released.");
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Two callers can arrive here at once: the teardown runs both on the ordinary completion path
+     * ({@link #shutdownAndAwaitTermination()}) and from the JVM shutdown hook, and a {@code Ctrl+C}
+     * landing while a finished run releases its producers is enough to overlap them. Releasing a
+     * producer twice is not harmless — an OpenCL producer's second release is rejected by the driver
+     * with {@code CL_INVALID_MEM_OBJECT}. {@link ProducerReleaser} owns that guarantee; clearing the
+     * collections below is bookkeeping, not the safeguard.
+     */
     @Override
     public void interrupt() {
         LOGGER.info("interrupt called: delegate interrupt to all keyProducers and producers");
 
-        // Interrupt all Producers
-        for (Producer producer : getAllProducers()) {
-            LOGGER.info("Interrupt Producer: " + producer.toString());
-            producer.interrupt();
-            LOGGER.info("waitTillProducerNotRunning ...");
-            producer.waitTillProducerNotRunning();
-            producer.releaseProducer();
-        }
-        freeAllProducers();
-
-        // Interrupt all KeyProducers
+        // Key producers first. A producer waiting for its next secret is parked inside the key
+        // producer, and a key producer configured to block indefinitely (timeoutMillis < 0, which is
+        // what an interactively driven source wants) only releases that wait when it is interrupted.
+        // Waiting for the producers first would therefore wait for something that cannot happen
+        // until after the wait — the producer would sit there until its shutdownTimeoutSeconds ran
+        // out, turning every shutdown into a multi-minute stall.
         for (KeyProducer keyProducer : getKeyProducers().values()) {
             LOGGER.info("Interrupt KeyProducer: " + keyProducer.toString());
             keyProducer.interrupt();
         }
         freeAllKeyProducers();
+
+        // Broadcasters own sockets of their own; releasing them here keeps the process able to exit.
+        for (ZmqResultBroadcaster broadcaster : zmqBroadcasters) {
+            broadcaster.close();
+        }
+        zmqBroadcasters.clear();
+        for (SocketResultBroadcaster broadcaster : socketBroadcasters) {
+            broadcaster.close();
+        }
+        socketBroadcasters.clear();
+        resultBroadcasters.clear();
+
+        // Interrupt and release all Producers, each exactly once even under a concurrent teardown.
+        producerReleaser.release(getAllProducers());
+        freeAllProducers();
 
         LOGGER.info("All producers released and freed.");
     }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/ResultBroadcaster.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/engine/ResultBroadcaster.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.engine;
+
+/**
+ * The one thing the orchestrator needs from a result broadcaster, regardless of its transport.
+ *
+ * <p>Announcing the grid cannot happen when a broadcaster is built: the producers do not exist yet
+ * at that point, and only they know the size a base is expanded to. This contract exists so the
+ * orchestrator can come back later and tell every broadcaster at once, without knowing whether it
+ * speaks WebSocket, ZeroMQ or plain TCP.
+ *
+ * <p>How a transport gets that message to a client differs and is its own business: a WebSocket can
+ * greet on connect and catch up whoever was already there, a ZeroMQ publisher cannot see its
+ * subscribers at all and has to republish, and a TCP server greets on accept.
+ */
+@FunctionalInterface
+interface ResultBroadcaster {
+
+    /**
+     * Publishes the grid configuration a client needs in order to send usable ranges.
+     *
+     * @param batchSizeInBits             the grid size each base is expanded to
+     * @param batchUsePrivateKeyIncrement whether one base yields a whole grid
+     */
+    void announceConfiguration(int batchSizeInBits, boolean batchUsePrivateKeyIncrement);
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/BatchResultJsonFormatter.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/BatchResultJsonFormatter.java
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.math.BigInteger;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.Hit;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Renders the result messages that every transport sends.
+ *
+ * <p>One place for the wire format, because three transports report the same thing and a format that
+ * exists three times drifts. External clients parse these field names, so this class is effectively
+ * a published contract even though nothing here enforces that.
+ *
+ * <p>Two message shapes, told apart by {@code type}:
+ *
+ * <ul>
+ *   <li>{@code config} — sent once a client can be told what grid the producers use. A client needs
+ *       {@code batchSizeInBits} to know the step it must advance by; the server aligns every
+ *       incoming base down to a multiple of it, so a smaller step resubmits one block forever while
+ *       the rest of the range is never touched.
+ *   <li>{@code batch} — the outcome of one checked batch, sent whether or not anything was found.
+ *       Reporting the empty case is what lets a client tell "checked, nothing there" from "never
+ *       checked".
+ * </ul>
+ *
+ * <p>Big integers are hex without a prefix, so a browser can read them straight into a {@code BigInt}.
+ * Output is always a single line: the line-delimited transports frame on the newline.
+ */
+@ToString
+public class BatchResultJsonFormatter {
+
+    /** Message discriminator for the per-batch outcome. */
+    private static final String TYPE_BATCH = "batch";
+
+    /** Message discriminator for the configuration greeting. */
+    private static final String TYPE_CONFIG = "config";
+
+    /** Radix used for the big-integer fields, matching how keys and ranges are written elsewhere. */
+    private static final int HEX_RADIX = 16;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Creates a new {@link BatchResultJsonFormatter}. */
+    public BatchResultJsonFormatter() {}
+
+    /**
+     * Renders the outcome of one checked batch.
+     *
+     * @param batchResult the outcome to render
+     * @return a single-line JSON message
+     * @throws JsonProcessingException if the payload cannot be written
+     */
+    public String formatBatch(BatchResult batchResult) throws JsonProcessingException {
+        final ObjectNode root = objectMapper.createObjectNode();
+        root.put("type", TYPE_BATCH);
+
+        final @Nullable BigInteger secretBase = batchResult.secretBase();
+        if (secretBase == null) {
+            root.putNull("secretBase");
+        } else {
+            root.put("secretBase", secretBase.toString(HEX_RADIX));
+        }
+        root.put("checkedCount", batchResult.checkedCount());
+
+        final ArrayNode hits = root.putArray("hits");
+        for (Hit hit : batchResult.hits()) {
+            final ObjectNode hitNode = hits.addObject();
+            hitNode.put("privateKey", hit.privateKey().toString(HEX_RADIX));
+            hitNode.put("hash160Hex", hit.hash160Hex());
+            hitNode.put("address", hit.address());
+            hitNode.put("compressed", hit.compressed());
+            hitNode.put("vanity", hit.vanity());
+        }
+        return objectMapper.writeValueAsString(root);
+    }
+
+    /**
+     * Renders the grid configuration a client needs in order to send usable ranges.
+     *
+     * @param batchSizeInBits             the grid size each base is expanded to
+     * @param batchUsePrivateKeyIncrement whether one base yields a whole grid; when {@code false} the
+     *                                    producer wants one secret per candidate instead
+     * @return a single-line JSON message
+     * @throws JsonProcessingException if the payload cannot be written
+     */
+    public String formatConfiguration(int batchSizeInBits, boolean batchUsePrivateKeyIncrement)
+            throws JsonProcessingException {
+        final ObjectNode root = objectMapper.createObjectNode();
+        root.put("type", TYPE_CONFIG);
+        root.put("batchSizeInBits", batchSizeInBits);
+        root.put("batchUsePrivateKeyIncrement", batchUsePrivateKeyIncrement);
+        root.put("secretByteLength", OpenClKernelConstants.PRIVATE_KEY_MAX_NUM_BYTES);
+        return objectMapper.writeValueAsString(root);
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaWebSocket.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/KeyProducerJavaWebSocket.java
@@ -3,32 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.keyproducer;
 
-import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
-import java.util.concurrent.Executors;
 import lombok.ToString;
 import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaWebSocket;
 import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
-import net.ladenthin.bitcoinaddressfinder.core.FireAndForget;
 import net.ladenthin.bitcoinaddressfinder.core.Startable;
 import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
 import net.ladenthin.bitcoinaddressfinder.util.KeyUtility;
-import org.java_websocket.WebSocket;
-import org.java_websocket.handshake.ClientHandshake;
-import org.java_websocket.server.WebSocketServer;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Key producer that receives secrets through a WebSocket server.
  *
- * <p>The embedded {@link WebSocketServer} is not constructed by the constructor;
- * callers must invoke {@link #start()} after construction. This matches the
- * sibling {@link KeyProducerJavaSocket} and {@link KeyProducerJavaZmq} producers
- * and removes the same partial-construction publication hazard (the anonymous
- * {@code WebSocketServer} subclass captures the outer-class {@code this} and its
- * callbacks call back into {@code addSecret} / read {@code shouldStop}).</p>
+ * <p>The server itself lives in {@link WebSocketEndpoint}, which this producer shares with the
+ * result broadcaster: one port carries the ranges in and the outcomes back, so a browser page needs
+ * a single connection to act as the whole user interface.
+ *
+ * <p>The endpoint is not started by the constructor; callers must invoke {@link #start()}
+ * afterwards. That keeps a partially-constructed instance from being published to the server's
+ * callback threads, which read {@code shouldStop} and call {@code addSecret}.
  */
 @ToString(callSuper = true)
 public class KeyProducerJavaWebSocket extends AbstractKeyProducerQueueBuffered<CKeyProducerJavaWebSocket>
@@ -36,72 +29,57 @@ public class KeyProducerJavaWebSocket extends AbstractKeyProducerQueueBuffered<C
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyProducerJavaWebSocket.class);
 
-    private @Nullable WebSocketServer webSocketServer;
+    @ToString.Exclude
+    private final WebSocketEndpoint endpoint;
 
     /**
-     * Creates a new WebSocket-based key producer. The embedded server is NOT
-     * constructed here; the caller must invoke {@link #start()} afterwards.
+     * Creates a new WebSocket-based key producer. The server is NOT started here; the caller must
+     * invoke {@link #start()} afterwards.
      *
      * @param config      the WebSocket configuration
      * @param keyUtility  cryptographic helper
      * @param bitHelper   bit/batch-size helper (unused but kept for symmetry)
      */
     public KeyProducerJavaWebSocket(CKeyProducerJavaWebSocket config, KeyUtility keyUtility, BitHelper bitHelper) {
-        super(config, keyUtility);
+        this(config, keyUtility, bitHelper, new WebSocketEndpoint(config.getPort()));
     }
 
     /**
-     * Builds the embedded {@link WebSocketServer} and submits its blocking
-     * {@code start()} call to a single-thread executor so the server runs in the
-     * background. Idempotency: calling {@code start()} more than once will
-     * replace the server reference; the intended usage is a single invocation
-     * right after construction.
+     * Creates a new WebSocket-based key producer on an explicit endpoint.
+     *
+     * @param config      the WebSocket configuration
+     * @param keyUtility  cryptographic helper
+     * @param bitHelper   bit/batch-size helper (unused but kept for symmetry)
+     * @param endpoint    the server shared with the result broadcaster
      */
+    public KeyProducerJavaWebSocket(
+            CKeyProducerJavaWebSocket config, KeyUtility keyUtility, BitHelper bitHelper, WebSocketEndpoint endpoint) {
+        super(config, keyUtility);
+        this.endpoint = endpoint;
+    }
+
+    /**
+     * Returns the shared server, so a result broadcaster can send on the same port.
+     *
+     * @return the endpoint backing this producer
+     */
+    public WebSocketEndpoint getEndpoint() {
+        return endpoint;
+    }
+
     @Override
     public void start() {
-        final WebSocketServer localServer = new WebSocketServer(new InetSocketAddress(cKeyProducerJava.getPort())) {
-            @Override
-            public void onOpen(WebSocket conn, ClientHandshake handshake) {
-                LOGGER.info("WebSocket connection opened from: {}", conn.getRemoteSocketAddress());
+        endpoint.setMessageHandler(message -> {
+            if (shouldStop) {
+                return;
             }
-
-            @Override
-            public void onClose(WebSocket conn, int code, String reason, boolean remote) {
-                LOGGER.info("WebSocket closed: {}", conn.getRemoteSocketAddress());
+            if (message.length == OpenClKernelConstants.PRIVATE_KEY_MAX_NUM_BYTES) {
+                addSecret(message);
+            } else {
+                LOGGER.warn("Invalid message length: {}", message.length);
             }
-
-            @Override
-            public void onMessage(WebSocket conn, ByteBuffer message) {
-                if (shouldStop) return;
-                if (message.remaining() == OpenClKernelConstants.PRIVATE_KEY_MAX_NUM_BYTES) {
-                    byte[] secret = new byte[OpenClKernelConstants.PRIVATE_KEY_MAX_NUM_BYTES];
-                    message.get(secret);
-                    addSecret(secret);
-                } else {
-                    LOGGER.warn("Invalid message length: {}", message.remaining());
-                }
-            }
-
-            @Override
-            public void onError(WebSocket conn, Exception ex) {
-                LOGGER.error("WebSocket error", ex);
-            }
-
-            @Override
-            public void onStart() {
-                LOGGER.info("WebSocket server started on port: {}", getPort());
-            }
-
-            @Override
-            public void onMessage(WebSocket ws, String string) {
-                LOGGER.info("onMessage: {}", string);
-            }
-        };
-        webSocketServer = localServer;
-
-        @FireAndForget("lifecycle via WebSocketServer.stop() in interrupt()")
-        @SuppressWarnings("FutureReturnValueIgnored")
-        Object unused = Executors.newSingleThreadExecutor().submit(localServer::start);
+        });
+        endpoint.start();
     }
 
     @Override
@@ -112,12 +90,6 @@ public class KeyProducerJavaWebSocket extends AbstractKeyProducerQueueBuffered<C
     @Override
     public void interrupt() {
         signalShutdown(); // wakes any caller blocked in createSecrets()
-        if (webSocketServer != null) {
-            try {
-                webSocketServer.stop();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
+        endpoint.stop();
     }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/SocketResultBroadcaster.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/SocketResultBroadcaster.java
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.FireAndForget;
+import net.ladenthin.bitcoinaddressfinder.core.ResultListener;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Serves the outcome of every checked batch to every connected TCP client.
+ *
+ * <p>Every batch is reported, hit or not, so a client sweeping a range can tell "checked, nothing
+ * there" from "never checked".
+ *
+ * <p><b>The payload contains private keys</b>, and every connected client receives every result —
+ * including hits from ranges somebody else submitted.
+ *
+ * <h2>Why this is a server of its own</h2>
+ * The plain-socket key producer serves exactly one peer: it accepts a single connection and reads a
+ * stream of fixed-width secrets from it. "Reach every listener" has no counterpart there, so this
+ * class keeps its own accept loop and its own client list rather than extending that one.
+ *
+ * <h2>Framing differs by direction</h2>
+ * Inbound secrets need no framing — every record is exactly
+ * {@code PRIVATE_KEY_MAX_NUM_BYTES} long. Results are variable-length JSON, so they are terminated
+ * by a newline and a reader can use {@code readLine()}. The formatter guarantees single-line output;
+ * an embedded newline would split one message into two.
+ *
+ * <h2>What it does not promise</h2>
+ * Delivery is best-effort: a client that is not connected when a batch completes misses that message
+ * and nothing replays it. The log remains the authoritative record of a hit. A client whose write
+ * fails is dropped, and one slow client cannot be allowed to stall the scan — writes happen on the
+ * consumer's worker thread, so a peer that stops reading will eventually fill its buffer and be
+ * dropped on the resulting error rather than blocking forever.
+ */
+@ToString
+public class SocketResultBroadcaster implements ResultListener, AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SocketResultBroadcaster.class);
+
+    /** Terminates every outbound message; see the framing note in the class comment. */
+    private static final String MESSAGE_TERMINATOR = "\n";
+
+    /** How long the accept loop waits before checking whether it should stop. */
+    private static final int ACCEPT_TIMEOUT_MILLIS = 250;
+
+    /** Poll interval used while waiting for an expected client count. */
+    private static final int CLIENT_WAIT_POLL_MILLIS = 20;
+
+    private final int port;
+    private final BatchResultJsonFormatter formatter;
+
+    @ToString.Exclude
+    private final List<Socket> clients = new CopyOnWriteArrayList<>();
+
+    @ToString.Exclude
+    private final ExecutorService acceptExecutor = Executors.newSingleThreadExecutor();
+
+    private volatile boolean shouldStop = false;
+
+    @ToString.Exclude
+    private volatile @Nullable ServerSocket serverSocket;
+
+    /** The greeting, once the producer configuration it describes is known. */
+    @ToString.Exclude
+    private volatile @Nullable String configurationMessage;
+
+    /**
+     * Creates a broadcaster serving on the given port. The server is not started here.
+     *
+     * @param port the TCP port to serve on
+     */
+    public SocketResultBroadcaster(int port) {
+        this(port, new BatchResultJsonFormatter());
+    }
+
+    /**
+     * Creates a broadcaster on an explicit formatter.
+     *
+     * @param port      the TCP port to serve on
+     * @param formatter renders the wire messages
+     */
+    public SocketResultBroadcaster(int port, BatchResultJsonFormatter formatter) {
+        this.port = port;
+        this.formatter = formatter;
+    }
+
+    /**
+     * Starts accepting clients on a background thread.
+     *
+     * @throws IOException if the port cannot be bound
+     */
+    public void start() throws IOException {
+        final ServerSocket localServerSocket = new ServerSocket(port);
+        localServerSocket.setSoTimeout(ACCEPT_TIMEOUT_MILLIS);
+        serverSocket = localServerSocket;
+        LOGGER.info("Serving results on port {}", port);
+
+        @FireAndForget("lifecycle via close()")
+        @SuppressWarnings("FutureReturnValueIgnored")
+        Object unused = acceptExecutor.submit(() -> {
+            while (!shouldStop) {
+                try {
+                    final Socket client = localServerSocket.accept();
+                    clients.add(client);
+                    LOGGER.info("Result listener connected: {}", String.valueOf(client.getRemoteSocketAddress()));
+                    // A client that arrives after the grid is known must not have to wait for the
+                    // next republication to learn it.
+                    final String greeting = configurationMessage;
+                    if (greeting != null) {
+                        writeTo(client, greeting);
+                    }
+                } catch (java.net.SocketTimeoutException e) {
+                    // expected: the timeout exists so the loop can observe shouldStop
+                } catch (IOException e) {
+                    if (!shouldStop) {
+                        LOGGER.warn("Accepting a result listener failed; continuing.", e);
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Records the grid configuration and sends it to everyone already connected.
+     *
+     * @param batchSizeInBits             the grid size each base is expanded to
+     * @param batchUsePrivateKeyIncrement whether one base yields a whole grid
+     */
+    public void announceConfiguration(int batchSizeInBits, boolean batchUsePrivateKeyIncrement) {
+        final String message;
+        try {
+            message = formatter.formatConfiguration(batchSizeInBits, batchUsePrivateKeyIncrement);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Could not serialise the grid configuration; clients will not receive it.", e);
+            return;
+        }
+        configurationMessage = message;
+        broadcast(message);
+    }
+
+    @Override
+    public void onBatchChecked(BatchResult batchResult) {
+        final String message;
+        try {
+            message = formatter.formatBatch(batchResult);
+        } catch (JsonProcessingException e) {
+            // Never let a serialisation problem reach the consumer thread that is draining keys.
+            LOGGER.error("Could not serialise a batch result; skipping this message.", e);
+            return;
+        }
+        broadcast(message);
+    }
+
+    /**
+     * Blocks until the expected number of clients is connected.
+     *
+     * <p>Exists for tests: a client's socket is connected before the accept loop has registered it,
+     * so sending immediately after connecting would race the registration.
+     *
+     * @param expected     the number of clients to wait for
+     * @param timeoutMillis how long to wait
+     * @throws InterruptedException if the wait is interrupted
+     */
+    public void awaitClientCount(int expected, int timeoutMillis) throws InterruptedException {
+        final long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (System.currentTimeMillis() < deadline) {
+            if (clients.size() >= expected) {
+                return;
+            }
+            Thread.sleep(CLIENT_WAIT_POLL_MILLIS);
+        }
+        throw new IllegalStateException(
+                "Expected " + expected + " result listeners but only " + clients.size() + " connected");
+    }
+
+    /**
+     * Sends one message to every connected client, dropping the ones that fail.
+     *
+     * @param message the message to send, without its terminator
+     */
+    private void broadcast(String message) {
+        // Collect first, remove after: mutating the list while walking it is legal on a
+        // copy-on-write list but reads as a bug at every later glance, and the intent here is
+        // simply "drop the ones that failed".
+        final List<Socket> dead = new ArrayList<>();
+        for (Socket client : clients) {
+            if (!writeTo(client, message)) {
+                dead.add(client);
+            }
+        }
+        for (Socket client : dead) {
+            clients.remove(client);
+            closeQuietly(client);
+        }
+    }
+
+    /**
+     * Writes one terminated message to one client.
+     *
+     * @param client  the client to write to
+     * @param message the message to send
+     * @return {@code true} if the write succeeded
+     */
+    private boolean writeTo(Socket client, String message) {
+        try {
+            final OutputStream out = client.getOutputStream();
+            out.write((message + MESSAGE_TERMINATOR).getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            return true;
+        } catch (IOException e) {
+            LOGGER.info("Result listener {} went away; dropping it.", String.valueOf(client.getRemoteSocketAddress()));
+            return false;
+        }
+    }
+
+    /**
+     * Closes a socket, ignoring failures.
+     *
+     * @param socket the resource to close
+     */
+    private static void closeQuietly(Closeable socket) {
+        try {
+            socket.close();
+        } catch (IOException e) {
+            // best-effort: the peer is already gone
+        }
+    }
+
+    @Override
+    public void close() {
+        shouldStop = true;
+        final ServerSocket localServerSocket = serverSocket;
+        if (localServerSocket != null) {
+            try {
+                localServerSocket.close();
+            } catch (IOException e) {
+                // best-effort during shutdown
+            }
+        }
+        for (Socket client : clients) {
+            closeQuietly(client);
+        }
+        clients.clear();
+        acceptExecutor.shutdownNow();
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/WebSocketEndpoint.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/WebSocketEndpoint.java
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.core.FireAndForget;
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One embedded WebSocket server, usable in both directions.
+ *
+ * <p>Extracted so incoming secrets and outgoing results can share a single server on a single port.
+ * That is what makes a browser page a complete user interface with one connection: it feeds ranges in
+ * and watches the outcome come back, without a second endpoint to configure.
+ *
+ * <p>The binding type {@link WebSocket} deliberately does not appear in this class's public API.
+ * Callers register a handler for inbound messages and a greeting for new connections; nothing above
+ * has to know which library moves the bytes.
+ */
+@ToString
+public class WebSocketEndpoint {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketEndpoint.class);
+
+    /** Receives binary messages arriving from a connected client. */
+    @FunctionalInterface
+    public interface MessageHandler {
+
+        /**
+         * Called for every binary message.
+         *
+         * @param message the message payload
+         */
+        void onBinaryMessage(byte[] message);
+    }
+
+    private final int port;
+
+    @ToString.Exclude
+    private @Nullable WebSocketServer webSocketServer;
+
+    @ToString.Exclude
+    private @Nullable MessageHandler messageHandler;
+
+    @ToString.Exclude
+    private @Nullable Supplier<@Nullable String> greetingSupplier;
+
+    /**
+     * Creates an endpoint bound to the given port. The server is not started here.
+     *
+     * @param port the TCP port to serve on
+     */
+    public WebSocketEndpoint(int port) {
+        this.port = port;
+    }
+
+    /**
+     * Registers the handler for inbound binary messages.
+     *
+     * @param messageHandler the handler, replacing any previous one
+     */
+    public void setMessageHandler(MessageHandler messageHandler) {
+        this.messageHandler = messageHandler;
+    }
+
+    /**
+     * Registers a greeting sent to every client right after it connects.
+     *
+     * <p>A supplier rather than a fixed string because the greeting describes the running
+     * configuration, which is only fully known once the producers have been configured — later than
+     * the moment this server starts accepting connections. Clients that connect before then simply
+     * receive nothing; {@link #greetAll()} catches them up.
+     *
+     * @param greetingSupplier produces the greeting; it may itself return {@code null} while the
+     *                         greeting is not yet known, in which case nothing is sent
+     */
+    public void setGreetingSupplier(@Nullable Supplier<@Nullable String> greetingSupplier) {
+        this.greetingSupplier = greetingSupplier;
+    }
+
+    /**
+     * Sends the current greeting to every connected client.
+     *
+     * <p>Used once the greeting becomes available, so clients that connected earlier are not left
+     * without it.
+     */
+    public void greetAll() {
+        final String greeting = currentGreeting();
+        if (greeting != null) {
+            broadcast(greeting);
+        }
+    }
+
+    /**
+     * Returns the greeting to send right now.
+     *
+     * @return the greeting, or {@code null} while none is available
+     */
+    private @Nullable String currentGreeting() {
+        final Supplier<@Nullable String> localSupplier = greetingSupplier;
+        if (localSupplier == null) {
+            return null;
+        }
+        final String greeting = localSupplier.get();
+        // An empty greeting is treated as absent: a client must never have to parse a blank message
+        // just because it connected before the configuration was known.
+        return greeting == null || greeting.isEmpty() ? null : greeting;
+    }
+
+    /**
+     * Starts the server on a background thread. Calling this more than once replaces the server;
+     * the intended usage is a single invocation.
+     */
+    public void start() {
+        final WebSocketServer localServer = new WebSocketServer(new InetSocketAddress(port)) {
+            @Override
+            public void onOpen(WebSocket conn, ClientHandshake handshake) {
+                LOGGER.info("WebSocket connection opened from: {}", conn.getRemoteSocketAddress());
+                final String greeting = currentGreeting();
+                if (greeting != null) {
+                    conn.send(greeting);
+                }
+            }
+
+            @Override
+            public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+                LOGGER.info("WebSocket closed: {}", conn.getRemoteSocketAddress());
+            }
+
+            @Override
+            public void onMessage(WebSocket conn, ByteBuffer message) {
+                final MessageHandler localHandler = messageHandler;
+                if (localHandler == null) {
+                    return;
+                }
+                final byte[] payload = new byte[message.remaining()];
+                message.get(payload);
+                localHandler.onBinaryMessage(payload);
+            }
+
+            @Override
+            public void onError(WebSocket conn, Exception ex) {
+                LOGGER.error("WebSocket error", ex);
+            }
+
+            @Override
+            public void onStart() {
+                LOGGER.info("WebSocket server started on port: {}", getPort());
+            }
+
+            @Override
+            public void onMessage(WebSocket ws, String string) {
+                LOGGER.info("onMessage: {}", string);
+            }
+        };
+        webSocketServer = localServer;
+
+        @FireAndForget("lifecycle via stop()")
+        @SuppressWarnings("FutureReturnValueIgnored")
+        Object unused = Executors.newSingleThreadExecutor().submit(localServer::start);
+    }
+
+    /**
+     * Sends a text message to every connected client.
+     *
+     * <p>Never throws: this is called from the consumer's worker threads, where a transport failure
+     * must not disturb the scan.
+     *
+     * @param message the message to send
+     */
+    public void broadcast(String message) {
+        final WebSocketServer localServer = webSocketServer;
+        if (localServer == null) {
+            return;
+        }
+        try {
+            localServer.broadcast(message);
+        } catch (RuntimeException e) {
+            LOGGER.warn("Broadcast failed; continuing.", e);
+        }
+    }
+
+    /** Stops the server, if it was started. */
+    public void stop() {
+        final WebSocketServer localServer = webSocketServer;
+        if (localServer != null) {
+            try {
+                localServer.stop();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/WebSocketResultBroadcaster.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/WebSocketResultBroadcaster.java
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.ResultListener;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sends the outcome of every checked batch to all connected WebSocket clients.
+ *
+ * <p>Every batch is reported, hit or not. That is what lets a client sweeping a range tell "checked,
+ * nothing there" from "never checked" — without it, a range dropped when the process stopped looks
+ * exactly like a clean one, and an automated sweep would move past ground it never covered.
+ *
+ * <p><b>The payload contains private keys.</b> Delivery is a broadcast: everyone connected receives
+ * every hit, including ones from ranges somebody else submitted. Expose this port accordingly.
+ *
+ * <p>Delivery is best-effort. A client that is not connected at the moment a batch completes misses
+ * that message and it is not replayed; the log remains the authoritative record of a hit.
+ */
+@ToString
+public class WebSocketResultBroadcaster implements ResultListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketResultBroadcaster.class);
+
+    @ToString.Exclude
+    private final WebSocketEndpoint endpoint;
+
+    private final BatchResultJsonFormatter formatter;
+
+    /** The greeting, once the producer configuration it describes is known. */
+    @ToString.Exclude
+    private volatile @Nullable String configurationMessage;
+
+    /**
+     * Creates a broadcaster sending on the given endpoint.
+     *
+     * @param endpoint the server shared with the key producer
+     */
+    public WebSocketResultBroadcaster(WebSocketEndpoint endpoint) {
+        this(endpoint, new BatchResultJsonFormatter());
+    }
+
+    /**
+     * Creates a broadcaster on an explicit formatter.
+     *
+     * @param endpoint  the server shared with the key producer
+     * @param formatter renders the wire messages
+     */
+    public WebSocketResultBroadcaster(WebSocketEndpoint endpoint, BatchResultJsonFormatter formatter) {
+        this.endpoint = endpoint;
+        this.formatter = formatter;
+        endpoint.setGreetingSupplier(() -> configurationMessage);
+    }
+
+    /**
+     * Publishes the grid configuration a client needs in order to send usable ranges.
+     *
+     * <p>Called once the producers are configured, which happens after the server has already begun
+     * accepting connections. Clients that connected earlier are caught up immediately; later ones
+     * receive it on connect.
+     *
+     * <p>Without this a client cannot know the step it must advance by. The server aligns every
+     * incoming base down to a multiple of {@code 2^batchSizeInBits}, so a client stepping by less
+     * would resubmit the same block over and over while leaving the rest of its range untouched —
+     * silently, because nothing rejects a misaligned base.
+     *
+     * @param batchSizeInBits              the grid size each base is expanded to
+     * @param batchUsePrivateKeyIncrement  whether one base yields a whole grid; when {@code false}
+     *                                     the producer wants one secret per candidate instead
+     */
+    public void announceConfiguration(int batchSizeInBits, boolean batchUsePrivateKeyIncrement) {
+        try {
+            configurationMessage = formatter.formatConfiguration(batchSizeInBits, batchUsePrivateKeyIncrement);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Could not serialise the grid configuration; clients will not receive it.", e);
+            return;
+        }
+        endpoint.greetAll();
+    }
+
+    @Override
+    public void onBatchChecked(BatchResult batchResult) {
+        final String message;
+        try {
+            message = formatter.formatBatch(batchResult);
+        } catch (JsonProcessingException e) {
+            // Never let a serialisation problem reach the consumer thread that is draining keys.
+            LOGGER.error("Could not serialise a batch result; skipping this message.", e);
+            return;
+        }
+        endpoint.broadcast(message);
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/ZmqResultBroadcaster.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/keyproducer/ZmqResultBroadcaster.java
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.ResultListener;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeromq.SocketType;
+import org.zeromq.ZContext;
+import org.zeromq.ZMQ;
+
+/**
+ * Publishes the outcome of every checked batch to ZeroMQ subscribers.
+ *
+ * <p>Every batch is reported, hit or not, so a subscriber sweeping a range can tell "checked,
+ * nothing there" from "never checked".
+ *
+ * <p><b>The payload contains private keys</b>, and every subscriber receives every result —
+ * including hits from ranges somebody else submitted.
+ *
+ * <h2>Why this needs its own address and its own socket</h2>
+ * Secrets arrive on a {@code PULL} socket, which cannot send. Results therefore go out over a
+ * separate {@code PUB} socket, and two socket types cannot share one endpoint — so unlike the
+ * WebSocket, which serves both directions on one port, ZeroMQ needs a second address configured.
+ *
+ * <h2>What {@code PUB}/{@code SUB} cannot promise</h2>
+ * <ul>
+ *   <li>A message published before a subscriber has finished connecting is dropped — the "slow
+ *       joiner" problem. There is no replay.
+ *   <li>The socket cannot tell when someone subscribes, so there is no connect event to greet on.
+ *       This is the concrete difference from the WebSocket, which catches up a client that arrived
+ *       early. Here the grid configuration is instead <b>republished</b> alongside batch results
+ *       (see {@link #republishConfiguration()}), which is the only way a late subscriber can ever
+ *       receive it.
+ *   <li>Delivery is best-effort throughout; the log remains the authoritative record of a hit.
+ * </ul>
+ */
+@ToString
+public class ZmqResultBroadcaster implements ResultListener, AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZmqResultBroadcaster.class);
+
+    /**
+     * Number of batch messages between two republications of the grid configuration.
+     *
+     * <p>A compromise: often enough that a subscriber joining mid-run learns the grid within a few
+     * seconds, rare enough that it does not measurably share the channel with the results.
+     */
+    private static final int CONFIG_REPUBLISH_EVERY_N_BATCHES = 64;
+
+    /**
+     * Linger of zero, so closing the context can never stall on undelivered messages. Results are
+     * best-effort by nature; blocking a shutdown to flush them would be the wrong trade.
+     */
+    private static final int LINGER_MILLIS = 0;
+
+    private final BatchResultJsonFormatter formatter;
+
+    @ToString.Exclude
+    private final ZContext context;
+
+    @ToString.Exclude
+    private final ZMQ.Socket publisher;
+
+    /** The greeting, once the producer configuration it describes is known. */
+    @ToString.Exclude
+    private volatile @Nullable String configurationMessage;
+
+    /**
+     * Counts batches so the configuration can be slipped in periodically.
+     *
+     * <p>Atomic because {@link #onBatchChecked} runs on every consumer worker thread at once: a
+     * plain int would lose increments and could let two threads republish in the same round.
+     */
+    private final AtomicInteger batchesSinceConfigRepublish = new AtomicInteger();
+
+    /**
+     * Creates a publisher bound to the given address.
+     *
+     * @param publishAddress the ZeroMQ address to bind the {@code PUB} socket to
+     */
+    public ZmqResultBroadcaster(String publishAddress) {
+        this(publishAddress, new BatchResultJsonFormatter());
+    }
+
+    /**
+     * Creates a publisher on an explicit formatter.
+     *
+     * @param publishAddress the ZeroMQ address to bind the {@code PUB} socket to
+     * @param formatter      renders the wire messages
+     */
+    public ZmqResultBroadcaster(String publishAddress, BatchResultJsonFormatter formatter) {
+        this.formatter = formatter;
+        this.context = new ZContext();
+        this.publisher = context.createSocket(SocketType.PUB);
+        this.publisher.setLinger(LINGER_MILLIS);
+        this.publisher.bind(publishAddress);
+        LOGGER.info("Publishing results on {}", publishAddress);
+    }
+
+    /**
+     * Records the grid configuration and publishes it once.
+     *
+     * <p>Subscribers connected at this moment receive it; later ones depend on
+     * {@link #republishConfiguration()}, because a {@code PUB} socket has no connect event to react
+     * to.
+     *
+     * @param batchSizeInBits             the grid size each base is expanded to
+     * @param batchUsePrivateKeyIncrement whether one base yields a whole grid
+     */
+    public void announceConfiguration(int batchSizeInBits, boolean batchUsePrivateKeyIncrement) {
+        try {
+            configurationMessage = formatter.formatConfiguration(batchSizeInBits, batchUsePrivateKeyIncrement);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Could not serialise the grid configuration; subscribers will not receive it.", e);
+            return;
+        }
+        republishConfiguration();
+    }
+
+    /**
+     * Publishes the recorded grid configuration again, for subscribers that joined since.
+     *
+     * <p>Does nothing while no configuration is known.
+     */
+    public void republishConfiguration() {
+        final String message = configurationMessage;
+        if (message != null) {
+            send(message);
+        }
+    }
+
+    @Override
+    public void onBatchChecked(BatchResult batchResult) {
+        final String message;
+        try {
+            message = formatter.formatBatch(batchResult);
+        } catch (JsonProcessingException e) {
+            // Never let a serialisation problem reach the consumer thread that is draining keys.
+            LOGGER.error("Could not serialise a batch result; skipping this message.", e);
+            return;
+        }
+        send(message);
+
+        if (batchesSinceConfigRepublish.incrementAndGet() >= CONFIG_REPUBLISH_EVERY_N_BATCHES) {
+            batchesSinceConfigRepublish.set(0);
+            republishConfiguration();
+        }
+    }
+
+    /**
+     * Sends one message, absorbing any transport failure.
+     *
+     * @param message the message to publish
+     */
+    private void send(String message) {
+        try {
+            publisher.send(message.getBytes(StandardCharsets.UTF_8), ZMQ.DONTWAIT);
+        } catch (RuntimeException e) {
+            // Called from the consumer's worker threads: a transport failure must not disturb the scan.
+            LOGGER.warn("Publishing a result failed; continuing.", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        publisher.close();
+        context.close();
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLBuilder.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLBuilder.java
@@ -3,265 +3,154 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.opencl;
 
-import static org.jocl.CL.CL_CONTEXT_PLATFORM;
-import static org.jocl.CL.CL_DEVICE_ADDRESS_BITS;
-import static org.jocl.CL.CL_DEVICE_ENDIAN_LITTLE;
-import static org.jocl.CL.CL_DEVICE_ERROR_CORRECTION_SUPPORT;
-import static org.jocl.CL.CL_DEVICE_EXTENSIONS;
-import static org.jocl.CL.CL_DEVICE_GLOBAL_MEM_SIZE;
-import static org.jocl.CL.CL_DEVICE_IMAGE2D_MAX_HEIGHT;
-import static org.jocl.CL.CL_DEVICE_IMAGE2D_MAX_WIDTH;
-import static org.jocl.CL.CL_DEVICE_IMAGE3D_MAX_DEPTH;
-import static org.jocl.CL.CL_DEVICE_IMAGE3D_MAX_HEIGHT;
-import static org.jocl.CL.CL_DEVICE_IMAGE3D_MAX_WIDTH;
-import static org.jocl.CL.CL_DEVICE_IMAGE_SUPPORT;
-import static org.jocl.CL.CL_DEVICE_LOCAL_MEM_SIZE;
-import static org.jocl.CL.CL_DEVICE_LOCAL_MEM_TYPE;
-import static org.jocl.CL.CL_DEVICE_MAX_CLOCK_FREQUENCY;
-import static org.jocl.CL.CL_DEVICE_MAX_COMPUTE_UNITS;
-import static org.jocl.CL.CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE;
-import static org.jocl.CL.CL_DEVICE_MAX_MEM_ALLOC_SIZE;
-import static org.jocl.CL.CL_DEVICE_MAX_READ_IMAGE_ARGS;
-import static org.jocl.CL.CL_DEVICE_MAX_WORK_GROUP_SIZE;
-import static org.jocl.CL.CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS;
-import static org.jocl.CL.CL_DEVICE_MAX_WORK_ITEM_SIZES;
-import static org.jocl.CL.CL_DEVICE_MAX_WRITE_IMAGE_ARGS;
-import static org.jocl.CL.CL_DEVICE_NAME;
-import static org.jocl.CL.CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR;
-import static org.jocl.CL.CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE;
-import static org.jocl.CL.CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT;
-import static org.jocl.CL.CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT;
-import static org.jocl.CL.CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG;
-import static org.jocl.CL.CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT;
-import static org.jocl.CL.CL_DEVICE_PROFILE;
-import static org.jocl.CL.CL_DEVICE_QUEUE_PROPERTIES;
-import static org.jocl.CL.CL_DEVICE_SINGLE_FP_CONFIG;
-import static org.jocl.CL.CL_DEVICE_TYPE;
-import static org.jocl.CL.CL_DEVICE_TYPE_ALL;
-import static org.jocl.CL.CL_DEVICE_VENDOR;
-import static org.jocl.CL.CL_DEVICE_VERSION;
-import static org.jocl.CL.CL_DRIVER_VERSION;
-import static org.jocl.CL.CL_PLATFORM_NAME;
-import static org.jocl.CL.CL_PLATFORM_NOT_FOUND_KHR;
-import static org.jocl.CL.clGetDeviceIDs;
-import static org.jocl.CL.clGetDeviceInfo;
-import static org.jocl.CL.clGetPlatformIDs;
-import static org.jocl.CL.clGetPlatformInfo;
-
 import com.google.common.collect.ImmutableList;
-import java.lang.reflect.Field;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
-import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClApi;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClDeviceId;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClPlatformId;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClBinding;
 import org.apache.maven.artifact.versioning.ComparableVersion;
-import org.jocl.CLException;
-import org.jocl.Pointer;
-import org.jocl.Sizeof;
-import org.jocl.cl_context_properties;
-import org.jocl.cl_device_id;
-import org.jocl.cl_platform_id;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.lwjgl.opencl.CL10;
 
 /**
- * Discovers available OpenCL platforms and devices via JOCL and wraps them in
- * {@link OpenCLPlatform} / {@link OpenCLDevice} objects.
+ * Discovers the available OpenCL platforms and devices and wraps them in {@link OpenCLPlatform} /
+ * {@link OpenCLDevice} value objects.
+ *
+ * <p>Every property is read at its exact declared width. That is not pedantry: the OpenCL
+ * specification permits a query buffer larger than the property, so reading a 32-bit
+ * {@code cl_uint} into a 64-bit slot is legal and used to work only because the previous binding
+ * happened to hand the driver a zero-initialised array. Scratch memory here is not zeroed, so an
+ * over-wide read would return whatever the upper half of that slot last held.
  */
-// JOCL upstream API is not annotated for nullness; every clGet*(...) call here
-// passes the null values that the OpenCL C ABI accepts (size-only queries, etc.).
-// Field.getBoolean(null) is the documented JDK contract for static fields.
-@SuppressWarnings({"nullness:argument", "nullness:dereference.of.nullable"})
+@ToString
 public class OpenCLBuilder {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpenCLBuilder.class);
+    /** Number of dimensions reported by {@code CL_DEVICE_MAX_WORK_ITEM_SIZES}. */
+    private static final int MAX_WORK_ITEM_SIZE_DIMENSIONS = 3;
 
-    /** Creates a new {@link OpenCLBuilder}. */
-    public OpenCLBuilder() {}
+    /** The OpenCL version from which this project's compact filter mode is usable. */
+    private static final ComparableVersion MINIMUM_COMPACT_MODE_VERSION = new ComparableVersion("2.0");
 
-    /** Whether device-info conversions should be formatted for human consumption when querying device info. */
-    public static final boolean TRANSFORM_TO_PRINT = true;
+    /** Value {@code CL_DEVICE_ENDIAN_LITTLE} reports for a little-endian device. */
+    private static final int CL_TRUE_AS_INT = 1;
+
+    private final ClApi clApi;
+
+    /**
+     * Creates a builder using the project's default OpenCL binding.
+     *
+     * @see OpenClBinding
+     */
+    public OpenCLBuilder() {
+        this(OpenClBinding.defaultClApi());
+    }
+
+    /**
+     * Creates a builder on an explicit OpenCL API, so tests can substitute it.
+     *
+     * @param clApi the OpenCL API to enumerate through
+     */
+    public OpenCLBuilder(ClApi clApi) {
+        this.clApi = clApi;
+    }
 
     /**
      * Discovers and returns every available OpenCL platform with its devices.
      *
-     * @return the list of detected OpenCL platforms
+     * @return the list of detected OpenCL platforms, empty when none is installed
      */
     public List<OpenCLPlatform> build() {
-        // Obtain the number of platforms. An OpenCL ICD *loader* can be present (so the native
-        // library loads) while no ICD/platform is actually installed — common on bare CI runners
-        // (e.g. Windows without a GPU driver). In that case the loader returns
-        // CL_PLATFORM_NOT_FOUND_KHR, which JOCL surfaces as a CLException when exceptions are enabled.
-        // Treat "no platforms" as an empty result rather than failing, so callers (and the
-        // OpenCLAddKernelSmokeTest) can cleanly skip instead of erroring.
-        int[] numPlatforms = new int[1];
-        try {
-            clGetPlatformIDs(0, null, numPlatforms);
-        } catch (CLException e) {
-            if (e.getStatus() == CL_PLATFORM_NOT_FOUND_KHR) {
-                return new ArrayList<>();
+        final List<ClPlatformId> platformIds = clApi.getPlatformIds();
+        final List<OpenCLPlatform> openCLPlatforms = new ArrayList<>(platformIds.size());
+        for (ClPlatformId platformId : platformIds) {
+            final String platformName = clApi.getPlatformInfoString(platformId, CL10.CL_PLATFORM_NAME);
+            final List<ClDeviceId> deviceIds = clApi.getDeviceIds(platformId, CL10.CL_DEVICE_TYPE_ALL);
+
+            final List<OpenCLDevice> openCLDevices = new ArrayList<>(deviceIds.size());
+            for (ClDeviceId deviceId : deviceIds) {
+                openCLDevices.add(createOpenCLDevice(deviceId));
             }
-            throw e;
+            openCLPlatforms.add(new OpenCLPlatform(platformId, platformName, ImmutableList.copyOf(openCLDevices)));
         }
-        int numPlatformCount = numPlatforms[0];
-        if (numPlatformCount == 0) {
-            // Exceptions-disabled path: the call returned the error code instead of throwing.
-            return new ArrayList<>();
-        }
-
-        // Obtain the platform IDs
-        List<OpenCLPlatform> openCLPlatforms = new ArrayList<>(numPlatformCount);
-        cl_platform_id[] platforms = new cl_platform_id[numPlatformCount];
-        clGetPlatformIDs(platforms.length, platforms, null);
-
-        for (int i = 0; i < platforms.length; i++) {
-            // Collect all devices of all platforms
-            final cl_platform_id platformId = platforms[i];
-
-            // Initialize the context properties
-            cl_context_properties contextProperties = new cl_context_properties();
-            contextProperties.addProperty(CL_CONTEXT_PLATFORM, platformId);
-
-            String platformName = getString(platformId, CL_PLATFORM_NAME);
-
-            // Obtain the number of devices for the current platform
-            int[] numDevicesArray = new int[1];
-            clGetDeviceIDs(platformId, CL_DEVICE_TYPE_ALL, 0, null, numDevicesArray);
-            int numDevices = numDevicesArray[0];
-
-            cl_device_id[] devicesArray = new cl_device_id[numDevices];
-            clGetDeviceIDs(platformId, CL_DEVICE_TYPE_ALL, numDevices, devicesArray, null);
-
-            List<OpenCLDevice> openCLDevices = new ArrayList<>(numDevices);
-            for (cl_device_id device : devicesArray) {
-                OpenCLDevice openCLDevice = createOpenCLDevice(device);
-                openCLDevices.add(openCLDevice);
-            }
-
-            OpenCLPlatform openCLPlatform =
-                    new OpenCLPlatform(platformName, contextProperties, ImmutableList.copyOf(openCLDevices));
-            openCLPlatforms.add(openCLPlatform);
-        }
-
         return openCLPlatforms;
     }
 
-    private OpenCLDevice createOpenCLDevice(cl_device_id device) {
-        String deviceName = getString(device, CL_DEVICE_NAME);
-        String deviceVendor = getString(device, CL_DEVICE_VENDOR);
-        String driverVersion = getString(device, CL_DRIVER_VERSION);
-        String deviceProfile = getString(device, CL_DEVICE_PROFILE);
-        String deviceVersion = getString(device, CL_DEVICE_VERSION);
-        String deviceExtensions = getString(device, CL_DEVICE_EXTENSIONS);
-        boolean endianLittle = getInt(device, CL_DEVICE_ENDIAN_LITTLE) == 1;
-        long deviceType = getLong(device, CL_DEVICE_TYPE);
-        int maxComputeUnits = getInt(device, CL_DEVICE_MAX_COMPUTE_UNITS);
-        long maxWorkItemDimensions = getLong(device, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS);
-        long[] maxWorkItemSizes = getSizes(device, CL_DEVICE_MAX_WORK_ITEM_SIZES, 3);
-        long maxWorkGroupSize = getSize(device, CL_DEVICE_MAX_WORK_GROUP_SIZE);
-        long maxClockFrequency = getLong(device, CL_DEVICE_MAX_CLOCK_FREQUENCY);
-        int addressBits = getInt(device, CL_DEVICE_ADDRESS_BITS);
-        long maxMemAllocSize = getLong(device, CL_DEVICE_MAX_MEM_ALLOC_SIZE);
-        long globalMemSize = getLong(device, CL_DEVICE_GLOBAL_MEM_SIZE);
-        int errorCorrectionSupport = getInt(device, CL_DEVICE_ERROR_CORRECTION_SUPPORT);
-        int localMemType = getInt(device, CL_DEVICE_LOCAL_MEM_TYPE);
-        long localMemSize = getLong(device, CL_DEVICE_LOCAL_MEM_SIZE);
-        long maxConstantBufferSize = getLong(device, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE);
-        // JOCL upstream deprecated CL_DEVICE_QUEUE_PROPERTIES (OpenCL 2.0+ replaced it with
-        // CL_DEVICE_QUEUE_ON_HOST_PROPERTIES); JOCL has not exposed the replacement constant
-        // yet. Suppress narrowly so any other deprecation in this method still surfaces.
-        @SuppressWarnings("deprecation")
-        final int queuePropertiesConstant = CL_DEVICE_QUEUE_PROPERTIES;
-        long queueProperties = getLong(device, queuePropertiesConstant);
-        int imageSupport = getInt(device, CL_DEVICE_IMAGE_SUPPORT);
-        int maxReadImageArgs = getInt(device, CL_DEVICE_MAX_READ_IMAGE_ARGS);
-        int maxWriteImageArgs = getInt(device, CL_DEVICE_MAX_WRITE_IMAGE_ARGS);
-        long singleFpConfig = getLong(device, CL_DEVICE_SINGLE_FP_CONFIG);
-        long image2dMaxWidth = getSize(device, CL_DEVICE_IMAGE2D_MAX_WIDTH);
-        long image2dMaxHeight = getSize(device, CL_DEVICE_IMAGE2D_MAX_HEIGHT);
-        long image3dMaxWidth = getSize(device, CL_DEVICE_IMAGE3D_MAX_WIDTH);
-        long image3dMaxHeight = getSize(device, CL_DEVICE_IMAGE3D_MAX_HEIGHT);
-        long image3dMaxDepth = getSize(device, CL_DEVICE_IMAGE3D_MAX_DEPTH);
-        int preferredVectorWidthChar = getInt(device, CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR);
-        int preferredVectorWidthShort = getInt(device, CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT);
-        int preferredVectorWidthInt = getInt(device, CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT);
-        int preferredVectorWidthLong = getInt(device, CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG);
-        int preferredVectorWidthFloat = getInt(device, CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT);
-        int preferredVectorWidthDouble = getInt(device, CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE);
-
+    /**
+     * Reads every property of one device into an {@link OpenCLDevice}.
+     *
+     * @param device the device to describe
+     * @return the populated value object
+     */
+    private OpenCLDevice createOpenCLDevice(ClDeviceId device) {
         return new OpenCLDevice(
                 device,
-                deviceName,
-                deviceVendor,
-                driverVersion,
-                deviceProfile,
-                deviceVersion,
-                deviceExtensions,
-                deviceType,
-                endianLittle,
-                maxComputeUnits,
-                maxWorkItemDimensions,
-                longsToImmutableList(maxWorkItemSizes),
-                maxWorkGroupSize,
-                maxClockFrequency,
-                addressBits,
-                maxMemAllocSize,
-                globalMemSize,
-                errorCorrectionSupport,
-                localMemType,
-                localMemSize,
-                maxConstantBufferSize,
-                queueProperties,
-                imageSupport,
-                maxReadImageArgs,
-                maxWriteImageArgs,
-                singleFpConfig,
-                image2dMaxWidth,
-                image2dMaxHeight,
-                image3dMaxWidth,
-                image3dMaxHeight,
-                image3dMaxDepth,
-                preferredVectorWidthChar,
-                preferredVectorWidthShort,
-                preferredVectorWidthInt,
-                preferredVectorWidthLong,
-                preferredVectorWidthFloat,
-                preferredVectorWidthDouble);
-    }
-
-    private static ImmutableList<@NonNull Long> longsToImmutableList(long... array) {
-        ImmutableList.Builder<@NonNull Long> b = ImmutableList.builderWithExpectedSize(array.length);
-        for (long l : array) {
-            b.add(l);
-        }
-        return b.build();
+                clApi.getDeviceInfoString(device, CL10.CL_DEVICE_NAME),
+                clApi.getDeviceInfoString(device, CL10.CL_DEVICE_VENDOR),
+                clApi.getDeviceInfoString(device, CL10.CL_DRIVER_VERSION),
+                clApi.getDeviceInfoString(device, CL10.CL_DEVICE_PROFILE),
+                clApi.getDeviceInfoString(device, CL10.CL_DEVICE_VERSION),
+                clApi.getDeviceInfoString(device, CL10.CL_DEVICE_EXTENSIONS),
+                clApi.getDeviceInfoLong(device, CL10.CL_DEVICE_TYPE),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_ENDIAN_LITTLE) == CL_TRUE_AS_INT,
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_MAX_COMPUTE_UNITS),
+                // cl_uint, widened for the value object; never queried as 64 bits (see class comment)
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS),
+                longsToImmutableList(clApi.getDeviceInfoSizes(
+                        device, CL10.CL_DEVICE_MAX_WORK_ITEM_SIZES, MAX_WORK_ITEM_SIZE_DIMENSIONS)),
+                clApi.getDeviceInfoSizes(device, CL10.CL_DEVICE_MAX_WORK_GROUP_SIZE, 1)[0],
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_MAX_CLOCK_FREQUENCY),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_ADDRESS_BITS),
+                clApi.getDeviceInfoLong(device, CL10.CL_DEVICE_MAX_MEM_ALLOC_SIZE),
+                clApi.getDeviceInfoLong(device, CL10.CL_DEVICE_GLOBAL_MEM_SIZE),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_ERROR_CORRECTION_SUPPORT),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_LOCAL_MEM_TYPE),
+                clApi.getDeviceInfoLong(device, CL10.CL_DEVICE_LOCAL_MEM_SIZE),
+                clApi.getDeviceInfoLong(device, CL10.CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE),
+                clApi.getDeviceInfoLong(device, CL10.CL_DEVICE_QUEUE_PROPERTIES),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_IMAGE_SUPPORT),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_MAX_READ_IMAGE_ARGS),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_MAX_WRITE_IMAGE_ARGS),
+                clApi.getDeviceInfoLong(device, CL10.CL_DEVICE_SINGLE_FP_CONFIG),
+                clApi.getDeviceInfoSizes(device, CL10.CL_DEVICE_IMAGE2D_MAX_WIDTH, 1)[0],
+                clApi.getDeviceInfoSizes(device, CL10.CL_DEVICE_IMAGE2D_MAX_HEIGHT, 1)[0],
+                clApi.getDeviceInfoSizes(device, CL10.CL_DEVICE_IMAGE3D_MAX_WIDTH, 1)[0],
+                clApi.getDeviceInfoSizes(device, CL10.CL_DEVICE_IMAGE3D_MAX_HEIGHT, 1)[0],
+                clApi.getDeviceInfoSizes(device, CL10.CL_DEVICE_IMAGE3D_MAX_DEPTH, 1)[0],
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT),
+                clApi.getDeviceInfoInt(device, CL10.CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE));
     }
 
     /**
-     * Reports whether the JOCL native OpenCL library has been loaded.
+     * Wraps a primitive array into an immutable list.
      *
-     * <p>Reflects the internal {@code org.jocl.CL.nativeLibraryLoaded} flag,
-     * which JOCL sets to {@code true} after a successful first call into the
-     * native library and never resets. Treats any
-     * {@link UnsatisfiedLinkError} / {@link NoClassDefFoundError} during
-     * the reflective lookup as "not loaded".
-     *
-     * @return {@code true} if the native library was loaded successfully and is usable
+     * @param array the values to wrap
+     * @return an immutable list of the same values
      */
-    public static boolean isOpenClNativeLibraryLoaded() {
+    private static ImmutableList<@NonNull Long> longsToImmutableList(long... array) {
+        final ImmutableList.Builder<@NonNull Long> builder = ImmutableList.builderWithExpectedSize(array.length);
+        for (long value : array) {
+            builder.add(value);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Reports whether the native OpenCL library could be loaded.
+     *
+     * @return {@code true} if the OpenCL runtime is usable on this machine
+     */
+    public boolean isOpenClLibraryAvailable() {
         try {
-            Class.forName("org.jocl.CL");
-            Field field = org.jocl.CL.class.getDeclaredField("nativeLibraryLoaded");
-            field.setAccessible(true);
-            return field.getBoolean(null);
-        } catch (java.lang.UnsatisfiedLinkError e) {
-            return false;
-        } catch (java.lang.NoClassDefFoundError e) {
-            return false;
-        } catch (Exception e) {
-            LOGGER.error("OpenCL native library probe failed", e);
+            clApi.getPlatformIds();
+            return true;
+        } catch (RuntimeException | LinkageError e) {
             return false;
         }
     }
@@ -272,10 +161,9 @@ public class OpenCLBuilder {
      * @param openCLPlatforms the platforms to inspect
      * @return {@code true} if at least one OpenCL 2.0+ device exists
      */
-    public static boolean isOneOpenCL2_0OrGreaterDeviceAvailable(Iterable<OpenCLPlatform> openCLPlatforms) {
+    public boolean isOneOpenCL2_0OrGreaterDeviceAvailable(Iterable<OpenCLPlatform> openCLPlatforms) {
         for (OpenCLPlatform openCLPlatform : openCLPlatforms) {
-            List<OpenCLDevice> openCLDevices = openCLPlatform.openCLDevices();
-            for (OpenCLDevice openCLDevice : openCLDevices) {
+            for (OpenCLDevice openCLDevice : openCLPlatform.openCLDevices()) {
                 if (isOpenCL2_0OrGreater(openCLDevice.getDeviceVersionAsComparableVersion())) {
                     return true;
                 }
@@ -290,137 +178,7 @@ public class OpenCLBuilder {
      * @param openCLDeviceVersion the parsed device version
      * @return {@code true} if {@code openCLDeviceVersion >= 2.0}
      */
-    public static boolean isOpenCL2_0OrGreater(ComparableVersion openCLDeviceVersion) {
-        final ComparableVersion v2_0 = new ComparableVersion("2.0");
-        return openCLDeviceVersion.compareTo(v2_0) >= 0;
-    }
-
-    /**
-     * Returns the value of the device info parameter with the given name
-     *
-     * @param device The device
-     * @param paramName The parameter name
-     * @return The value
-     */
-    private static int getInt(cl_device_id device, int paramName) {
-        return getInts(device, paramName, 1)[0];
-    }
-
-    /**
-     * Returns the values of the device info parameter with the given name
-     *
-     * @param device The device
-     * @param paramName The parameter name
-     * @param numValues The number of values
-     * @return The value
-     */
-    private static int[] getInts(cl_device_id device, int paramName, int numValues) {
-        int[] values = new int[numValues];
-        clGetDeviceInfo(device, paramName, (long) Sizeof.cl_int * numValues, Pointer.to(values), null);
-        return values;
-    }
-
-    /**
-     * Returns the value of the device info parameter with the given name
-     *
-     * @param device The device
-     * @param paramName The parameter name
-     * @return The value
-     */
-    private static long getLong(cl_device_id device, int paramName) {
-        return getLongs(device, paramName, 1)[0];
-    }
-
-    /**
-     * Returns the values of the device info parameter with the given name
-     *
-     * @param device The device
-     * @param paramName The parameter name
-     * @param numValues The number of values
-     * @return The value
-     */
-    private static long[] getLongs(cl_device_id device, int paramName, int numValues) {
-        long[] values = new long[numValues];
-        clGetDeviceInfo(device, paramName, (long) Sizeof.cl_long * numValues, Pointer.to(values), null);
-        return values;
-    }
-
-    /**
-     * Returns the value of the device info parameter with the given name
-     *
-     * @param device The device
-     * @param paramName The parameter name
-     * @return The value
-     */
-    private static String getString(cl_device_id device, int paramName) {
-        // Obtain the length of the string that will be queried
-        long[] size = new long[1];
-        clGetDeviceInfo(device, paramName, 0, null, size);
-
-        // Create a buffer of the appropriate size and fill it with the info
-        byte[] buffer = new byte[(int) size[0]];
-        clGetDeviceInfo(device, paramName, buffer.length, Pointer.to(buffer), null);
-
-        // Create a string from the buffer (excluding the trailing \0 byte)
-        return new String(buffer, 0, buffer.length - 1, java.nio.charset.StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Returns the value of the platform info parameter with the given name
-     *
-     * @param platform The platform
-     * @param paramName The parameter name
-     * @return The value
-     */
-    private static String getString(cl_platform_id platform, int paramName) {
-        // Obtain the length of the string that will be queried
-        long[] size = new long[1];
-        clGetPlatformInfo(platform, paramName, 0, null, size);
-
-        // Create a buffer of the appropriate size and fill it with the info
-        byte[] buffer = new byte[(int) size[0]];
-        clGetPlatformInfo(platform, paramName, buffer.length, Pointer.to(buffer), null);
-
-        // Create a string from the buffer (excluding the trailing \0 byte)
-        return new String(buffer, 0, buffer.length - 1, java.nio.charset.StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Returns the value of the device info parameter with the given name
-     *
-     * @param device The device
-     * @param paramName The parameter name
-     * @return The value
-     */
-    private static long getSize(cl_device_id device, int paramName) {
-        return getSizes(device, paramName, 1)[0];
-    }
-
-    /**
-     * Returns the values of the device info parameter with the given name
-     *
-     * @param device The device
-     * @param paramName The parameter name
-     * @param numValues The number of values
-     * @return The value
-     */
-    static long[] getSizes(cl_device_id device, int paramName, int numValues) {
-        // The size of the returned data has to depend on
-        // the size of a size_t, which is handled here
-        long size = (long) numValues * Sizeof.size_t;
-        ByteBuffer buffer = ByteBuffer.allocate(ByteBufferUtility.ensureByteBufferCapacityFitsInt(size))
-                .order(ByteOrder.nativeOrder());
-        clGetDeviceInfo(device, paramName, size, Pointer.to(buffer), null);
-        long[] values = new long[numValues];
-        if (Sizeof.size_t == 4) {
-            for (int i = 0; i < numValues; i++) {
-                values[i] = buffer.getInt(i * Sizeof.size_t);
-            }
-        } else {
-            for (int i = 0; i < numValues; i++) {
-                values[i] = buffer.getLong(i * Sizeof.size_t);
-            }
-        }
-        return values;
+    public boolean isOpenCL2_0OrGreater(ComparableVersion openCLDeviceVersion) {
+        return openCLDeviceVersion.compareTo(MINIMUM_COMPACT_MODE_VERSION) >= 0;
     }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -3,29 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.opencl;
 
-import static org.jocl.CL.CL_MEM_COPY_HOST_PTR;
-import static org.jocl.CL.CL_MEM_READ_ONLY;
-import static org.jocl.CL.CL_MEM_READ_WRITE;
-import static org.jocl.CL.CL_MEM_WRITE_ONLY;
-import static org.jocl.CL.CL_QUEUE_PROFILING_ENABLE;
-import static org.jocl.CL.CL_QUEUE_PROPERTIES;
-import static org.jocl.CL.CL_TRUE;
-import static org.jocl.CL.clBuildProgram;
-import static org.jocl.CL.clCreateBuffer;
-import static org.jocl.CL.clCreateCommandQueueWithProperties;
-import static org.jocl.CL.clCreateContext;
-import static org.jocl.CL.clCreateKernel;
-import static org.jocl.CL.clCreateProgramWithSource;
-import static org.jocl.CL.clEnqueueNDRangeKernel;
-import static org.jocl.CL.clEnqueueReadBuffer;
-import static org.jocl.CL.clFinish;
-import static org.jocl.CL.clReleaseCommandQueue;
-import static org.jocl.CL.clReleaseContext;
-import static org.jocl.CL.clReleaseKernel;
-import static org.jocl.CL.clReleaseMemObject;
-import static org.jocl.CL.clReleaseProgram;
-import static org.jocl.CL.clSetKernelArg;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Resources;
 import java.io.IOException;
@@ -44,33 +21,27 @@ import lombok.ToString;
 import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
 import net.ladenthin.bitcoinaddressfinder.configuration.GpuFilterType;
 import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClApi;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClBufferFlags;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClCommandQueue;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClContext;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClKernel;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClMem;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClProgram;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClBinding;
 import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
 import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
 import net.ladenthin.bitcoinaddressfinder.util.MultilineLogger;
 import org.apache.maven.artifact.versioning.ComparableVersion;
-import org.jocl.CL;
-import org.jocl.Pointer;
-import org.jocl.Sizeof;
-import org.jocl.cl_command_queue;
-import org.jocl.cl_context;
-import org.jocl.cl_context_properties;
-import org.jocl.cl_device_id;
-import org.jocl.cl_kernel;
-import org.jocl.cl_mem;
-import org.jocl.cl_program;
-import org.jocl.cl_queue_properties;
 import org.jspecify.annotations.Nullable;
+import org.lwjgl.opencl.CL10;
+import org.lwjgl.opencl.CL11;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * OpenCL context and kernel lifecycle wrapper used by the GPU producer.
  */
-// The JOCL upstream API is not annotated for nullness; every clXxx(...) call here
-// passes the null values that the OpenCL C ABI accepts (e.g. pfn_notify, user_data,
-// errcode_ret). Checker Framework reads those parameters as @NonNull by default and
-// flags every site. Suppress at class scope rather than per call — same justification.
-@SuppressWarnings({"nullness:argument", "nullness:dereference.of.nullable"})
 @ToString
 public class OpenCLContext implements ReleaseCLObject {
 
@@ -119,7 +90,12 @@ public class OpenCLContext implements ReleaseCLObject {
     }
 
     private static final String KERNEL_NAME = "generateKeysKernel_grid";
-    private static final boolean EXCEPTIONS_ENABLED = true;
+
+    /** Placeholder used in log lines when the driver reports no {@code CL_DEVICE_VENDOR}. */
+    private static final String UNKNOWN_VENDOR = "unknown";
+
+    /** Global work size of the fixed-base precompute kernels, which are single-work-item by design. */
+    private static final long[] SINGLE_WORK_ITEM = {1L};
 
     /**
      * {@code clBuildProgram} options string (Stage-0 quick win). Kept as a single constant so it is
@@ -232,6 +208,9 @@ public class OpenCLContext implements ReleaseCLObject {
     boolean resolveEffectiveNoInlineHelpers(String deviceName, @Nullable String deviceVendor) {
         final Boolean configured = producerOpenCL.noInlineHelpers;
         final boolean amd = isAmdVendor(deviceVendor);
+        // A driver may report no vendor at all. Naming that explicitly beats logging a bare null,
+        // and it keeps the log arguments non-null, which is what the nullness checker requires.
+        final String vendorForLog = deviceVendor == null ? UNKNOWN_VENDOR : deviceVendor;
         // Effective decision (semantics unchanged): explicit true/false verbatim; null (auto) = out-of-line
         // on AMD only, inline elsewhere. Only the LOGGING differs — every path that is not already both
         // fast to compile AND fast at runtime now warns, so the tradeoff is never silent.
@@ -248,7 +227,7 @@ public class OpenCLContext implements ReleaseCLObject {
                             + "kernel "
                             + "(one-time 8-16+ min compile on AMD, then comgr-cached).",
                     deviceName,
-                    deviceVendor,
+                    vendorForLog,
                     source);
         } else if (amd) {
             // INLINE on AMD: full runtime speed, but the first compile is slow (then comgr-cached).
@@ -259,7 +238,7 @@ public class OpenCLContext implements ReleaseCLObject {
                             + "are fast. Set noInlineHelpers=true for a fast ~3 s compile at ~4x lower runtime "
                             + "throughput.",
                     deviceName,
-                    deviceVendor,
+                    vendorForLog,
                     source);
         } else {
             // INLINE on non-AMD: fast to compile AND full runtime speed — nothing to warn about.
@@ -267,7 +246,7 @@ public class OpenCLContext implements ReleaseCLObject {
                     "noInlineHelpers -> INLINED kernel on non-AMD device '{}' (vendor '{}', source: {}) for full "
                             + "throughput; compiles quickly on this vendor.",
                     deviceName,
-                    deviceVendor,
+                    vendorForLog,
                     source);
         }
         return effective;
@@ -351,20 +330,23 @@ public class OpenCLContext implements ReleaseCLObject {
     private final CProducerOpenCL producerOpenCL;
     private final BitHelper bitHelper;
 
-    // JOCL native-pointer wrappers (cl_context / cl_command_queue / cl_program / cl_kernel) —
+    @ToString.Exclude
+    private final ClApi clApi;
+
+    // Native-handle wrappers (ClContext / ClCommandQueue / ClProgram / ClKernel) —
     // toString is uninformative for any of them. openClTask is also excluded to avoid
     // recursive aggregation into this context's snapshot.
     @ToString.Exclude
-    private @Nullable cl_context context;
+    private @Nullable ClContext context;
 
     @ToString.Exclude
-    private @Nullable cl_command_queue commandQueue;
+    private @Nullable ClCommandQueue commandQueue;
 
     @ToString.Exclude
-    private @Nullable cl_program program;
+    private @Nullable ClProgram program;
 
     @ToString.Exclude
-    private @Nullable cl_kernel kernel;
+    private @Nullable ClKernel kernel;
 
     @ToString.Exclude
     private @Nullable OpenClTask openClTask;
@@ -378,7 +360,7 @@ public class OpenCLContext implements ReleaseCLObject {
      * {@code init()} and after {@code close()}.
      */
     @ToString.Exclude
-    private @Nullable cl_mem fuse8FingerprintsMem;
+    private @Nullable ClMem fuse8FingerprintsMem;
 
     /**
      * GPU VRAM buffer holding the 5-int Binary Fuse 8 metadata
@@ -390,7 +372,7 @@ public class OpenCLContext implements ReleaseCLObject {
      * the real metadata. {@code null} before {@code init()} and after {@code close()}.
      */
     @ToString.Exclude
-    private @Nullable cl_mem fuse8MetadataMem;
+    private @Nullable ClMem fuse8MetadataMem;
 
     /**
      * Which fingerprint width was actually uploaded, or {@code null} when only the placeholder is
@@ -423,7 +405,7 @@ public class OpenCLContext implements ReleaseCLObject {
      * {@code init()} and after {@code close()}.
      */
     @ToString.Exclude
-    private @Nullable cl_mem igTableMem;
+    private @Nullable ClMem igTableMem;
 
     /**
      * GPU VRAM buffer holding the fixed-base comb table used to compute the one-time anchor
@@ -436,7 +418,7 @@ public class OpenCLContext implements ReleaseCLObject {
      * {@link #close()}. ~64 KB. {@code null} before {@code init()} and after {@code close()}.
      */
     @ToString.Exclude
-    private @Nullable cl_mem combTableMem;
+    private @Nullable ClMem combTableMem;
 
     private final ByteBufferUtility byteBufferUtility = new ByteBufferUtility(true);
 
@@ -449,8 +431,20 @@ public class OpenCLContext implements ReleaseCLObject {
      * @param bitHelper      the bit/batch-size helper
      */
     public OpenCLContext(CProducerOpenCL producerOpenCL, BitHelper bitHelper) {
+        this(producerOpenCL, bitHelper, OpenClBinding.defaultClApi());
+    }
+
+    /**
+     * Creates a new OpenCL context on an explicit OpenCL API, so tests can substitute it.
+     *
+     * @param producerOpenCL the OpenCL producer configuration
+     * @param bitHelper      the bit/batch-size helper
+     * @param clApi          the OpenCL API to work through
+     */
+    public OpenCLContext(CProducerOpenCL producerOpenCL, BitHelper bitHelper, ClApi clApi) {
         this.producerOpenCL = producerOpenCL;
         this.bitHelper = bitHelper;
+        this.clApi = clApi;
     }
 
     /** Reclaims the heap before a filter upload; injectable so the trigger can be verified. */
@@ -490,10 +484,7 @@ public class OpenCLContext implements ReleaseCLObject {
 
         // #################### general ####################
 
-        // Enable exceptions and subsequently omit error checks in this sample
-        CL.setExceptionsEnabled(EXCEPTIONS_ENABLED);
-
-        List<OpenCLPlatform> platforms = new OpenCLBuilder().build();
+        List<OpenCLPlatform> platforms = new OpenCLBuilder(clApi).build();
 
         OpenCLPlatformSelector platformSelector = new OpenCLPlatformSelector();
         OpenCLDeviceSelection selection = platformSelector.select(
@@ -512,26 +503,21 @@ public class OpenCLContext implements ReleaseCLObject {
                 producerOpenCL.enableGpuFilter && !producerOpenCL.transferAll,
                 device.getDeviceVersionAsComparableVersion(),
                 device.deviceName());
-        cl_context_properties contextProperties = selection.contextProperties();
-        cl_device_id[] cl_device_ids = new cl_device_id[] {device.device()};
-
         // Create a context for the selected device
-        context = clCreateContext(contextProperties, 1, cl_device_ids, null, null, null);
+        final ClContext localContext = clApi.createContext(selection.platform().platformId(), device.device());
+        context = localContext;
 
-        // Create a command-queue for the selected device. Opt-in device-side profiling
-        // (CL_QUEUE_PROFILING_ENABLE) is enabled only when the diagnostic flag is set, so the
-        // production pipeline pays no profiling overhead (see CProducerOpenCL.enableProfiling).
-        cl_queue_properties properties = new cl_queue_properties();
-        if (producerOpenCL.enableProfiling) {
-            properties.addProperty(CL_QUEUE_PROPERTIES, CL_QUEUE_PROFILING_ENABLE);
-        }
-        commandQueue = clCreateCommandQueueWithProperties(context, device.device(), properties, null);
+        // Create a command-queue for the selected device. Opt-in device-side profiling is enabled
+        // only when the diagnostic flag is set, so the production pipeline pays no profiling
+        // overhead (see CProducerOpenCL.enableProfiling).
+        commandQueue = clApi.createCommandQueue(localContext, device.device(), producerOpenCL.enableProfiling);
 
         // #################### kernel specifix ####################
 
         String[] openCLPrograms = getOpenCLPrograms();
         // Create the program from the source code
-        program = clCreateProgramWithSource(context, openCLPrograms.length, openCLPrograms, null, null);
+        final ClProgram localProgram = clApi.createProgramWithSource(localContext, openCLPrograms);
+        program = localProgram;
 
         // Build the program with the Stage-0 quick-win options (see CL_BUILD_OPTIONS), plus the
         // per-config modular-inverse selector (see CProducerOpenCL.useSafeGcdInverse). The noinline
@@ -539,18 +525,18 @@ public class OpenCLContext implements ReleaseCLObject {
         // only; logged) — see resolveEffectiveNoInlineHelpers.
         final boolean effectiveNoInlineHelpers =
                 resolveEffectiveNoInlineHelpers(device.deviceName(), device.deviceVendor());
-        clBuildProgram(program, 0, null, buildOptions(effectiveNoInlineHelpers), null, null);
+        clApi.buildProgram(localProgram, device.device(), buildOptions(effectiveNoInlineHelpers));
 
         if (producerOpenCL.logGpuDiagnostics) {
             logProgramBuildLog(device);
         }
 
         // Create the kernel
-        kernel = clCreateKernel(program, KERNEL_NAME, null);
+        kernel = clApi.createKernel(localProgram, KERNEL_NAME);
 
         logKernelResourceUsage(device);
 
-        openClTask = new OpenClTask(context, producerOpenCL, bitHelper, byteBufferUtility);
+        openClTask = new OpenClTask(clApi, localContext, producerOpenCL, bitHelper, byteBufferUtility);
 
         // Allocate a dummy empty filter so the kernel's fuse8 arguments are always bindable.
         // uploadGpuFilter() replaces it with the real filter; until then the kernel runs in
@@ -578,25 +564,16 @@ public class OpenCLContext implements ReleaseCLObject {
      * @param device the selected OpenCL device the kernel was built for
      */
     private void logKernelResourceUsage(OpenCLDevice device) {
-        final cl_kernel localKernel = Objects.requireNonNull(kernel);
-        final long[] value = new long[1];
-        CL.clGetKernelWorkGroupInfo(
-                localKernel, device.device(), CL.CL_KERNEL_WORK_GROUP_SIZE, Sizeof.size_t, Pointer.to(value), null);
-        final long kernelMaxWorkGroupSize = value[0];
-        CL.clGetKernelWorkGroupInfo(
-                localKernel,
-                device.device(),
-                CL.CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE,
-                Sizeof.size_t,
-                Pointer.to(value),
-                null);
-        final long workGroupSizeMultiple = value[0];
-        CL.clGetKernelWorkGroupInfo(
-                localKernel, device.device(), CL.CL_KERNEL_PRIVATE_MEM_SIZE, Sizeof.cl_ulong, Pointer.to(value), null);
-        final long privateMemBytes = value[0];
-        CL.clGetKernelWorkGroupInfo(
-                localKernel, device.device(), CL.CL_KERNEL_LOCAL_MEM_SIZE, Sizeof.cl_ulong, Pointer.to(value), null);
-        final long localMemBytes = value[0];
+        final ClKernel localKernel = Objects.requireNonNull(kernel);
+        // Width matters: the two work-group sizes are size_t, the two memory sizes are cl_ulong.
+        final long kernelMaxWorkGroupSize =
+                clApi.getKernelWorkGroupInfoSize(localKernel, device.device(), CL10.CL_KERNEL_WORK_GROUP_SIZE);
+        final long workGroupSizeMultiple = clApi.getKernelWorkGroupInfoSize(
+                localKernel, device.device(), CL11.CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE);
+        final long privateMemBytes =
+                clApi.getKernelWorkGroupInfoUlong(localKernel, device.device(), CL11.CL_KERNEL_PRIVATE_MEM_SIZE);
+        final long localMemBytes =
+                clApi.getKernelWorkGroupInfoUlong(localKernel, device.device(), CL10.CL_KERNEL_LOCAL_MEM_SIZE);
         LOGGER.info(
                 "Kernel resource usage: kernelMaxWorkGroupSize={} workGroupSizeMultiple={} privateMemBytes={} localMemBytes={}",
                 kernelMaxWorkGroupSize,
@@ -615,13 +592,8 @@ public class OpenCLContext implements ReleaseCLObject {
      * @param device the device the program was built for
      */
     private void logProgramBuildLog(OpenCLDevice device) {
-        final cl_program localProgram = Objects.requireNonNull(program);
-        final long[] size = new long[1];
-        CL.clGetProgramBuildInfo(localProgram, device.device(), CL.CL_PROGRAM_BUILD_LOG, 0, null, size);
-        final byte[] logBytes = new byte[(int) size[0]];
-        CL.clGetProgramBuildInfo(
-                localProgram, device.device(), CL.CL_PROGRAM_BUILD_LOG, logBytes.length, Pointer.to(logBytes), null);
-        LOGGER.info("GPU program build log:\n{}", new String(logBytes, StandardCharsets.UTF_8));
+        final ClProgram localProgram = Objects.requireNonNull(program);
+        LOGGER.info("GPU program build log:\n{}", clApi.getProgramBuildLog(localProgram, device.device()));
     }
 
     /**
@@ -766,11 +738,14 @@ public class OpenCLContext implements ReleaseCLObject {
     /** Fuse-8 buffer upload: the {@code byte[]} slot array goes to the device as-is. */
     private void allocateFilterBuffers(
             byte[] fingerprints, int seedLo, int seedHi, int segLen, int segLenMask, int segCountLen) {
-        // Avoid Pointer.to on a zero-length array (the empty-filter placeholder); the pointer would
-        // be unused anyway because FromPointer pads a zero-size upload with its own dummy byte.
-        final Pointer host = fingerprints.length == 0 ? Pointer.to(new byte[] {0}) : Pointer.to(fingerprints);
-        allocateFilterBuffersFromPointer(
-                host, (long) fingerprints.length, seedLo, seedHi, segLen, segLenMask, segCountLen);
+        allocateFilterBuffers(
+                (long) fingerprints.length,
+                (queue, mem) -> clApi.writeBufferChunked(queue, mem, fingerprints),
+                seedLo,
+                seedHi,
+                segLen,
+                segLenMask,
+                segCountLen);
     }
 
     /**
@@ -787,9 +762,9 @@ public class OpenCLContext implements ReleaseCLObject {
      */
     private void allocateFilterBuffersShort(
             short[] fingerprints, int seedLo, int seedHi, int segLen, int segLenMask, int segCountLen) {
-        allocateFilterBuffersFromPointer(
-                Pointer.to(fingerprints),
+        allocateFilterBuffers(
                 (long) fingerprints.length * Short.BYTES,
+                (queue, mem) -> clApi.writeBufferChunked(queue, mem, fingerprints),
                 seedLo,
                 seedHi,
                 segLen,
@@ -797,16 +772,33 @@ public class OpenCLContext implements ReleaseCLObject {
                 segCountLen);
     }
 
-    private void allocateFilterBuffersFromPointer(
-            Pointer fingerprintHost,
+    /**
+     * Allocates the two filter buffers and fills the fingerprint buffer through {@code upload}.
+     *
+     * <p>The payload is written in slices rather than allocated with a copy-host-pointer flag. The
+     * binding cannot hand a Java array to the driver, so a single-shot upload would first need an
+     * off-heap staging copy the size of the whole filter — several gigabytes at the Full-DB tier,
+     * where the 16-bit filter's byte image does not even fit a Java {@code byte[]}.
+     *
+     * @param fingerprintByteSize size of the fingerprint payload in bytes
+     * @param upload              writes the fingerprint payload into the allocated buffer
+     * @param seedLo              low 32 bits of the construction seed
+     * @param seedHi              high 32 bits of the construction seed
+     * @param segLen              per-segment {@code reduce} length
+     * @param segLenMask          {@code segLen - 1}
+     * @param segCountLen         total fingerprint slot count
+     */
+    private void allocateFilterBuffers(
             long fingerprintByteSize,
+            FilterUpload upload,
             int seedLo,
             int seedHi,
             int segLen,
             int segLenMask,
             int segCountLen) {
-        final cl_context localContext = context;
-        if (localContext == null || closed) {
+        final ClContext localContext = context;
+        final ClCommandQueue localQueue = commandQueue;
+        if (localContext == null || localQueue == null || closed) {
             throw new IllegalStateException("uploadGpuFilter called before init() or after close() (context="
                     + (localContext == null ? "null" : "set")
                     + ", closed="
@@ -822,46 +814,63 @@ public class OpenCLContext implements ReleaseCLObject {
         // Zero-size device buffers are invalid; pad an empty filter to a single zero byte. The
         // kernel relies on segCountLen == 0 (not the buffer length) to detect the empty filter, so
         // the padding byte is never read.
-        final Pointer host = fingerprintByteSize <= 0L ? Pointer.to(new byte[] {0}) : fingerprintHost;
-        final long byteSize = fingerprintByteSize <= 0L ? 1L : fingerprintByteSize;
+        final boolean empty = fingerprintByteSize <= 0L;
+        final long byteSize = empty ? 1L : fingerprintByteSize;
         // An upload right after a filter build can fail to pin host memory while the build's
         // transient garbage still occupies the heap (measured on RDNA3); reclaim it first.
         reclaimHeapBeforeUpload();
-        final cl_mem localFpMem =
-                clCreateBuffer(localContext, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, byteSize, host, null);
+        final ClMem localFpMem = clApi.createBuffer(localContext, ClBufferFlags.READ_ONLY, byteSize);
+        try {
+            if (!empty) {
+                upload.writeInto(localQueue, localFpMem);
+            }
+        } catch (RuntimeException e) {
+            clApi.releaseMemObject(localFpMem);
+            throw e;
+        }
 
         final int[] metadata = new int[] {seedLo, seedHi, segLen, segLenMask, segCountLen};
-        final cl_mem localMetaMem;
+        final ClMem localMetaMem;
         try {
-            localMetaMem = clCreateBuffer(
-                    localContext,
-                    CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
-                    (long) metadata.length * Sizeof.cl_int,
-                    Pointer.to(metadata),
-                    null);
+            localMetaMem =
+                    clApi.createBuffer(localContext, ClBufferFlags.READ_ONLY, (long) metadata.length * Integer.BYTES);
+            clApi.writeBufferChunked(localQueue, localMetaMem, metadata);
         } catch (RuntimeException e) {
             // First buffer was allocated; free it before propagating so no VRAM is leaked.
-            clReleaseMemObject(localFpMem);
+            clApi.releaseMemObject(localFpMem);
             throw e;
         }
         fuse8FingerprintsMem = localFpMem;
         fuse8MetadataMem = localMetaMem;
     }
 
+    /** Writes a filter payload into an already-allocated device buffer. */
+    @FunctionalInterface
+    private interface FilterUpload {
+
+        /**
+         * Writes the payload.
+         *
+         * @param commandQueue the queue to submit the writes to
+         * @param mem          the destination device buffer
+         */
+        void writeInto(ClCommandQueue commandQueue, ClMem mem);
+    }
+
     private void releaseGpuFilter() {
         uploadedFilterType = null;
         if (fuse8FingerprintsMem != null) {
-            clReleaseMemObject(fuse8FingerprintsMem);
+            clApi.releaseMemObject(fuse8FingerprintsMem);
             fuse8FingerprintsMem = null;
         }
         if (fuse8MetadataMem != null) {
-            clReleaseMemObject(fuse8MetadataMem);
+            clApi.releaseMemObject(fuse8MetadataMem);
             fuse8MetadataMem = null;
         }
     }
 
     private void uploadIGTable(int keysPerWorkItem) {
-        final cl_context localContext = Objects.requireNonNull(context);
+        final ClContext localContext = Objects.requireNonNull(context);
         // One entry per walked key (m = 1 .. keysPerWorkItem-1); at least one so the device buffer is
         // never zero-size. When keysPerWorkItem == 1 the walk reads no i*G entry, so the placeholder
         // (left unwritten by the kernel's count=0 run) is never consumed.
@@ -872,19 +881,21 @@ public class OpenCLContext implements ReleaseCLObject {
             // precompute_ig_table emits only radix-2^32, so build into a scratch buffer and lower it
             // once with our own convert_ig_table_to_fe10x26 kernel (present only on the 2^26 build).
             final long radixBytes = (long) entries * OpenClKernelConstants.TWO_COORDINATES_NUM_BYTES;
-            final cl_mem radix32Table = clCreateBuffer(localContext, CL_MEM_READ_WRITE, radixBytes, null, null);
+            final ClMem radix32Table = clApi.createBuffer(localContext, ClBufferFlags.READ_WRITE, radixBytes);
             try {
                 enqueuePrecomputeKernel(radix32Table, "precompute_ig_table", keysPerWorkItem - 1);
                 final long bytes = (long) entries * OpenClKernelConstants.FE10X26_TWO_COORDINATES_NUM_BYTES;
-                igTableMem = clCreateBuffer(localContext, CL_MEM_READ_WRITE, bytes, null, null);
-                enqueueConvertIgTableToFe10x26(igTableMem, radix32Table, keysPerWorkItem - 1);
+                final ClMem localIgTable = clApi.createBuffer(localContext, ClBufferFlags.READ_WRITE, bytes);
+                igTableMem = localIgTable;
+                enqueueConvertIgTableToFe10x26(localIgTable, radix32Table, keysPerWorkItem - 1);
             } finally {
-                clReleaseMemObject(radix32Table);
+                clApi.releaseMemObject(radix32Table);
             }
         } else {
             final long bytes = (long) entries * OpenClKernelConstants.TWO_COORDINATES_NUM_BYTES;
-            igTableMem = clCreateBuffer(localContext, CL_MEM_READ_WRITE, bytes, null, null);
-            enqueuePrecomputeKernel(igTableMem, "precompute_ig_table", keysPerWorkItem - 1);
+            final ClMem localIgTable = clApi.createBuffer(localContext, ClBufferFlags.READ_WRITE, bytes);
+            igTableMem = localIgTable;
+            enqueuePrecomputeKernel(localIgTable, "precompute_ig_table", keysPerWorkItem - 1);
         }
     }
 
@@ -898,18 +909,18 @@ public class OpenCLContext implements ReleaseCLObject {
      * @param in    the source radix-2³² table buffer ({@code [x(8)][y(8)]} per entry)
      * @param count number of entries to convert ({@code keysPerWorkItem - 1}; 0 is a valid no-op)
      */
-    private void enqueueConvertIgTableToFe10x26(cl_mem out, cl_mem in, int count) {
-        final cl_program localProgram = Objects.requireNonNull(program);
-        final cl_command_queue localQueue = Objects.requireNonNull(commandQueue);
-        final cl_kernel convertKernel = clCreateKernel(localProgram, "convert_ig_table_to_fe10x26", null);
+    private void enqueueConvertIgTableToFe10x26(ClMem out, ClMem in, int count) {
+        final ClProgram localProgram = Objects.requireNonNull(program);
+        final ClCommandQueue localQueue = Objects.requireNonNull(commandQueue);
+        final ClKernel convertKernel = clApi.createKernel(localProgram, "convert_ig_table_to_fe10x26");
         try {
-            clSetKernelArg(convertKernel, 0, Sizeof.cl_mem, Pointer.to(out));
-            clSetKernelArg(convertKernel, 1, Sizeof.cl_mem, Pointer.to(in));
-            clSetKernelArg(convertKernel, 2, Sizeof.cl_uint, Pointer.to(new int[] {count}));
-            clEnqueueNDRangeKernel(localQueue, convertKernel, 1, null, new long[] {1L}, null, 0, null, null);
-            clFinish(localQueue);
+            clApi.setKernelArg(convertKernel, 0, out);
+            clApi.setKernelArg(convertKernel, 1, in);
+            clApi.setKernelArgInt(convertKernel, 2, count);
+            clApi.enqueueNDRangeKernel(localQueue, convertKernel, SINGLE_WORK_ITEM, false);
+            clApi.finish(localQueue);
         } finally {
-            clReleaseKernel(convertKernel);
+            clApi.releaseKernel(convertKernel);
         }
     }
 
@@ -923,39 +934,40 @@ public class OpenCLContext implements ReleaseCLObject {
      * @param kernelName the precompute kernel name
      * @param countArg   value for a trailing {@code const u32 count} argument, or {@code null}
      */
-    private void enqueuePrecomputeKernel(cl_mem out, String kernelName, @Nullable Integer countArg) {
-        final cl_program localProgram = Objects.requireNonNull(program);
-        final cl_command_queue localQueue = Objects.requireNonNull(commandQueue);
-        final cl_kernel precomputeKernel = clCreateKernel(localProgram, kernelName, null);
+    private void enqueuePrecomputeKernel(ClMem out, String kernelName, @Nullable Integer countArg) {
+        final ClProgram localProgram = Objects.requireNonNull(program);
+        final ClCommandQueue localQueue = Objects.requireNonNull(commandQueue);
+        final ClKernel precomputeKernel = clApi.createKernel(localProgram, kernelName);
         try {
-            clSetKernelArg(precomputeKernel, 0, Sizeof.cl_mem, Pointer.to(out));
+            clApi.setKernelArg(precomputeKernel, 0, out);
             if (countArg != null) {
-                clSetKernelArg(precomputeKernel, 1, Sizeof.cl_uint, Pointer.to(new int[] {countArg}));
+                clApi.setKernelArgInt(precomputeKernel, 1, countArg);
             }
-            clEnqueueNDRangeKernel(localQueue, precomputeKernel, 1, null, new long[] {1L}, null, 0, null, null);
-            clFinish(localQueue);
+            clApi.enqueueNDRangeKernel(localQueue, precomputeKernel, SINGLE_WORK_ITEM, false);
+            clApi.finish(localQueue);
         } finally {
-            clReleaseKernel(precomputeKernel);
+            clApi.releaseKernel(precomputeKernel);
         }
     }
 
     private void releaseIGTable() {
         if (igTableMem != null) {
-            clReleaseMemObject(igTableMem);
+            clApi.releaseMemObject(igTableMem);
             igTableMem = null;
         }
     }
 
     private void uploadCombTable() {
-        final cl_context localContext = Objects.requireNonNull(context);
+        final ClContext localContext = Objects.requireNonNull(context);
         final long bytes = (long) COMB_POSITIONS * COMB_MAGNITUDES * OpenClKernelConstants.TWO_COORDINATES_NUM_BYTES;
-        combTableMem = clCreateBuffer(localContext, CL_MEM_READ_WRITE, bytes, null, null);
-        enqueuePrecomputeKernel(combTableMem, "precompute_comb_table", null);
+        final ClMem localCombTable = clApi.createBuffer(localContext, ClBufferFlags.READ_WRITE, bytes);
+        combTableMem = localCombTable;
+        enqueuePrecomputeKernel(localCombTable, "precompute_comb_table", null);
     }
 
     private void releaseCombTable() {
         if (combTableMem != null) {
-            clReleaseMemObject(combTableMem);
+            clApi.releaseMemObject(combTableMem);
             combTableMem = null;
         }
     }
@@ -970,13 +982,14 @@ public class OpenCLContext implements ReleaseCLObject {
      * success from {@code clCreateBuffer} even for an absurd multi-exabyte request, deferring the
      * backing storage until first use. Only touching the buffer (a blocking 1-byte read here) forces
      * the driver to materialize it, which is where an impossible size is rejected. This is the same
-     * reason the real RDNA3 failure appeared with {@code CL_MEM_COPY_HOST_PTR} (which must pin host
-     * memory immediately), not with a bare create.
+     * reason the real RDNA3 failure appeared with an upload that pins host memory immediately, not
+     * with a bare create.
      *
-     * <p>With JOCL exceptions enabled ({@link #EXCEPTIONS_ENABLED}) the rejection surfaces as a JOCL
-     * {@link org.jocl.CLException} — a {@link RuntimeException} carrying a status such as {@code
-     * CL_MEM_OBJECT_ALLOCATION_FAILURE} / {@code CL_OUT_OF_RESOURCES} / {@code CL_INVALID_BUFFER_SIZE}
-     * — and <b>never</b> an {@link OutOfMemoryError}. That is the evidence behind {@code
+     * <p>The rejection surfaces as an
+     * {@link net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClCallFailedException} — a
+     * {@link RuntimeException} carrying a status such as {@code CL_MEM_OBJECT_ALLOCATION_FAILURE} /
+     * {@code CL_OUT_OF_RESOURCES} / {@code CL_INVALID_BUFFER_SIZE} — and <b>never</b> an
+     * {@link OutOfMemoryError}. That is the evidence behind {@code
      * TuneConfiguration.runArm}'s per-arm catch: the sweep probes {@code batchSizeInBits} up to {@link
      * net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants#BIT_COUNT_FOR_MAX_CHUNKS_ARRAY},
      * whose output buffer scales as {@code 2^bits} and can exceed what a smaller card allocates.
@@ -991,18 +1004,18 @@ public class OpenCLContext implements ReleaseCLObject {
      */
     @VisibleForTesting
     void allocateDeviceReadWriteBufferForTesting(long bytes) {
-        final cl_context localContext = Objects.requireNonNull(context, "init() must run before allocating a buffer");
-        final cl_command_queue localQueue =
+        final ClContext localContext = Objects.requireNonNull(context, "init() must run before allocating a buffer");
+        final ClCommandQueue localQueue =
                 Objects.requireNonNull(commandQueue, "init() must run before allocating a buffer");
-        final cl_mem mem = clCreateBuffer(localContext, CL_MEM_READ_WRITE, bytes, null, null);
+        final ClMem mem = clApi.createBuffer(localContext, ClBufferFlags.READ_WRITE, bytes);
         try {
             // Force the (possibly lazy) driver to materialize the backing storage; this is where an
-            // impossible size is rejected with a CLException.
-            final byte[] probe = new byte[1];
-            clEnqueueReadBuffer(localQueue, mem, CL_TRUE, 0L, 1L, Pointer.to(probe), 0, null, null);
-            clFinish(localQueue);
+            // impossible size is rejected.
+            final ByteBuffer probe = ByteBuffer.allocateDirect(1);
+            clApi.enqueueReadBuffer(localQueue, mem, 0L, probe, false);
+            clApi.finish(localQueue);
         } finally {
-            clReleaseMemObject(mem);
+            clApi.releaseMemObject(mem);
         }
     }
 
@@ -1021,22 +1034,23 @@ public class OpenCLContext implements ReleaseCLObject {
      */
     @VisibleForTesting
     byte[] runPrecomputeKernelForTesting(String kernelName, int outputBytes, @Nullable Integer countArg) {
-        final cl_context localContext = Objects.requireNonNull(context);
-        final cl_command_queue localQueue = Objects.requireNonNull(commandQueue);
+        final ClContext localContext = Objects.requireNonNull(context);
+        final ClCommandQueue localQueue = Objects.requireNonNull(commandQueue);
 
-        final cl_mem out = clCreateBuffer(localContext, CL_MEM_READ_WRITE, outputBytes, null, null);
+        final ClMem out = clApi.createBuffer(localContext, ClBufferFlags.READ_WRITE, outputBytes);
         try {
             enqueuePrecomputeKernel(out, kernelName, countArg);
 
             final ByteBuffer buf = ByteBuffer.allocateDirect(outputBytes);
-            clEnqueueReadBuffer(localQueue, out, CL_TRUE, 0, outputBytes, Pointer.to(buf), 0, null, null);
-            clFinish(localQueue);
+            clApi.enqueueReadBuffer(localQueue, out, 0L, buf, false);
+            clApi.finish(localQueue);
 
             final byte[] bytes = new byte[outputBytes];
+            buf.position(0);
             buf.get(bytes);
             return bytes;
         } finally {
-            clReleaseMemObject(out);
+            clApi.releaseMemObject(out);
         }
     }
 
@@ -1054,32 +1068,32 @@ public class OpenCLContext implements ReleaseCLObject {
      */
     @VisibleForTesting
     public void runBenchInvMod(int globalWorkSize, int iterations, boolean inputHighLimbsZero) {
-        final cl_context localContext = Objects.requireNonNull(context);
-        final cl_program localProgram = Objects.requireNonNull(program);
-        final cl_command_queue localQueue = Objects.requireNonNull(commandQueue);
+        final ClContext localContext = Objects.requireNonNull(context);
+        final ClProgram localProgram = Objects.requireNonNull(program);
+        final ClCommandQueue localQueue = Objects.requireNonNull(commandQueue);
 
-        final cl_kernel benchKernel = clCreateKernel(localProgram, "bench_inv_mod", null);
-        final cl_mem out =
-                clCreateBuffer(localContext, CL_MEM_WRITE_ONLY, (long) globalWorkSize * Sizeof.cl_uint, null, null);
+        final ClKernel benchKernel = clApi.createKernel(localProgram, "bench_inv_mod");
+        final ClMem out =
+                clApi.createBuffer(localContext, ClBufferFlags.WRITE_ONLY, (long) globalWorkSize * Integer.BYTES);
         try {
-            clSetKernelArg(benchKernel, 0, Sizeof.cl_mem, Pointer.to(out));
-            clSetKernelArg(benchKernel, 1, Sizeof.cl_uint, Pointer.to(new int[] {iterations}));
-            clSetKernelArg(benchKernel, 2, Sizeof.cl_uint, Pointer.to(new int[] {inputHighLimbsZero ? 1 : 0}));
-            clEnqueueNDRangeKernel(localQueue, benchKernel, 1, null, new long[] {globalWorkSize}, null, 0, null, null);
-            clFinish(localQueue);
+            clApi.setKernelArg(benchKernel, 0, out);
+            clApi.setKernelArgInt(benchKernel, 1, iterations);
+            clApi.setKernelArgInt(benchKernel, 2, inputHighLimbsZero ? 1 : 0);
+            clApi.enqueueNDRangeKernel(localQueue, benchKernel, new long[] {globalWorkSize}, false);
+            clApi.finish(localQueue);
         } finally {
-            clReleaseMemObject(out);
-            clReleaseKernel(benchKernel);
+            clApi.releaseMemObject(out);
+            clApi.releaseKernel(benchKernel);
         }
     }
 
     // Filter-probe microbenchmark state. Held across calls on purpose: the filter reaches gigabytes
     // at production sizes, so uploading it per measured invocation would measure PCIe, not the probe.
-    private @Nullable cl_kernel benchFilterKernel;
-    private @Nullable cl_mem benchFilterMem;
-    private @Nullable cl_mem benchFilterMetaMem;
-    private @Nullable cl_mem benchFilterKeysMem;
-    private @Nullable cl_mem benchFilterHitsMem;
+    private @Nullable ClKernel benchFilterKernel;
+    private @Nullable ClMem benchFilterMem;
+    private @Nullable ClMem benchFilterMetaMem;
+    private @Nullable ClMem benchFilterKeysMem;
+    private @Nullable ClMem benchFilterHitsMem;
     private int benchFilterProbeCount;
 
     /**
@@ -1096,7 +1110,12 @@ public class OpenCLContext implements ReleaseCLObject {
      */
     @VisibleForTesting
     public void prepareBenchFilterProbeFuse8(byte[] fingerprints, int[] meta, long[] probeKeys) {
-        prepareBenchFilterProbe("benchmarkFilterFuse8", Pointer.to(fingerprints), fingerprints.length, meta, probeKeys);
+        prepareBenchFilterProbe(
+                "benchmarkFilterFuse8",
+                fingerprints.length,
+                (queue, mem) -> clApi.writeBufferChunked(queue, mem, fingerprints),
+                meta,
+                probeKeys);
     }
 
     /**
@@ -1117,8 +1136,8 @@ public class OpenCLContext implements ReleaseCLObject {
         // image exceeds Integer.MAX_VALUE, still uploads. See allocateFilterBuffersShort.
         prepareBenchFilterProbe(
                 "benchmarkFilterFuse16",
-                Pointer.to(fingerprints),
                 (long) fingerprints.length * Short.BYTES,
+                (queue, mem) -> clApi.writeBufferChunked(queue, mem, fingerprints),
                 meta,
                 probeKeys);
     }
@@ -1136,45 +1155,48 @@ public class OpenCLContext implements ReleaseCLObject {
     public void prepareBenchFilterProbeBlockedBloom(long[] words, int[] meta, long[] probeKeys) {
         prepareBenchFilterProbe(
                 "benchmarkFilterBlockedBloom",
-                Pointer.to(words),
-                (long) words.length * Sizeof.cl_ulong,
+                (long) words.length * Long.BYTES,
+                (queue, mem) -> clApi.writeBufferChunked(queue, mem, words),
                 meta,
                 probeKeys);
     }
 
     private void prepareBenchFilterProbe(
-            String kernelName, Pointer filterHost, long filterBytes, int[] meta, long[] probeKeys) {
-        final cl_context localContext = Objects.requireNonNull(context);
-        final cl_program localProgram = Objects.requireNonNull(program);
+            String kernelName, long filterBytes, FilterUpload filterUpload, int[] meta, long[] probeKeys) {
+        final ClContext localContext = Objects.requireNonNull(context);
+        final ClProgram localProgram = Objects.requireNonNull(program);
+        final ClCommandQueue localQueue = Objects.requireNonNull(commandQueue);
 
         releaseBenchFilterProbe(); // idempotent: a second prepare must not leak the first upload
         benchFilterProbeCount = probeKeys.length;
-        benchFilterKernel = clCreateKernel(localProgram, kernelName, null);
+        benchFilterKernel = clApi.createKernel(localProgram, kernelName);
         // Same host-memory-pinning trap as the production upload: reclaim the build's transient
         // garbage so the driver can pin the staging region (see reclaimHeapBeforeUpload).
         reclaimHeapBeforeUpload();
-        benchFilterMem =
-                clCreateBuffer(localContext, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, filterBytes, filterHost, null);
-        benchFilterMetaMem = clCreateBuffer(
-                localContext,
-                CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
-                (long) meta.length * Sizeof.cl_uint,
-                Pointer.to(meta),
-                null);
-        benchFilterKeysMem = clCreateBuffer(
-                localContext,
-                CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
-                (long) probeKeys.length * Sizeof.cl_ulong,
-                Pointer.to(probeKeys),
-                null);
-        benchFilterHitsMem = clCreateBuffer(localContext, CL_MEM_WRITE_ONLY, benchFilterProbeCount, null, null);
 
-        final cl_kernel k = Objects.requireNonNull(benchFilterKernel);
-        clSetKernelArg(k, 0, Sizeof.cl_mem, Pointer.to(Objects.requireNonNull(benchFilterMem)));
-        clSetKernelArg(k, 1, Sizeof.cl_mem, Pointer.to(Objects.requireNonNull(benchFilterMetaMem)));
-        clSetKernelArg(k, 2, Sizeof.cl_mem, Pointer.to(Objects.requireNonNull(benchFilterKeysMem)));
-        clSetKernelArg(k, 3, Sizeof.cl_mem, Pointer.to(Objects.requireNonNull(benchFilterHitsMem)));
-        clSetKernelArg(k, 4, Sizeof.cl_uint, Pointer.to(new int[] {benchFilterProbeCount}));
+        final ClMem localFilterMem = clApi.createBuffer(localContext, ClBufferFlags.READ_ONLY, filterBytes);
+        filterUpload.writeInto(localQueue, localFilterMem);
+        benchFilterMem = localFilterMem;
+
+        final ClMem localMetaMem =
+                clApi.createBuffer(localContext, ClBufferFlags.READ_ONLY, (long) meta.length * Integer.BYTES);
+        clApi.writeBufferChunked(localQueue, localMetaMem, meta);
+        benchFilterMetaMem = localMetaMem;
+
+        final ClMem localKeysMem =
+                clApi.createBuffer(localContext, ClBufferFlags.READ_ONLY, (long) probeKeys.length * Long.BYTES);
+        clApi.writeBufferChunked(localQueue, localKeysMem, probeKeys);
+        benchFilterKeysMem = localKeysMem;
+
+        final ClMem localHitsMem = clApi.createBuffer(localContext, ClBufferFlags.WRITE_ONLY, benchFilterProbeCount);
+        benchFilterHitsMem = localHitsMem;
+
+        final ClKernel k = Objects.requireNonNull(benchFilterKernel);
+        clApi.setKernelArg(k, 0, localFilterMem);
+        clApi.setKernelArg(k, 1, localMetaMem);
+        clApi.setKernelArg(k, 2, localKeysMem);
+        clApi.setKernelArg(k, 3, localHitsMem);
+        clApi.setKernelArgInt(k, 4, benchFilterProbeCount);
     }
 
     /**
@@ -1186,25 +1208,25 @@ public class OpenCLContext implements ReleaseCLObject {
      */
     @VisibleForTesting
     public int runBenchFilterProbe() {
-        final cl_command_queue localQueue = Objects.requireNonNull(commandQueue);
-        final cl_kernel k = benchFilterKernel;
+        final ClCommandQueue localQueue = Objects.requireNonNull(commandQueue);
+        final ClKernel k = benchFilterKernel;
         if (k == null) {
             throw new IllegalStateException(
                     "prepareBenchFilterProbe* must be called before runBenchFilterProbe() (benchFilterKernel=null, benchFilterProbeCount="
                             + benchFilterProbeCount
                             + ")");
         }
-        clEnqueueNDRangeKernel(localQueue, k, 1, null, new long[] {benchFilterProbeCount}, null, 0, null, null);
-        clFinish(localQueue);
+        clApi.enqueueNDRangeKernel(localQueue, k, new long[] {benchFilterProbeCount}, false);
+        clApi.finish(localQueue);
         return benchFilterProbeCount;
     }
 
     /** Releases the filter-probe benchmark buffers and kernel. Safe to call repeatedly. */
     @VisibleForTesting
     public void releaseBenchFilterProbe() {
-        for (cl_mem mem : new cl_mem[] {benchFilterMem, benchFilterMetaMem, benchFilterKeysMem, benchFilterHitsMem}) {
+        for (ClMem mem : new ClMem[] {benchFilterMem, benchFilterMetaMem, benchFilterKeysMem, benchFilterHitsMem}) {
             if (mem != null) {
-                clReleaseMemObject(mem);
+                clApi.releaseMemObject(mem);
             }
         }
         benchFilterMem = null;
@@ -1212,7 +1234,7 @@ public class OpenCLContext implements ReleaseCLObject {
         benchFilterKeysMem = null;
         benchFilterHitsMem = null;
         if (benchFilterKernel != null) {
-            clReleaseKernel(benchFilterKernel);
+            clApi.releaseKernel(benchFilterKernel);
             benchFilterKernel = null;
         }
         benchFilterProbeCount = 0;
@@ -1233,22 +1255,22 @@ public class OpenCLContext implements ReleaseCLObject {
      */
     @VisibleForTesting
     public void runBenchFeMul(int globalWorkSize, int iterations, boolean useReducedRadix) {
-        final cl_context localContext = Objects.requireNonNull(context);
-        final cl_program localProgram = Objects.requireNonNull(program);
-        final cl_command_queue localQueue = Objects.requireNonNull(commandQueue);
+        final ClContext localContext = Objects.requireNonNull(context);
+        final ClProgram localProgram = Objects.requireNonNull(program);
+        final ClCommandQueue localQueue = Objects.requireNonNull(commandQueue);
 
-        final cl_kernel benchKernel = clCreateKernel(localProgram, "bench_fe_mul", null);
-        final cl_mem out =
-                clCreateBuffer(localContext, CL_MEM_WRITE_ONLY, (long) globalWorkSize * Sizeof.cl_uint, null, null);
+        final ClKernel benchKernel = clApi.createKernel(localProgram, "bench_fe_mul");
+        final ClMem out =
+                clApi.createBuffer(localContext, ClBufferFlags.WRITE_ONLY, (long) globalWorkSize * Integer.BYTES);
         try {
-            clSetKernelArg(benchKernel, 0, Sizeof.cl_mem, Pointer.to(out));
-            clSetKernelArg(benchKernel, 1, Sizeof.cl_uint, Pointer.to(new int[] {iterations}));
-            clSetKernelArg(benchKernel, 2, Sizeof.cl_uint, Pointer.to(new int[] {useReducedRadix ? 1 : 0}));
-            clEnqueueNDRangeKernel(localQueue, benchKernel, 1, null, new long[] {globalWorkSize}, null, 0, null, null);
-            clFinish(localQueue);
+            clApi.setKernelArg(benchKernel, 0, out);
+            clApi.setKernelArgInt(benchKernel, 1, iterations);
+            clApi.setKernelArgInt(benchKernel, 2, useReducedRadix ? 1 : 0);
+            clApi.enqueueNDRangeKernel(localQueue, benchKernel, new long[] {globalWorkSize}, false);
+            clApi.finish(localQueue);
         } finally {
-            clReleaseMemObject(out);
-            clReleaseKernel(benchKernel);
+            clApi.releaseMemObject(out);
+            clApi.releaseKernel(benchKernel);
         }
     }
 
@@ -1268,19 +1290,19 @@ public class OpenCLContext implements ReleaseCLObject {
                 openClTask = null;
             }
             if (kernel != null) {
-                clReleaseKernel(kernel);
+                clApi.releaseKernel(kernel);
                 kernel = null;
             }
             if (program != null) {
-                clReleaseProgram(program);
+                clApi.releaseProgram(program);
                 program = null;
             }
             if (commandQueue != null) {
-                clReleaseCommandQueue(commandQueue);
+                clApi.releaseCommandQueue(commandQueue);
                 commandQueue = null;
             }
             if (context != null) {
-                clReleaseContext(context);
+                clApi.releaseContext(context);
                 context = null;
             }
             closed = true;
@@ -1295,12 +1317,12 @@ public class OpenCLContext implements ReleaseCLObject {
      */
     public OpenCLGridResult createKeys(BigInteger privateKeyBase) {
         OpenClTask localOpenClTask = Objects.requireNonNull(openClTask);
-        cl_kernel localKernel = Objects.requireNonNull(kernel);
-        cl_command_queue localCommandQueue = Objects.requireNonNull(commandQueue);
-        cl_mem localFuse8FingerprintsMem = Objects.requireNonNull(fuse8FingerprintsMem);
-        cl_mem localFuse8MetadataMem = Objects.requireNonNull(fuse8MetadataMem);
-        cl_mem localIgTableMem = Objects.requireNonNull(igTableMem);
-        cl_mem localCombTableMem = Objects.requireNonNull(combTableMem);
+        ClKernel localKernel = Objects.requireNonNull(kernel);
+        ClCommandQueue localCommandQueue = Objects.requireNonNull(commandQueue);
+        ClMem localFuse8FingerprintsMem = Objects.requireNonNull(fuse8FingerprintsMem);
+        ClMem localFuse8MetadataMem = Objects.requireNonNull(fuse8MetadataMem);
+        ClMem localIgTableMem = Objects.requireNonNull(igTableMem);
+        ClMem localCombTableMem = Objects.requireNonNull(combTableMem);
 
         // Compact (filter) mode only when a real filter is uploaded AND the caller did not force
         // full transfer; otherwise run full transfer (no filter, or vanity forced transferAll).

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDevice.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDevice.java
@@ -11,55 +11,55 @@ import java.io.Serializable;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.util.List;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClDeviceId;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClDeviceInfoFormatter;
 import org.apache.maven.artifact.versioning.ComparableVersion;
-import org.jocl.CL;
-import org.jocl.cl_device_id;
 import org.jspecify.annotations.NonNull;
 
 /**
  * Represents an OpenCL device and its properties.
  *
- * @param device                     See {@link org.jocl.cl_device_id}
- * @param deviceName                 See {@link org.jocl.CL#CL_DEVICE_NAME}
- * @param deviceVendor               See {@link org.jocl.CL#CL_DEVICE_VENDOR}
- * @param driverVersion              See {@link org.jocl.CL#CL_DRIVER_VERSION}
- * @param deviceProfile              See {@link org.jocl.CL#CL_DEVICE_PROFILE}
- * @param deviceVersion              See {@link org.jocl.CL#CL_DEVICE_VERSION}
- * @param deviceExtensions           See {@link org.jocl.CL#CL_DEVICE_EXTENSIONS}
- * @param deviceType                 See {@link org.jocl.CL#CL_DEVICE_TYPE}
- * @param endianLittle               See {@link org.jocl.CL#CL_DEVICE_ENDIAN_LITTLE}
- * @param maxComputeUnits            See {@link org.jocl.CL#CL_DEVICE_MAX_COMPUTE_UNITS}
- * @param maxWorkItemDimensions      See {@link org.jocl.CL#CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS}
- * @param maxWorkItemSizes           See {@link org.jocl.CL#CL_DEVICE_MAX_WORK_ITEM_SIZES}
- * @param maxWorkGroupSize           See {@link org.jocl.CL#CL_DEVICE_MAX_WORK_GROUP_SIZE}
- * @param maxClockFrequency          See {@link org.jocl.CL#CL_DEVICE_MAX_CLOCK_FREQUENCY}
- * @param addressBits                See {@link org.jocl.CL#CL_DEVICE_ADDRESS_BITS}
- * @param maxMemAllocSize            See {@link org.jocl.CL#CL_DEVICE_MAX_MEM_ALLOC_SIZE}
- * @param globalMemSize              See {@link org.jocl.CL#CL_DEVICE_GLOBAL_MEM_SIZE}
- * @param errorCorrectionSupport     See {@link org.jocl.CL#CL_DEVICE_ERROR_CORRECTION_SUPPORT}
- * @param localMemType               See {@link org.jocl.CL#CL_DEVICE_LOCAL_MEM_TYPE}
- * @param localMemSize               See {@link org.jocl.CL#CL_DEVICE_LOCAL_MEM_SIZE}
- * @param maxConstantBufferSize      See {@link org.jocl.CL#CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE}
- * @param queueProperties            See {@link org.jocl.CL#CL_DEVICE_QUEUE_PROPERTIES}
- * @param imageSupport               See {@link org.jocl.CL#CL_DEVICE_IMAGE_SUPPORT}
- * @param maxReadImageArgs           See {@link org.jocl.CL#CL_DEVICE_MAX_READ_IMAGE_ARGS}
- * @param maxWriteImageArgs          See {@link org.jocl.CL#CL_DEVICE_MAX_WRITE_IMAGE_ARGS}
- * @param singleFpConfig             See {@link org.jocl.CL#CL_DEVICE_SINGLE_FP_CONFIG}
- * @param image2dMaxWidth            See {@link org.jocl.CL#CL_DEVICE_IMAGE2D_MAX_WIDTH}
- * @param image2dMaxHeight           See {@link org.jocl.CL#CL_DEVICE_IMAGE2D_MAX_HEIGHT}
- * @param image3dMaxWidth            See {@link org.jocl.CL#CL_DEVICE_IMAGE3D_MAX_WIDTH}
- * @param image3dMaxHeight           See {@link org.jocl.CL#CL_DEVICE_IMAGE3D_MAX_HEIGHT}
- * @param image3dMaxDepth            See {@link org.jocl.CL#CL_DEVICE_IMAGE3D_MAX_DEPTH}
- * @param preferredVectorWidthChar   See {@link org.jocl.CL#CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR}
- * @param preferredVectorWidthShort  See {@link org.jocl.CL#CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT}
- * @param preferredVectorWidthInt    See {@link org.jocl.CL#CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT}
- * @param preferredVectorWidthLong   See {@link org.jocl.CL#CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG}
- * @param preferredVectorWidthFloat  See {@link org.jocl.CL#CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT}
- * @param preferredVectorWidthDouble See {@link org.jocl.CL#CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE}
+ * @param device                     the device handle
+ * @param deviceName                 See {@code CL_DEVICE_NAME}
+ * @param deviceVendor               See {@code CL_DEVICE_VENDOR}
+ * @param driverVersion              See {@code CL_DRIVER_VERSION}
+ * @param deviceProfile              See {@code CL_DEVICE_PROFILE}
+ * @param deviceVersion              See {@code CL_DEVICE_VERSION}
+ * @param deviceExtensions           See {@code CL_DEVICE_EXTENSIONS}
+ * @param deviceType                 See {@code CL_DEVICE_TYPE}
+ * @param endianLittle               See {@code CL_DEVICE_ENDIAN_LITTLE}
+ * @param maxComputeUnits            See {@code CL_DEVICE_MAX_COMPUTE_UNITS}
+ * @param maxWorkItemDimensions      See {@code CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS}
+ * @param maxWorkItemSizes           See {@code CL_DEVICE_MAX_WORK_ITEM_SIZES}
+ * @param maxWorkGroupSize           See {@code CL_DEVICE_MAX_WORK_GROUP_SIZE}
+ * @param maxClockFrequency          See {@code CL_DEVICE_MAX_CLOCK_FREQUENCY}
+ * @param addressBits                See {@code CL_DEVICE_ADDRESS_BITS}
+ * @param maxMemAllocSize            See {@code CL_DEVICE_MAX_MEM_ALLOC_SIZE}
+ * @param globalMemSize              See {@code CL_DEVICE_GLOBAL_MEM_SIZE}
+ * @param errorCorrectionSupport     See {@code CL_DEVICE_ERROR_CORRECTION_SUPPORT}
+ * @param localMemType               See {@code CL_DEVICE_LOCAL_MEM_TYPE}
+ * @param localMemSize               See {@code CL_DEVICE_LOCAL_MEM_SIZE}
+ * @param maxConstantBufferSize      See {@code CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE}
+ * @param queueProperties            See {@code CL_DEVICE_QUEUE_PROPERTIES}
+ * @param imageSupport               See {@code CL_DEVICE_IMAGE_SUPPORT}
+ * @param maxReadImageArgs           See {@code CL_DEVICE_MAX_READ_IMAGE_ARGS}
+ * @param maxWriteImageArgs          See {@code CL_DEVICE_MAX_WRITE_IMAGE_ARGS}
+ * @param singleFpConfig             See {@code CL_DEVICE_SINGLE_FP_CONFIG}
+ * @param image2dMaxWidth            See {@code CL_DEVICE_IMAGE2D_MAX_WIDTH}
+ * @param image2dMaxHeight           See {@code CL_DEVICE_IMAGE2D_MAX_HEIGHT}
+ * @param image3dMaxWidth            See {@code CL_DEVICE_IMAGE3D_MAX_WIDTH}
+ * @param image3dMaxHeight           See {@code CL_DEVICE_IMAGE3D_MAX_HEIGHT}
+ * @param image3dMaxDepth            See {@code CL_DEVICE_IMAGE3D_MAX_DEPTH}
+ * @param preferredVectorWidthChar   See {@code CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR}
+ * @param preferredVectorWidthShort  See {@code CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT}
+ * @param preferredVectorWidthInt    See {@code CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT}
+ * @param preferredVectorWidthLong   See {@code CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG}
+ * @param preferredVectorWidthFloat  See {@code CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT}
+ * @param preferredVectorWidthDouble See {@code CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE}
  */
 @Immutable
 public record OpenCLDevice(
-        @SuppressWarnings("Immutable") cl_device_id device,
+        ClDeviceId device,
         String deviceName,
         String deviceVendor,
         String driverVersion,
@@ -99,6 +99,25 @@ public record OpenCLDevice(
         implements Serializable {
 
     /**
+     * Renders the OpenCL bit fields in {@link #toStringPretty()}. A shared instance: the formatter is
+     * stateless, and a record component would make it part of this device's identity.
+     */
+    @SuppressWarnings("Immutable")
+    private static final ClDeviceInfoFormatter FORMATTER = new ClDeviceInfoFormatter();
+
+    /**
+     * Renders the device handle for the human-readable dump.
+     *
+     * <p>Formatted as hexadecimal rather than as the record's own {@code toString()}: the value is a
+     * native pointer, which is how every driver tool and log prints it.
+     *
+     * @return the handle as {@code cl_device_id[0x...]}
+     */
+    private String formatHandle() {
+        return String.format("cl_device_id[0x%x]", device.handle());
+    }
+
+    /**
      * Returns the byte order this device uses.
      *
      * @return {@link ByteOrder#LITTLE_ENDIAN} or {@link ByteOrder#BIG_ENDIAN}
@@ -121,14 +140,14 @@ public record OpenCLDevice(
 
         try (PrintStream ps = new PrintStream(baos, true, charset)) {
             ps.println("--- Info for OpenCL device: " + deviceName + " ---");
-            ps.printf("cl_device_id:                          %s%n", device);
+            ps.printf("cl_device_id:                          %s%n", formatHandle());
             ps.printf("CL_DEVICE_NAME:                        %s%n", deviceName);
             ps.printf("CL_DEVICE_VENDOR:                      %s%n", deviceVendor);
             ps.printf("CL_DRIVER_VERSION:                     %s%n", driverVersion);
             ps.printf("CL_DEVICE_PROFILE:                     %s%n", deviceProfile);
             ps.printf("CL_DEVICE_VERSION:                     %s%n", deviceVersion);
             ps.printf("CL_DEVICE_EXTENSIONS:                  %s%n", deviceExtensions);
-            ps.printf("CL_DEVICE_TYPE:                        %s%n", CL.stringFor_cl_device_type(deviceType));
+            ps.printf("CL_DEVICE_TYPE:                        %s%n", FORMATTER.formatDeviceType(deviceType));
             ps.printf("CL_DEVICE_ENDIAN_LITTLE:               %b%n", endianLittle);
             ps.printf("CL_DEVICE_MAX_COMPUTE_UNITS:           %d%n", maxComputeUnits);
             ps.printf("CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS:    %d%n", maxWorkItemDimensions);
@@ -139,17 +158,16 @@ public record OpenCLDevice(
             ps.printf("CL_DEVICE_MAX_MEM_ALLOC_SIZE:          %d MByte%n", maxMemAllocSize / (1024 * 1024));
             ps.printf("CL_DEVICE_GLOBAL_MEM_SIZE:             %d MByte%n", globalMemSize / (1024 * 1024));
             ps.printf("CL_DEVICE_ERROR_CORRECTION_SUPPORT:    %s%n", errorCorrectionSupport != 0 ? "yes" : "no");
-            ps.printf(
-                    "CL_DEVICE_LOCAL_MEM_TYPE:              %s%n", CL.stringFor_cl_device_local_mem_type(localMemType));
+            ps.printf("CL_DEVICE_LOCAL_MEM_TYPE:              %s%n", FORMATTER.formatLocalMemType(localMemType));
             ps.printf("CL_DEVICE_LOCAL_MEM_SIZE:              %d KByte%n", localMemSize / 1024);
             ps.printf("CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE:    %d KByte%n", maxConstantBufferSize / 1024);
             ps.printf(
                     "CL_DEVICE_QUEUE_PROPERTIES:            %s%n",
-                    CL.stringFor_cl_command_queue_properties(queueProperties));
+                    FORMATTER.formatCommandQueueProperties(queueProperties));
             ps.printf("CL_DEVICE_IMAGE_SUPPORT:               %d%n", imageSupport);
             ps.printf("CL_DEVICE_MAX_READ_IMAGE_ARGS:         %d%n", maxReadImageArgs);
             ps.printf("CL_DEVICE_MAX_WRITE_IMAGE_ARGS:        %d%n", maxWriteImageArgs);
-            ps.printf("CL_DEVICE_SINGLE_FP_CONFIG:            %s%n", CL.stringFor_cl_device_fp_config(singleFpConfig));
+            ps.printf("CL_DEVICE_SINGLE_FP_CONFIG:            %s%n", FORMATTER.formatDeviceFpConfig(singleFpConfig));
             ps.printf("CL_DEVICE_IMAGE2D_MAX_WIDTH:           %d%n", image2dMaxWidth);
             ps.printf("CL_DEVICE_IMAGE2D_MAX_HEIGHT:          %d%n", image2dMaxHeight);
             ps.printf("CL_DEVICE_IMAGE3D_MAX_WIDTH:           %d%n", image3dMaxWidth);

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDeviceSelection.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDeviceSelection.java
@@ -3,15 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.opencl;
 
-import org.jocl.cl_context_properties;
-
 /**
- * Result of {@link OpenCLPlatformSelector#select}: the selected platform and device plus the
- * matching {@link cl_context_properties}.
+ * Result of {@link OpenCLPlatformSelector#select}: the selected platform and the device chosen on it.
  *
- * @param platform           the selected OpenCL platform
- * @param device             the selected OpenCL device on that platform
- * @param contextProperties  the context properties referencing the platform
+ * <p>The platform is kept alongside the device because creating a context needs both — the device
+ * handle alone does not say which platform it came from.
+ *
+ * @param platform the selected OpenCL platform
+ * @param device   the selected OpenCL device on that platform
  */
-public record OpenCLDeviceSelection(
-        OpenCLPlatform platform, OpenCLDevice device, cl_context_properties contextProperties) {}
+public record OpenCLDeviceSelection(OpenCLPlatform platform, OpenCLDevice device) {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDeviceTopology.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDeviceTopology.java
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.opencl;
 
-import static org.jocl.CL.clGetDeviceInfo;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Locale;
-import org.jocl.Pointer;
+import lombok.ToString;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClApi;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClBinding;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -44,9 +44,10 @@ import org.jspecify.annotations.Nullable;
  * cannot cause a merge, so an unsupported device falls back to today's behaviour (swept once per
  * enumeration entry) and can never be wrongly folded into another.
  */
-public final class OpenCLDeviceTopology {
+@ToString
+public class OpenCLDeviceTopology {
 
-    /** {@code CL_DEVICE_UUID_KHR} from {@code cl_ext.h}; not defined by JOCL's {@code CL}. */
+    /** {@code CL_DEVICE_UUID_KHR} from {@code cl_ext.h}; not exposed as a binding constant. */
     private static final int CL_DEVICE_UUID_KHR = 0x106A;
 
     /** {@code CL_UUID_SIZE_KHR}: the UUID is exactly this many opaque bytes. */
@@ -87,8 +88,20 @@ public final class OpenCLDeviceTopology {
      */
     private static final Splitter EXTENSION_SPLITTER = Splitter.on(' ').omitEmptyStrings();
 
-    private OpenCLDeviceTopology() {
-        // static helper
+    private final ClApi clApi;
+
+    /** Creates a topology resolver using the project's default OpenCL binding. */
+    public OpenCLDeviceTopology() {
+        this(OpenClBinding.defaultClApi());
+    }
+
+    /**
+     * Creates a topology resolver on an explicit OpenCL API, so tests can substitute it.
+     *
+     * @param clApi the OpenCL API used to read the identity properties
+     */
+    public OpenCLDeviceTopology(ClApi clApi) {
+        this.clApi = clApi;
     }
 
     /**
@@ -98,7 +111,7 @@ public final class OpenCLDeviceTopology {
      * @param device the device to fingerprint
      * @return a stable fingerprint, or {@code null} when no source is available
      */
-    public static @Nullable String physicalDeviceFingerprintOf(OpenCLDevice device) {
+    public @Nullable String physicalDeviceFingerprintOf(OpenCLDevice device) {
         String extensions = device.deviceExtensions();
         if (supportsDeviceUuid(extensions)) {
             String uuid = parseDeviceUuid(query(device, CL_DEVICE_UUID_KHR, CL_UUID_SIZE_KHR));
@@ -127,19 +140,11 @@ public final class OpenCLDeviceTopology {
      * @return the payload, or an empty array when the driver rejected the query — the parsers below
      *     reject it on length, so an empty array and a refusal are the same outcome without a null
      */
-    private static byte[] query(OpenCLDevice device, int param, int bytes) {
-        try {
-            byte[] payload = new byte[bytes];
-            // A length-1 array receives the number of bytes actually written; the value is unused,
-            // but the binding's nullness contract requires a non-null array here.
-            long[] bytesWritten = new long[1];
-            clGetDeviceInfo(device.device(), param, bytes, Pointer.to(payload), bytesWritten);
-            return payload;
-        } catch (RuntimeException | LinkageError e) {
-            // Any driver/JOCL failure: treat the identity as unknown so the device is kept, never
-            // merged. De-duplication is a best-effort optimisation, not a correctness requirement.
-            return new byte[0];
-        }
+    private byte[] query(OpenCLDevice device, int param, int bytes) {
+        // Any driver failure is absorbed by the API and surfaces as an empty payload: the identity
+        // is then unknown, so the device is kept and never merged. De-duplication is a best-effort
+        // optimisation, not a correctness requirement.
+        return clApi.getDeviceInfoBytesOrEmpty(device.device(), param, bytes);
     }
 
     /**
@@ -153,7 +158,8 @@ public final class OpenCLDeviceTopology {
      * @return the fingerprint, or {@code null} when the payload is unusable
      */
     @VisibleForTesting
-    static @Nullable String parseDeviceUuid(byte @Nullable [] uuid) {
+    @Nullable
+    String parseDeviceUuid(byte @Nullable [] uuid) {
         if (uuid == null || uuid.length != CL_UUID_SIZE_KHR) {
             return null;
         }
@@ -180,7 +186,8 @@ public final class OpenCLDeviceTopology {
      * @return the fingerprint, or {@code null} when the payload is unusable
      */
     @VisibleForTesting
-    static @Nullable String parsePciBusInfo(byte @Nullable [] payload) {
+    @Nullable
+    String parsePciBusInfo(byte @Nullable [] payload) {
         if (payload == null || payload.length != PCI_BUS_INFO_BYTES) {
             return null;
         }
@@ -203,7 +210,8 @@ public final class OpenCLDeviceTopology {
      * @return the fingerprint, or {@code null} when the payload is unusable
      */
     @VisibleForTesting
-    static @Nullable String parseAmdTopology(byte @Nullable [] topology) {
+    @Nullable
+    String parseAmdTopology(byte @Nullable [] topology) {
         if (topology == null || topology.length != CL_DEVICE_TOPOLOGY_AMD_BYTES) {
             return null;
         }
@@ -224,7 +232,7 @@ public final class OpenCLDeviceTopology {
      * @return {@code true} if the extension is present
      */
     @VisibleForTesting
-    static boolean supportsDeviceUuid(String extensions) {
+    boolean supportsDeviceUuid(String extensions) {
         return hasExtension(extensions, DEVICE_UUID_EXTENSION);
     }
 
@@ -235,7 +243,7 @@ public final class OpenCLDeviceTopology {
      * @return {@code true} if the extension is present
      */
     @VisibleForTesting
-    static boolean supportsPciBusInfo(String extensions) {
+    boolean supportsPciBusInfo(String extensions) {
         return hasExtension(extensions, PCI_BUS_INFO_EXTENSION);
     }
 
@@ -246,7 +254,7 @@ public final class OpenCLDeviceTopology {
      * @return {@code true} if the extension is present
      */
     @VisibleForTesting
-    static boolean supportsAmdTopology(String extensions) {
+    boolean supportsAmdTopology(String extensions) {
         return hasExtension(extensions, AMD_ATTRIBUTE_QUERY_EXTENSION);
     }
 
@@ -261,7 +269,7 @@ public final class OpenCLDeviceTopology {
      * @param extension  the extension to look for
      * @return {@code true} if the list contains it as a whole token
      */
-    private static boolean hasExtension(String extensions, String extension) {
+    private boolean hasExtension(String extensions, String extension) {
         for (String candidate : EXTENSION_SPLITTER.split(extensions)) {
             if (candidate.equals(extension)) {
                 return true;

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLPlatform.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLPlatform.java
@@ -6,36 +6,24 @@ package net.ladenthin.bitcoinaddressfinder.opencl;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import java.io.Serializable;
-import org.jocl.cl_context_properties;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClPlatformId;
 import org.jspecify.annotations.NonNull;
 
 /**
  * Represents an OpenCL platform and its associated devices.
  *
- * @param platformName      the name of the OpenCL platform
- * @param contextProperties the context properties of the OpenCL platform
- * @param openCLDevices     a list of associated OpenCL devices
+ * <p>Carries the platform handle rather than a prepared context-property list. The properties are a
+ * throwaway argument of {@code clCreateContext} — building them at the point of use keeps this a
+ * plain description of the machine, and it removes a binding-specific structure from a type that the
+ * layers above pass around.
+ *
+ * @param platformId    the platform handle
+ * @param platformName  the name of the OpenCL platform
+ * @param openCLDevices a list of associated OpenCL devices
  */
 @Immutable
 public record OpenCLPlatform(
+        @NonNull ClPlatformId platformId,
         @NonNull String platformName,
-        @SuppressWarnings("Immutable") @NonNull cl_context_properties contextProperties,
         @NonNull ImmutableList<@NonNull OpenCLDevice> openCLDevices)
-        implements Serializable {
-
-    /**
-     * Canonical constructor.
-     *
-     * @param platformName      the name of the OpenCL platform
-     * @param contextProperties the context properties of the OpenCL platform
-     * @param openCLDevices     the associated OpenCL devices
-     */
-    public OpenCLPlatform(
-            String platformName,
-            cl_context_properties contextProperties,
-            ImmutableList<@NonNull OpenCLDevice> openCLDevices) {
-        this.platformName = platformName;
-        this.contextProperties = contextProperties;
-        this.openCLDevices = openCLDevices;
-    }
-}
+        implements Serializable {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLPlatformSelector.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLPlatformSelector.java
@@ -20,7 +20,7 @@ public class OpenCLPlatformSelector {
      * @param platformIndex The index of the platform to select
      * @param deviceType The OpenCL device type (e.g., CL_DEVICE_TYPE_GPU)
      * @param deviceIndex The index of the device within the platform
-     * @return A selected OpenCLDeviceSelection containing platform, device, and context properties
+     * @return A selected OpenCLDeviceSelection containing the platform and the device
      */
     public OpenCLDeviceSelection select(
             List<OpenCLPlatform> platforms, int platformIndex, long deviceType, int deviceIndex) {
@@ -41,6 +41,6 @@ public class OpenCLPlatformSelector {
 
         OpenCLDevice selectedDevice = matchingDevices.get(deviceIndex);
 
-        return new OpenCLDeviceSelection(selectedPlatform, selectedDevice, selectedPlatform.contextProperties());
+        return new OpenCLDeviceSelection(selectedPlatform, selectedDevice);
     }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenClTask.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenClTask.java
@@ -3,22 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder.opencl;
 
-import static org.jocl.CL.CL_MEM_READ_ONLY;
-import static org.jocl.CL.CL_MEM_USE_HOST_PTR;
-import static org.jocl.CL.CL_MEM_WRITE_ONLY;
-import static org.jocl.CL.CL_PROFILING_COMMAND_END;
-import static org.jocl.CL.CL_PROFILING_COMMAND_START;
-import static org.jocl.CL.CL_TRUE;
-import static org.jocl.CL.clCreateBuffer;
-import static org.jocl.CL.clEnqueueNDRangeKernel;
-import static org.jocl.CL.clEnqueueReadBuffer;
-import static org.jocl.CL.clEnqueueWriteBuffer;
-import static org.jocl.CL.clFinish;
-import static org.jocl.CL.clGetEventProfilingInfo;
-import static org.jocl.CL.clReleaseEvent;
-import static org.jocl.CL.clReleaseMemObject;
-import static org.jocl.CL.clSetKernelArg;
-
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -27,28 +11,25 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.ToString;
 import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
 import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClApi;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClBufferFlags;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClCommandQueue;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClContext;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClEvent;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClKernel;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClMem;
 import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
 import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
 import net.ladenthin.bitcoinaddressfinder.util.EndiannessConverter;
 import net.ladenthin.bitcoinaddressfinder.util.PrivateKeyTooLargeException;
 import net.ladenthin.bitcoinaddressfinder.util.PrivateKeyValidator;
-import org.jocl.Pointer;
-import org.jocl.Sizeof;
-import org.jocl.cl_command_queue;
-import org.jocl.cl_context;
-import org.jocl.cl_event;
-import org.jocl.cl_kernel;
-import org.jocl.cl_mem;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulates one OpenCL kernel invocation: manages source/destination buffers and runs the kernel.
  */
-// JOCL upstream API is not annotated for nullness; every clXxx(...) call here passes
-// the null values that the OpenCL C ABI accepts (e.g. errcode_ret, event_wait_list,
-// event, global_work_offset). Suppress at class scope to avoid per-call noise.
-@SuppressWarnings({"nullness:argument", "nullness:dereference.of.nullable"})
 @ToString
 public class OpenClTask implements ReleaseCLObject {
 
@@ -60,24 +41,42 @@ public class OpenClTask implements ReleaseCLObject {
     /** Sentinel meaning "no profiling timestamp captured for the most recent launch". */
     public static final long PROFILING_NOT_AVAILABLE = -1L;
 
+    /** Kernel argument positions, in the order {@code generateKeysKernel_grid} declares them. */
+    private static final int ARG_DESTINATION = 0;
+
+    private static final int ARG_PRIVATE_KEY_SOURCE = 1;
+    private static final int ARG_KEYS_PER_WORK_ITEM = 2;
+    private static final int ARG_FILTER_FINGERPRINTS = 3;
+    private static final int ARG_FILTER_METADATA = 4;
+    private static final int ARG_TRANSFER_ALL = 5;
+
+    /**
+     * {@code filter_type} sits directly behind {@code transfer_all} in the kernel signature, so the
+     * table buffers that follow it occupy 7 and 8 rather than 6 and 7.
+     */
+    private static final int ARG_FILTER_TYPE = 6;
+
+    private static final int ARG_IG_TABLE = 7;
+    private static final int ARG_COMB_TABLE = 8;
+
+    @ToString.Exclude
+    private final ClApi clApi;
+
     private final CProducerOpenCL cProducer;
 
     // SourceArgument carries its own ByteBuffer payload — heavy and not useful in logs.
     @ToString.Exclude
     private final SourceArgument privateKeySourceArgument;
 
-    // Reusable GPU output buffer (CL_MEM_WRITE_ONLY). Allocated once at the fixed per-batch result
-    // size and reused for every executeKernel() launch, instead of clCreateBuffer/clReleaseMemObject
-    // per launch (the ~100+ MB device buffer alloc/free dominated per-launch host overhead). It is
-    // safe to reuse a single device buffer because executeKernel() uses it strictly synchronously
-    // (kernel write + readback, each followed by clFinish, on the single producer thread) before
-    // returning; the asynchronous result readers only ever touch the host-side ByteBuffer copy, never
-    // this cl_mem. Released in close().
+    // Reusable GPU output buffer (write-only). Allocated once at the fixed per-batch result size and
+    // reused for every executeKernel() launch, instead of creating and releasing it per launch (the
+    // ~100+ MB device buffer alloc/free dominated per-launch host overhead). It is safe to reuse a
+    // single device buffer because executeKernel() uses it strictly synchronously (kernel write +
+    // readback, each followed by a finish, on the single producer thread) before returning; the
+    // asynchronous result readers only ever touch the host-side ByteBuffer copy, never this buffer.
+    // Released in close().
     @ToString.Exclude
-    private final cl_mem dstMem;
-
-    @ToString.Exclude
-    private final Pointer dstMemPointer;
+    private final ClMem dstMem;
 
     // Pool of reusable host-side readback buffers (full per-batch result size). Unlike dstMem, each
     // launch's host buffer is handed to an OpenCLGridResult and read ASYNCHRONOUSLY by the
@@ -109,34 +108,38 @@ public class OpenClTask implements ReleaseCLObject {
     private volatile long lastResultReadbackNanos = PROFILING_NOT_AVAILABLE;
 
     /**
-     * Common base for source and destination OpenCL buffer arguments backed by a {@link ByteBuffer}.
+     * Kernel input buffer backed by host memory the caller keeps alive.
+     *
+     * <p>The device buffer is created over the host allocation rather than as a copy, which is what
+     * lets the private key be rewritten between launches without reallocating anything.
      */
-    public abstract static class CLByteBufferPointerArgument implements ReleaseCLObject {
-        /** Host-side direct byte buffer holding the data. */
-        protected final ByteBuffer byteBuffer;
-        /** {@link Pointer} that references {@link #byteBuffer} for host memory transfers. */
-        protected final Pointer hostMemoryPointer;
-        /** Underlying OpenCL memory object. */
-        protected final cl_mem mem;
-        /** {@link Pointer} that references {@link #mem} for {@code clSetKernelArg}. */
-        protected final Pointer clMemPointer;
+    public static class SourceArgument implements ReleaseCLObject {
 
+        private final ClApi clApi;
+        private final ByteBuffer byteBuffer;
+        private final ClMem mem;
         private boolean closed = false;
 
-        /**
-         * Creates a new wrapper around an allocated OpenCL buffer.
-         *
-         * @param byteBuffer        the backing direct byte buffer
-         * @param hostMemoryPointer pointer to {@code byteBuffer}
-         * @param mem               the OpenCL memory object
-         * @param clMemPointer      pointer to {@code mem}
-         */
-        public CLByteBufferPointerArgument(
-                ByteBuffer byteBuffer, Pointer hostMemoryPointer, cl_mem mem, Pointer clMemPointer) {
+        private SourceArgument(ClApi clApi, ByteBuffer byteBuffer, ClMem mem) {
+            this.clApi = clApi;
             this.byteBuffer = byteBuffer;
-            this.hostMemoryPointer = hostMemoryPointer;
             this.mem = mem;
-            this.clMemPointer = clMemPointer;
+        }
+
+        /**
+         * Allocates a new source buffer.
+         *
+         * @param clApi       the OpenCL API to allocate through
+         * @param context     the OpenCL context
+         * @param sizeInBytes the buffer size in bytes
+         * @return the created {@link SourceArgument}
+         */
+        public static SourceArgument create(ClApi clApi, ClContext context, long sizeInBytes) {
+            final ByteBuffer byteBuffer =
+                    ByteBuffer.allocateDirect(ByteBufferUtility.ensureByteBufferCapacityFitsInt(sizeInBytes));
+            final ClMem mem = clApi.createBufferFromHostMemory(
+                    context, ClBufferFlags.READ_ONLY | ClBufferFlags.USE_HOST_PTR, byteBuffer);
+            return new SourceArgument(clApi, byteBuffer, mem);
         }
 
         /**
@@ -149,29 +152,11 @@ public class OpenClTask implements ReleaseCLObject {
         }
 
         /**
-         * Returns the host-memory pointer used for {@code clEnqueueRead/WriteBuffer}.
+         * Returns the wrapped device memory object.
          *
-         * @return the host-memory pointer used for {@code clEnqueueRead/WriteBuffer}
+         * @return the wrapped device memory object
          */
-        public Pointer getHostMemoryPointer() {
-            return hostMemoryPointer;
-        }
-
-        /**
-         * Returns the {@code cl_mem} pointer used for {@code clSetKernelArg}.
-         *
-         * @return the {@code cl_mem} pointer used for {@code clSetKernelArg}
-         */
-        public Pointer getClMemPointer() {
-            return clMemPointer;
-        }
-
-        /**
-         * Returns the wrapped {@link cl_mem} object.
-         *
-         * @return the wrapped {@link cl_mem} object
-         */
-        public cl_mem getMem() {
+        public ClMem getMem() {
             return mem;
         }
 
@@ -183,60 +168,38 @@ public class OpenClTask implements ReleaseCLObject {
         @Override
         public void close() {
             if (!closed) {
-                clReleaseMemObject(mem);
+                clApi.releaseMemObject(mem);
                 closed = true;
             }
         }
     }
 
     /**
-     * Source (kernel input) OpenCL buffer argument.
-     */
-    public static class SourceArgument extends CLByteBufferPointerArgument {
-
-        private SourceArgument(ByteBuffer byteBuffer, Pointer hostMemoryPointer, cl_mem mem, Pointer clMemPointer) {
-            super(byteBuffer, hostMemoryPointer, mem, clMemPointer);
-        }
-
-        /**
-         * Allocates a new source buffer of {@code sizeInBytes} bytes.
-         *
-         * @param context     the OpenCL context
-         * @param sizeInBytes the buffer size in bytes
-         * @return the created {@link SourceArgument}
-         */
-        public static SourceArgument create(cl_context context, long sizeInBytes) {
-            final ByteBuffer byteBuffer =
-                    ByteBuffer.allocateDirect(ByteBufferUtility.ensureByteBufferCapacityFitsInt(sizeInBytes));
-            final Pointer hostMemoryPointer = Pointer.to(byteBuffer);
-            final cl_mem mem = clCreateBuffer(
-                    context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR, sizeInBytes, hostMemoryPointer, null);
-            final Pointer clMemPointer = Pointer.to(mem);
-            return new SourceArgument(byteBuffer, hostMemoryPointer, mem, clMemPointer);
-        }
-    }
-
-    /**
      * Creates a new OpenCL task. Only usable after the surrounding {@link OpenCLContext} has been initialised.
      *
+     * @param clApi             the OpenCL API to work through
      * @param context           the OpenCL context
      * @param cProducer         the OpenCL producer configuration
      * @param bitHelper         bit/batch-size helper
      * @param byteBufferUtility byte-buffer helper used for endian conversion
      */
     public OpenClTask(
-            cl_context context, CProducerOpenCL cProducer, BitHelper bitHelper, ByteBufferUtility byteBufferUtility) {
+            ClApi clApi,
+            ClContext context,
+            CProducerOpenCL cProducer,
+            BitHelper bitHelper,
+            ByteBufferUtility byteBufferUtility) {
+        this.clApi = clApi;
         this.cProducer = cProducer;
         this.bitHelper = bitHelper;
         this.byteBufferUtility = byteBufferUtility;
         this.privateKeyValidator = new PrivateKeyValidator();
         this.maxPrivateKeyForBatchSize = privateKeyValidator.getMaxPrivateKeyForBatchSize(cProducer.batchSizeInBits);
-        this.privateKeySourceArgument = SourceArgument.create(context, PRIVATE_KEY_SOURCE_SIZE_IN_BYTES);
+        this.privateKeySourceArgument = SourceArgument.create(clApi, context, PRIVATE_KEY_SOURCE_SIZE_IN_BYTES);
         // Allocate the reusable GPU output buffer once at the fixed per-batch size (constant for this
         // task's lifetime). Reused by every executeKernel() launch; released in close(). Uses the
         // static size helper to avoid a this-escape (no overridable instance call in the constructor).
-        this.dstMem = clCreateBuffer(context, CL_MEM_WRITE_ONLY, dstSizeInBytes(cProducer), null, null);
-        this.dstMemPointer = Pointer.to(dstMem);
+        this.dstMem = clApi.createBuffer(context, ClBufferFlags.WRITE_ONLY, dstSizeInBytes(cProducer));
     }
 
     /**
@@ -268,8 +231,8 @@ public class OpenClTask implements ReleaseCLObject {
 
     /**
      * Checks out a host-side readback buffer: reuses one from the pool, or allocates a fresh
-     * full-size direct buffer if the pool is empty. The returned buffer has position 0 so
-     * {@code Pointer.to(...)} reads from the start.
+     * full-size direct buffer if the pool is empty. The returned buffer has position 0 so the
+     * transfer reads from the start.
      *
      * @return a host readback buffer of {@link #getDstSizeInBytes()} bytes
      */
@@ -348,7 +311,7 @@ public class OpenClTask implements ReleaseCLObject {
     /**
      * Runs the OpenCL kernel for the configured batch and returns the result buffer.
      *
-     * <p>Binds the two GPU Binary Fuse 8 filter buffers and the {@code transfer_all} mode flag
+     * <p>Binds the two GPU Binary Fuse filter buffers and the {@code transfer_all} mode flag
      * as kernel arguments, zero-initialises the output buffer's leading count word (so compact
      * mode's {@code atomic_add} starts from zero), runs the kernel, then reads back only the
      * bytes the kernel actually produced: in full-transfer mode the whole grid
@@ -371,18 +334,17 @@ public class OpenClTask implements ReleaseCLObject {
      * @return the destination buffer containing kernel results
      */
     public ByteBuffer executeKernel(
-            cl_kernel kernel,
-            cl_command_queue commandQueue,
-            cl_mem fuse8FpMem,
-            cl_mem fuse8MetaMem,
+            ClKernel kernel,
+            ClCommandQueue commandQueue,
+            ClMem fuse8FpMem,
+            ClMem fuse8MetaMem,
             int transferAll,
             int filterType,
-            cl_mem iGTableMem,
-            cl_mem combTableMem) {
+            ClMem iGTableMem,
+            ClMem combTableMem) {
         // Host-side readback buffer for this launch. Checked out from the pool (reused, see field
         // doc) or freshly allocated if the pool is empty; returned by OpenCLGridResult.close().
         final ByteBuffer dstByteBuffer = acquireHostBuffer();
-        final Pointer dstByteBufferPointer = Pointer.to(dstByteBuffer);
 
         // Set the work-item dimensions
         final long totalResultCount = bitHelper.convertBitsToSize(cProducer.batchSizeInBits);
@@ -405,73 +367,43 @@ public class OpenClTask implements ReleaseCLObject {
                     + " (cProducer.batchSizeInBits=" + cProducer.batchSizeInBits + ")");
         }
 
-        final long[] global_work_size = new long[] {adjustedWorkSize};
-        final long[] localWorkSize = null; // new long[]{1}; // enabling the system to choose the work-group size.
-        final int workDim = 1;
+        final long[] globalWorkSize = new long[] {adjustedWorkSize};
 
         // Set the arguments for the kernel
-        clSetKernelArg(kernel, 0, Sizeof.cl_mem, dstMemPointer);
-        clSetKernelArg(kernel, 1, Sizeof.cl_mem, privateKeySourceArgument.getClMemPointer());
-        clSetKernelArg(kernel, 2, Sizeof.cl_uint, Pointer.to(new int[] {keysPerWorkItem}));
-        clSetKernelArg(kernel, 3, Sizeof.cl_mem, Pointer.to(fuse8FpMem));
-        clSetKernelArg(kernel, 4, Sizeof.cl_mem, Pointer.to(fuse8MetaMem));
-        clSetKernelArg(kernel, 5, Sizeof.cl_uint, Pointer.to(new int[] {transferAll}));
-        // filter_type sits directly behind transfer_all in the kernel signature; the table buffers
-        // that follow it therefore occupy indices 7 and 8, not 6 and 7.
-        clSetKernelArg(kernel, 6, Sizeof.cl_uint, Pointer.to(new int[] {filterType}));
-        clSetKernelArg(kernel, 7, Sizeof.cl_mem, Pointer.to(iGTableMem));
-        clSetKernelArg(kernel, 8, Sizeof.cl_mem, Pointer.to(combTableMem));
+        clApi.setKernelArg(kernel, ARG_DESTINATION, dstMem);
+        clApi.setKernelArg(kernel, ARG_PRIVATE_KEY_SOURCE, privateKeySourceArgument.getMem());
+        clApi.setKernelArgInt(kernel, ARG_KEYS_PER_WORK_ITEM, keysPerWorkItem);
+        clApi.setKernelArg(kernel, ARG_FILTER_FINGERPRINTS, fuse8FpMem);
+        clApi.setKernelArg(kernel, ARG_FILTER_METADATA, fuse8MetaMem);
+        clApi.setKernelArgInt(kernel, ARG_TRANSFER_ALL, transferAll);
+        clApi.setKernelArgInt(kernel, ARG_FILTER_TYPE, filterType);
+        clApi.setKernelArg(kernel, ARG_IG_TABLE, iGTableMem);
+        clApi.setKernelArg(kernel, ARG_COMB_TABLE, combTableMem);
 
         {
-            // write src buffer
-            clEnqueueWriteBuffer(
-                    commandQueue,
-                    privateKeySourceArgument.getMem(),
-                    CL_TRUE,
-                    0,
-                    PRIVATE_KEY_SOURCE_SIZE_IN_BYTES,
-                    privateKeySourceArgument.getHostMemoryPointer(),
-                    0,
-                    null,
-                    null);
-            clFinish(commandQueue);
+            // write src buffer. The transfer length is the buffer's remaining bytes, so the window
+            // is set explicitly rather than relying on whatever position the last writer left.
+            final ByteBuffer source = privateKeySourceArgument.getByteBuffer();
+            source.position(0).limit(PRIVATE_KEY_SOURCE_SIZE_IN_BYTES);
+            clApi.enqueueWriteBuffer(commandQueue, privateKeySourceArgument.getMem(), 0L, source);
+            clApi.finish(commandQueue);
         }
         {
             // zero-initialise the leading count word so compact mode's atomic_add starts at
             // 0 (full mode's work-item 0 overwrites it with the sentinel). Also resets any stale
             // count left in the reused dstMem from the previous launch.
             final ByteBuffer zeroHeader = ByteBuffer.allocateDirect(OpenClKernelConstants.OUTPUT_HEADER_SIZE_BYTES);
-            clEnqueueWriteBuffer(
-                    commandQueue,
-                    dstMem,
-                    CL_TRUE,
-                    0,
-                    OpenClKernelConstants.OUTPUT_HEADER_SIZE_BYTES,
-                    Pointer.to(zeroHeader),
-                    0,
-                    null,
-                    null);
-            clFinish(commandQueue);
+            clApi.enqueueWriteBuffer(commandQueue, dstMem, 0L, zeroHeader);
+            clApi.finish(commandQueue);
         }
         final boolean profiling = cProducer.enableProfiling;
         {
             // execute the kernel
             final long beforeExecute = System.currentTimeMillis();
-            if (profiling) {
-                // Profiling path: timestamp the kernel on the device. The event is a non-null
-                // local kept within this branch so NullAway sees no nullable JOCL argument.
-                final cl_event kernelEvent = new cl_event();
-                clEnqueueNDRangeKernel(
-                        commandQueue, kernel, workDim, null, global_work_size, localWorkSize, 0, null, kernelEvent);
-                clFinish(commandQueue);
-                lastKernelExecutionNanos = deviceElapsedNanos(kernelEvent);
-                clReleaseEvent(kernelEvent);
-            } else {
-                clEnqueueNDRangeKernel(
-                        commandQueue, kernel, workDim, null, global_work_size, localWorkSize, 0, null, null);
-                clFinish(commandQueue);
-                lastKernelExecutionNanos = PROFILING_NOT_AVAILABLE;
-            }
+            final @Nullable ClEvent kernelEvent =
+                    clApi.enqueueNDRangeKernel(commandQueue, kernel, globalWorkSize, profiling);
+            clApi.finish(commandQueue);
+            lastKernelExecutionNanos = consumeElapsedNanos(kernelEvent);
 
             final long afterExecute = System.currentTimeMillis();
 
@@ -484,17 +416,8 @@ public class OpenClTask implements ReleaseCLObject {
             // full mode -> overallWorkSize entries; compact mode -> K hit entries.
             final ByteBuffer countHeader = ByteBuffer.allocateDirect(OpenClKernelConstants.OUTPUT_HEADER_SIZE_BYTES)
                     .order(OpenClKernelConstants.GPU_NATIVE_WORD_ORDER);
-            clEnqueueReadBuffer(
-                    commandQueue,
-                    dstMem,
-                    CL_TRUE,
-                    0,
-                    OpenClKernelConstants.OUTPUT_HEADER_SIZE_BYTES,
-                    Pointer.to(countHeader),
-                    0,
-                    null,
-                    null);
-            clFinish(commandQueue);
+            clApi.enqueueReadBuffer(commandQueue, dstMem, 0L, countHeader, false);
+            clApi.finish(commandQueue);
 
             final int count = countHeader.getInt(0);
             final long entriesToRead;
@@ -517,18 +440,14 @@ public class OpenClTask implements ReleaseCLObject {
                     + entriesToRead * OpenClKernelConstants.OUTPUT_ENTRY_SIZE_BYTES;
 
             final long beforeRead = System.currentTimeMillis();
-            if (profiling) {
-                final cl_event readEvent = new cl_event();
-                clEnqueueReadBuffer(
-                        commandQueue, dstMem, CL_TRUE, 0, bytesToRead, dstByteBufferPointer, 0, null, readEvent);
-                clFinish(commandQueue);
-                lastResultReadbackNanos = deviceElapsedNanos(readEvent);
-                clReleaseEvent(readEvent);
-            } else {
-                clEnqueueReadBuffer(commandQueue, dstMem, CL_TRUE, 0, bytesToRead, dstByteBufferPointer, 0, null, null);
-                clFinish(commandQueue);
-                lastResultReadbackNanos = PROFILING_NOT_AVAILABLE;
-            }
+            // The read length is the destination's remaining bytes, so the window is narrowed to
+            // exactly the produced range — this is where compact mode's bandwidth saving happens.
+            dstByteBuffer.position(0).limit(ByteBufferUtility.ensureByteBufferCapacityFitsInt(bytesToRead));
+            final @Nullable ClEvent readEvent =
+                    clApi.enqueueReadBuffer(commandQueue, dstMem, 0L, dstByteBuffer, profiling);
+            clApi.finish(commandQueue);
+            lastResultReadbackNanos = consumeElapsedNanos(readEvent);
+            dstByteBuffer.position(0);
 
             final long afterRead = System.currentTimeMillis();
 
@@ -541,17 +460,20 @@ public class OpenClTask implements ReleaseCLObject {
     }
 
     /**
-     * Reads the device-side {@code END - START} duration of a profiled command.
+     * Reads and releases a profiling event, if one was captured.
      *
-     * @param event a completed event from a profiling-enabled queue
-     * @return the on-device execution time of the command, in nanoseconds
+     * @param event the event captured for the command, or {@code null} when profiling is off
+     * @return the on-device duration in nanoseconds, or {@link #PROFILING_NOT_AVAILABLE}
      */
-    private static long deviceElapsedNanos(cl_event event) {
-        final long[] start = new long[1];
-        final long[] end = new long[1];
-        clGetEventProfilingInfo(event, CL_PROFILING_COMMAND_START, Sizeof.cl_ulong, Pointer.to(start), null);
-        clGetEventProfilingInfo(event, CL_PROFILING_COMMAND_END, Sizeof.cl_ulong, Pointer.to(end), null);
-        return end[0] - start[0];
+    private long consumeElapsedNanos(@Nullable ClEvent event) {
+        if (event == null) {
+            return PROFILING_NOT_AVAILABLE;
+        }
+        try {
+            return clApi.getEventElapsedNanos(event);
+        } finally {
+            clApi.releaseEvent(event);
+        }
     }
 
     /**
@@ -593,32 +515,8 @@ public class OpenClTask implements ReleaseCLObject {
             // Release the reusable GPU output buffer. Safe here: close() runs only after the
             // producer has stopped issuing launches; the asynchronous result readers never touch
             // dstMem (they read the host-side ByteBuffer copies), so there is no use-after-free.
-            clReleaseMemObject(dstMem);
+            clApi.releaseMemObject(dstMem);
             closed = true;
         }
-    }
-
-    /**
-     * https://stackoverflow.com/questions/3366925/deep-copy-duplicate-of-javas-bytebuffer/4074089
-     */
-    // Preserved as a reusable helper for potential future safe native↔JVM-heap handoff
-    // in the OpenCL pipeline. No current production or test caller; UnusedMethod
-    // suppressed to keep -Werror clean.
-    @SuppressWarnings("UnusedMethod")
-    private static ByteBuffer cloneByteBuffer(final ByteBuffer original) {
-        // Create clone with same capacity as original.
-        final ByteBuffer clone = original.isDirect()
-                ? ByteBuffer.allocateDirect(original.capacity())
-                : ByteBuffer.allocate(original.capacity());
-
-        // Create a read-only copy of the original.
-        // This allows reading from the original without modifying it.
-        final ByteBuffer readOnlyCopy = original.asReadOnlyBuffer();
-
-        // Flip and read from the original.
-        readOnlyCopy.flip();
-        clone.put(readOnlyCopy);
-
-        return clone;
     }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/ReleaseCLObject.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/ReleaseCLObject.java
@@ -7,7 +7,7 @@ package net.ladenthin.bitcoinaddressfinder.opencl;
  * Represents an OpenCL-related object that holds a native resource and must be explicitly released.
  * <p>
  * Extends {@link AutoCloseable} to support usage with Java's {@code try-with-resources} construct.
- * This interface is intended for resources such as {@link org.jocl.cl_mem}, {@link org.jocl.cl_kernel}, etc.
+ * This interface is intended for wrappers around OpenCL objects such as device buffers and kernels,
  * which require manual cleanup via OpenCL's native API.
  * </p>
  *

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClApi.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClApi.java
@@ -1,0 +1,381 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Instance-based view of the OpenCL API.
+ *
+ * <p>The binding library exposes OpenCL exclusively through static methods, which cannot be
+ * substituted in a test: any class calling them directly can only be exercised on a machine with a
+ * working driver. Routing those calls through this interface is what allows the layers above to be
+ * tested with mocks and spies, and it keeps the choice of binding library confined to a single
+ * implementation class.
+ *
+ * <p>Methods here report failures as {@link OpenClCallFailedException} rather than returning error
+ * codes; the raw {@code cl_int} contract does not leak past this seam.
+ */
+public interface ClApi {
+
+    // ---------------------------------------------------------------------------------------
+    // Discovery
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Returns every OpenCL platform installed on the machine.
+     *
+     * @return the platform handles, empty if the ICD loader reports no installed platform
+     */
+    List<ClPlatformId> getPlatformIds();
+
+    /**
+     * Reads a string-valued platform property.
+     *
+     * @param platform  the platform to query
+     * @param paramName the {@code cl_platform_info} parameter, e.g. {@code CL_PLATFORM_NAME}
+     * @return the property value without its C string terminator
+     */
+    String getPlatformInfoString(ClPlatformId platform, int paramName);
+
+    /**
+     * Returns the devices of a platform that match the given device type.
+     *
+     * @param platform   the platform to enumerate
+     * @param deviceType the {@code cl_device_type} bit mask, e.g. {@code CL_DEVICE_TYPE_ALL}
+     * @return the matching device handles, empty if the platform exposes none
+     */
+    List<ClDeviceId> getDeviceIds(ClPlatformId platform, long deviceType);
+
+    /**
+     * Reads a string-valued device property.
+     *
+     * @param device    the device to query
+     * @param paramName the {@code cl_device_info} parameter, e.g. {@code CL_DEVICE_NAME}
+     * @return the property value without its C string terminator
+     */
+    String getDeviceInfoString(ClDeviceId device, int paramName);
+
+    /**
+     * Reads a 32-bit integer device property.
+     *
+     * @param device    the device to query
+     * @param paramName the {@code cl_device_info} parameter
+     * @return the property value
+     */
+    int getDeviceInfoInt(ClDeviceId device, int paramName);
+
+    /**
+     * Reads a 64-bit integer device property.
+     *
+     * @param device    the device to query
+     * @param paramName the {@code cl_device_info} parameter
+     * @return the property value
+     */
+    long getDeviceInfoLong(ClDeviceId device, int paramName);
+
+    /**
+     * Reads a device property consisting of one or more {@code size_t} values.
+     *
+     * @param device     the device to query
+     * @param paramName  the {@code cl_device_info} parameter
+     * @param valueCount the number of {@code size_t} values the property carries
+     * @return the property values, widened to {@code long}
+     */
+    long[] getDeviceInfoSizes(ClDeviceId device, int paramName, int valueCount);
+
+    /**
+     * Reads a device property as raw bytes, for properties whose layout is a vendor- or
+     * extension-defined struct.
+     *
+     * <p>Returns an empty array when the driver rejects the query, so an unsupported extension and a
+     * driver error are the same outcome for the caller. Extension-defined identity properties are
+     * best-effort by nature: callers treat "no answer" as "unknown", never as a failure.
+     *
+     * @param device    the device to query
+     * @param paramName the {@code cl_device_info} parameter
+     * @param byteCount the expected payload size in bytes
+     * @return the payload, or an empty array when the query was rejected
+     */
+    byte[] getDeviceInfoBytesOrEmpty(ClDeviceId device, int paramName, int byteCount);
+
+    // ---------------------------------------------------------------------------------------
+    // Context and command queue
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Creates a context bound to one device of one platform.
+     *
+     * @param platform the platform the device belongs to
+     * @param device   the device the context is created for
+     * @return the created context
+     */
+    ClContext createContext(ClPlatformId platform, ClDeviceId device);
+
+    /**
+     * Creates a command queue for a device.
+     *
+     * @param context          the owning context
+     * @param device           the target device
+     * @param enableProfiling  whether the queue timestamps its commands, which callers need to read
+     *                         device-side durations but which costs throughput
+     * @return the created command queue
+     */
+    ClCommandQueue createCommandQueue(ClContext context, ClDeviceId device, boolean enableProfiling);
+
+    /**
+     * Blocks until every command previously enqueued on the queue has completed.
+     *
+     * @param commandQueue the queue to drain
+     */
+    void finish(ClCommandQueue commandQueue);
+
+    // ---------------------------------------------------------------------------------------
+    // Program and kernel
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Creates a program from OpenCL C sources.
+     *
+     * @param context the owning context
+     * @param sources the source strings, concatenated by the runtime in the given order
+     * @return the created program
+     */
+    ClProgram createProgramWithSource(ClContext context, String[] sources);
+
+    /**
+     * Compiles and links a program for one device.
+     *
+     * @param program the program to build
+     * @param device  the target device
+     * @param options the {@code clBuildProgram} option string
+     */
+    void buildProgram(ClProgram program, ClDeviceId device, String options);
+
+    /**
+     * Returns the build log a device produced for a program.
+     *
+     * @param program the built program
+     * @param device  the device it was built for
+     * @return the build log, possibly empty
+     */
+    String getProgramBuildLog(ClProgram program, ClDeviceId device);
+
+    /**
+     * Creates a kernel from a built program.
+     *
+     * @param program    the built program
+     * @param kernelName the entry-point name
+     * @return the created kernel
+     */
+    ClKernel createKernel(ClProgram program, String kernelName);
+
+    /**
+     * Reads a {@code size_t}-typed kernel work-group property.
+     *
+     * <p>Separate from {@link #getKernelWorkGroupInfoUlong} because the two differ in width on a
+     * 32-bit host, where querying a {@code size_t} property into a 64-bit slot is rejected outright.
+     *
+     * @param kernel    the kernel to query
+     * @param device    the device the kernel was built for
+     * @param paramName the {@code cl_kernel_work_group_info} parameter, e.g. {@code CL_KERNEL_WORK_GROUP_SIZE}
+     * @return the property value
+     */
+    long getKernelWorkGroupInfoSize(ClKernel kernel, ClDeviceId device, int paramName);
+
+    /**
+     * Reads a {@code cl_ulong}-typed kernel work-group property.
+     *
+     * @param kernel    the kernel to query
+     * @param device    the device the kernel was built for
+     * @param paramName the {@code cl_kernel_work_group_info} parameter, e.g. {@code CL_KERNEL_PRIVATE_MEM_SIZE}
+     * @return the property value
+     */
+    long getKernelWorkGroupInfoUlong(ClKernel kernel, ClDeviceId device, int paramName);
+
+    /**
+     * Binds a memory object as a kernel argument.
+     *
+     * @param kernel   the kernel
+     * @param argIndex the zero-based argument position
+     * @param value    the memory object to bind
+     */
+    void setKernelArg(ClKernel kernel, int argIndex, ClMem value);
+
+    /**
+     * Binds a 32-bit integer as a kernel argument.
+     *
+     * @param kernel   the kernel
+     * @param argIndex the zero-based argument position
+     * @param value    the value to bind
+     */
+    void setKernelArgInt(ClKernel kernel, int argIndex, int value);
+
+    /**
+     * Enqueues a kernel launch.
+     *
+     * @param commandQueue   the queue to submit to
+     * @param kernel         the kernel to launch
+     * @param globalWorkSize the number of work items per dimension
+     * @param profilingEvent whether to capture a profiling event for the launch
+     * @return the profiling event when requested, otherwise {@code null}
+     */
+    @Nullable
+    ClEvent enqueueNDRangeKernel(
+            ClCommandQueue commandQueue, ClKernel kernel, long[] globalWorkSize, boolean profilingEvent);
+
+    // ---------------------------------------------------------------------------------------
+    // Buffers
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Allocates an uninitialised device buffer.
+     *
+     * @param context   the owning context
+     * @param flags     the {@code cl_mem_flags}, see {@link ClBufferFlags}
+     * @param sizeBytes the buffer size in bytes
+     * @return the created memory object
+     */
+    ClMem createBuffer(ClContext context, long flags, long sizeBytes);
+
+    /**
+     * Allocates a device buffer backed by caller-owned host memory.
+     *
+     * @param context    the owning context
+     * @param flags      the {@code cl_mem_flags}, which must include {@link ClBufferFlags#USE_HOST_PTR}
+     * @param hostBuffer a direct buffer that must outlive the memory object
+     * @return the created memory object
+     */
+    ClMem createBufferFromHostMemory(ClContext context, long flags, ByteBuffer hostBuffer);
+
+    /**
+     * Copies host data into a device buffer in bounded slices.
+     *
+     * <p>This exists instead of a {@code CL_MEM_COPY_HOST_PTR} allocation because the binding cannot
+     * hand a Java array to the driver: every transfer must originate from a direct buffer. Staging a
+     * whole payload would therefore need an off-heap copy as large as the payload itself, and the
+     * fingerprint filters this project uploads reach multiple gigabytes — the Full-DB 16-bit filter
+     * exceeds what a Java {@code byte[]} can even represent. Writing in slices through a small,
+     * reusable staging buffer keeps the extra footprint constant regardless of payload size.
+     *
+     * @param commandQueue the queue to submit the writes to
+     * @param mem          the destination device buffer
+     * @param source       the host payload
+     */
+    void writeBufferChunked(ClCommandQueue commandQueue, ClMem mem, byte[] source);
+
+    /**
+     * Copies host data into a device buffer in bounded slices.
+     *
+     * @param commandQueue the queue to submit the writes to
+     * @param mem          the destination device buffer
+     * @param source       the host payload, written in the host's native byte order
+     * @see #writeBufferChunked(ClCommandQueue, ClMem, byte[])
+     */
+    void writeBufferChunked(ClCommandQueue commandQueue, ClMem mem, short[] source);
+
+    /**
+     * Copies host data into a device buffer in bounded slices.
+     *
+     * @param commandQueue the queue to submit the writes to
+     * @param mem          the destination device buffer
+     * @param source       the host payload, written in the host's native byte order
+     * @see #writeBufferChunked(ClCommandQueue, ClMem, byte[])
+     */
+    void writeBufferChunked(ClCommandQueue commandQueue, ClMem mem, int[] source);
+
+    /**
+     * Copies host data into a device buffer in bounded slices.
+     *
+     * @param commandQueue the queue to submit the writes to
+     * @param mem          the destination device buffer
+     * @param source       the host payload, written in the host's native byte order
+     * @see #writeBufferChunked(ClCommandQueue, ClMem, byte[])
+     */
+    void writeBufferChunked(ClCommandQueue commandQueue, ClMem mem, long[] source);
+
+    /**
+     * Enqueues a blocking write from a direct host buffer into a device buffer.
+     *
+     * @param commandQueue the queue to submit to
+     * @param mem          the destination device buffer
+     * @param deviceOffset the byte offset into the device buffer
+     * @param source       the direct host buffer; its remaining bytes are written
+     */
+    void enqueueWriteBuffer(ClCommandQueue commandQueue, ClMem mem, long deviceOffset, ByteBuffer source);
+
+    /**
+     * Enqueues a blocking read from a device buffer into a direct host buffer.
+     *
+     * @param commandQueue   the queue to submit to
+     * @param mem            the source device buffer
+     * @param deviceOffset   the byte offset into the device buffer
+     * @param destination    the direct host buffer; its remaining bytes are filled
+     * @param profilingEvent whether to capture a profiling event for the transfer
+     * @return the profiling event when requested, otherwise {@code null}
+     */
+    @Nullable
+    ClEvent enqueueReadBuffer(
+            ClCommandQueue commandQueue, ClMem mem, long deviceOffset, ByteBuffer destination, boolean profilingEvent);
+
+    // ---------------------------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Returns the device-side duration of a completed command.
+     *
+     * @param event a completed event from a profiling-enabled queue
+     * @return the on-device execution time in nanoseconds
+     */
+    long getEventElapsedNanos(ClEvent event);
+
+    // ---------------------------------------------------------------------------------------
+    // Release
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Releases a memory object.
+     *
+     * @param mem the memory object to release
+     */
+    void releaseMemObject(ClMem mem);
+
+    /**
+     * Releases a kernel.
+     *
+     * @param kernel the kernel to release
+     */
+    void releaseKernel(ClKernel kernel);
+
+    /**
+     * Releases a program.
+     *
+     * @param program the program to release
+     */
+    void releaseProgram(ClProgram program);
+
+    /**
+     * Releases a command queue.
+     *
+     * @param commandQueue the queue to release
+     */
+    void releaseCommandQueue(ClCommandQueue commandQueue);
+
+    /**
+     * Releases a context.
+     *
+     * @param context the context to release
+     */
+    void releaseContext(ClContext context);
+
+    /**
+     * Releases an event.
+     *
+     * @param event the event to release
+     */
+    void releaseEvent(ClEvent event);
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClBufferFlags.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClBufferFlags.java
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import org.lwjgl.opencl.CL10;
+
+/**
+ * The {@code cl_mem_flags} values this project uses when creating device buffers.
+ *
+ * <p>Collected here so the layers above the binding can express intent — read-only input, write-only
+ * output, host-backed — without importing the binding library's constants, which is what keeps the
+ * {@code org.lwjgl} dependency confined to this package.
+ *
+ * <p>{@code CL_MEM_COPY_HOST_PTR} is deliberately absent. Every host-to-device transfer in this
+ * project goes through an explicit chunked write instead; see
+ * {@link ClApi#writeBufferChunked} for why.
+ */
+public final class ClBufferFlags {
+
+    /** Device buffer the kernel only reads. */
+    public static final long READ_ONLY = CL10.CL_MEM_READ_ONLY;
+
+    /** Device buffer the kernel only writes. */
+    public static final long WRITE_ONLY = CL10.CL_MEM_WRITE_ONLY;
+
+    /** Device buffer the kernel both reads and writes. */
+    public static final long READ_WRITE = CL10.CL_MEM_READ_WRITE;
+
+    /** Device buffer backed by a caller-owned host allocation that must stay alive and pinned. */
+    public static final long USE_HOST_PTR = CL10.CL_MEM_USE_HOST_PTR;
+
+    private ClBufferFlags() {
+        // constant holder
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClCommandQueue.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClCommandQueue.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * Handle to an OpenCL command queue, through which work is submitted to one device.
+ *
+ * <p>Corresponds to the OpenCL C type {@code cl_command_queue}.
+ *
+ * @param handle the native handle value
+ */
+@Immutable
+public record ClCommandQueue(long handle) implements ClHandle {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClContext.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * Handle to an OpenCL context, the scope that owns queues, buffers and programs.
+ *
+ * <p>Corresponds to the OpenCL C type {@code cl_context}.
+ *
+ * @param handle the native handle value
+ */
+@Immutable
+public record ClContext(long handle) implements ClHandle {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClDeviceId.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClDeviceId.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * Handle to an OpenCL device belonging to a platform.
+ *
+ * <p>Corresponds to the OpenCL C type {@code cl_device_id}.
+ *
+ * @param handle the native handle value
+ */
+@Immutable
+public record ClDeviceId(long handle) implements ClHandle {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClDeviceInfoFormatter.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClDeviceInfoFormatter.java
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import lombok.ToString;
+import org.lwjgl.opencl.CL10;
+import org.lwjgl.opencl.CL11;
+import org.lwjgl.opencl.CL12;
+import org.lwjgl.opencl.CL20;
+
+/**
+ * Renders OpenCL device-info bit fields as their symbolic names.
+ *
+ * <p>Replaces the {@code CL.stringFor_*} convenience methods that the previous binding provided and
+ * LWJGL does not. The output format is deliberately identical to the old one: device reports are
+ * user-facing, and {@code OpenCLDevice.toStringPretty()} is asserted line by line against a fixed
+ * sample, so any deviation would be both a visible change and a test failure.
+ *
+ * <p>Set-valued fields render each name in ascending bit order, every name followed by a space. A
+ * field whose value is zero renders as {@code (none)}; a field carrying only unrecognised bits
+ * renders as the empty string. Enumerated fields render as the single matching name.
+ *
+ * <p>An instance class rather than a static utility, per the project convention on helper classes.
+ */
+@ToString
+public class ClDeviceInfoFormatter {
+
+    /**
+     * Appended after every symbolic name of a set-valued bit field — including the last one, so the
+     * rendered value carries a trailing space.
+     *
+     * <p>That trailing space is inherited rather than chosen: the previous binding emitted it, and a
+     * parity sweep against it proved the behaviour. It is invisible in practice because the device
+     * report is compared line by line after {@code stripTrailing()}, which is exactly why the quirk
+     * survived unnoticed. Reproduced here so the two implementations agree byte for byte; dropping it
+     * is a deliberate cleanup for after the old binding is gone, not a silent change now.
+     */
+    private static final char NAME_TERMINATOR = ' ';
+
+    /**
+     * Rendered value of a bit field whose bits are all unknown or unset. Not the empty string: the
+     * previous binding printed this literal, and device reports are compared against fixed samples.
+     */
+    private static final String NO_FLAGS = "(none)";
+
+    /**
+     * {@code cl_device_type} bits in ascending order, paired with their names. The order is part of
+     * the rendered output, so it is fixed here rather than derived from a map.
+     */
+    private static final long[] DEVICE_TYPE_BITS = {
+        CL10.CL_DEVICE_TYPE_DEFAULT,
+        CL10.CL_DEVICE_TYPE_CPU,
+        CL10.CL_DEVICE_TYPE_GPU,
+        CL10.CL_DEVICE_TYPE_ACCELERATOR,
+        CL12.CL_DEVICE_TYPE_CUSTOM
+    };
+
+    /** Names matching {@link #DEVICE_TYPE_BITS}, index by index. */
+    private static final String[] DEVICE_TYPE_NAMES = {
+        "CL_DEVICE_TYPE_DEFAULT",
+        "CL_DEVICE_TYPE_CPU",
+        "CL_DEVICE_TYPE_GPU",
+        "CL_DEVICE_TYPE_ACCELERATOR",
+        "CL_DEVICE_TYPE_CUSTOM"
+    };
+
+    /**
+     * {@code cl_command_queue_properties} bits in ascending order. The two OpenCL 2.0 device-queue
+     * bits belong here as well; leaving them out made a device that reports them render as if it had
+     * no queue properties at all.
+     */
+    private static final long[] QUEUE_PROPERTY_BITS = {
+        CL10.CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
+        CL10.CL_QUEUE_PROFILING_ENABLE,
+        CL20.CL_QUEUE_ON_DEVICE,
+        CL20.CL_QUEUE_ON_DEVICE_DEFAULT
+    };
+
+    /** Names matching {@link #QUEUE_PROPERTY_BITS}, index by index. */
+    private static final String[] QUEUE_PROPERTY_NAMES = {
+        "CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE",
+        "CL_QUEUE_PROFILING_ENABLE",
+        "CL_QUEUE_ON_DEVICE",
+        "CL_QUEUE_ON_DEVICE_DEFAULT"
+    };
+
+    /** {@code cl_device_fp_config} bits in ascending order. */
+    private static final long[] FP_CONFIG_BITS = {
+        CL10.CL_FP_DENORM,
+        CL10.CL_FP_INF_NAN,
+        CL10.CL_FP_ROUND_TO_NEAREST,
+        CL10.CL_FP_ROUND_TO_ZERO,
+        CL10.CL_FP_ROUND_TO_INF,
+        CL10.CL_FP_FMA,
+        CL11.CL_FP_SOFT_FLOAT,
+        CL12.CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT
+    };
+
+    /** Names matching {@link #FP_CONFIG_BITS}, index by index. */
+    private static final String[] FP_CONFIG_NAMES = {
+        "CL_FP_DENORM",
+        "CL_FP_INF_NAN",
+        "CL_FP_ROUND_TO_NEAREST",
+        "CL_FP_ROUND_TO_ZERO",
+        "CL_FP_ROUND_TO_INF",
+        "CL_FP_FMA",
+        "CL_FP_SOFT_FLOAT",
+        "CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT"
+    };
+
+    /** Creates a new {@link ClDeviceInfoFormatter}. */
+    public ClDeviceInfoFormatter() {}
+
+    /**
+     * Renders a {@code cl_device_type} bit field.
+     *
+     * @param deviceType the device-type bits
+     * @return the symbolic names joined by a space, empty if no known bit is set
+     */
+    public String formatDeviceType(long deviceType) {
+        return formatBitField(deviceType, DEVICE_TYPE_BITS, DEVICE_TYPE_NAMES);
+    }
+
+    /**
+     * Renders a {@code cl_device_local_mem_type} enumeration value.
+     *
+     * <p>Only {@code CL_LOCAL} and {@code CL_GLOBAL} are valid here. {@code CL_NONE} shares the value
+     * {@code 0} but belongs to other enumerations, so it is reported as invalid rather than accepted
+     * — matching the previous binding, whose behaviour a parity sweep confirmed.
+     *
+     * @param localMemType the local-memory type
+     * @return {@code CL_LOCAL}, {@code CL_GLOBAL}, or an "INVALID" description for anything else
+     */
+    public String formatLocalMemType(int localMemType) {
+        if (localMemType == CL10.CL_LOCAL) {
+            return "CL_LOCAL";
+        }
+        if (localMemType == CL10.CL_GLOBAL) {
+            return "CL_GLOBAL";
+        }
+        return "INVALID cl_device_local_mem_type: " + localMemType;
+    }
+
+    /**
+     * Renders a {@code cl_command_queue_properties} bit field.
+     *
+     * @param queueProperties the queue-property bits
+     * @return the symbolic names joined by a space, empty if no known bit is set
+     */
+    public String formatCommandQueueProperties(long queueProperties) {
+        return formatBitField(queueProperties, QUEUE_PROPERTY_BITS, QUEUE_PROPERTY_NAMES);
+    }
+
+    /**
+     * Renders a {@code cl_device_fp_config} bit field.
+     *
+     * @param fpConfig the floating-point configuration bits
+     * @return the symbolic names joined by a space, empty if no known bit is set
+     */
+    public String formatDeviceFpConfig(long fpConfig) {
+        return formatBitField(fpConfig, FP_CONFIG_BITS, FP_CONFIG_NAMES);
+    }
+
+    /**
+     * Renders a bit field by collecting the names of every set bit, in the order given.
+     *
+     * @param value the bit field to render
+     * @param bits  the recognised bits, in the order they should appear
+     * @param names the names matching {@code bits}, index by index
+     * @return the matching names joined by a space, empty if none matched
+     */
+    private String formatBitField(long value, long[] bits, String[] names) {
+        // Only the all-clear field is reported as "(none)". A field carrying nothing but bits this
+        // build does not know renders as the empty string instead - matching the previous binding,
+        // as the parity sweep established. The distinction is worth keeping: "(none)" states that
+        // the device has no such capability, while "" says the value could not be interpreted.
+        if (value == 0L) {
+            return NO_FLAGS;
+        }
+        final StringBuilder present = new StringBuilder();
+        for (int i = 0; i < bits.length; i++) {
+            if ((value & bits[i]) != 0L) {
+                present.append(names[i]).append(NAME_TERMINATOR);
+            }
+        }
+        return present.toString();
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClErrorChecker.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClErrorChecker.java
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import lombok.ToString;
+
+/**
+ * Turns the OpenCL C error-code contract into Java exceptions.
+ *
+ * <p>Every OpenCL entry point reports failure through a returned {@code cl_int} (or, for the
+ * create-style calls, by returning a NULL handle and writing the code into an out-parameter). The
+ * LWJGL binding forwards that contract verbatim and never throws by itself, so a call whose result
+ * is not inspected fails silently and only surfaces later as corrupted state or a confusing
+ * follow-up error. Routing every call through this checker makes that impossible.
+ *
+ * <p>An instance class rather than a static utility, per the project convention on helper classes:
+ * collaborators receive it through the constructor, which keeps the dependency explicit and lets
+ * tests substitute it.
+ */
+@ToString
+public class ClErrorChecker {
+
+    /** The OpenCL NULL handle, returned by create-style entry points when the object was not created. */
+    private static final long NULL_HANDLE = 0L;
+
+    /**
+     * Error code reported for a NULL handle when the failing call did not surface a code of its own.
+     * {@link ClErrorCodeResolver#CL_SUCCESS} would be misleading here, so the generic
+     * {@code CL_INVALID_VALUE} is used to keep {@link OpenClCallFailedException#getErrorCode()}
+     * meaningful in every case.
+     */
+    private static final int NULL_HANDLE_ERROR_CODE = org.lwjgl.opencl.CL10.CL_INVALID_VALUE;
+
+    private final ClErrorCodeResolver errorCodeResolver;
+
+    /**
+     * Creates a new checker.
+     *
+     * @param errorCodeResolver resolves numeric error codes to their symbolic OpenCL names
+     */
+    public ClErrorChecker(ClErrorCodeResolver errorCodeResolver) {
+        this.errorCodeResolver = errorCodeResolver;
+    }
+
+    /**
+     * Verifies that an OpenCL entry point reported success.
+     *
+     * @param errorCode          the {@code cl_int} returned by the entry point
+     * @param openClFunctionName name of the entry point, used to attribute the failure
+     * @throws OpenClCallFailedException if {@code errorCode} does not denote success
+     */
+    public void checkSuccess(int errorCode, String openClFunctionName) {
+        if (errorCodeResolver.isSuccess(errorCode)) {
+            return;
+        }
+        final String message =
+                String.format("OpenCL call %s failed: %s", openClFunctionName, errorCodeResolver.describe(errorCode));
+        throw new OpenClCallFailedException(message, errorCode, openClFunctionName);
+    }
+
+    /**
+     * Verifies that a create-style OpenCL entry point actually produced an object.
+     *
+     * @param handle             the handle returned by the entry point
+     * @param openClFunctionName name of the entry point, used to attribute the failure
+     * @return {@code handle} unchanged, so the call can be used inline
+     * @throws OpenClCallFailedException if {@code handle} is the NULL handle
+     */
+    public long requireCreated(long handle, String openClFunctionName) {
+        if (handle != NULL_HANDLE) {
+            return handle;
+        }
+        final String message = String.format("OpenCL call %s returned a NULL handle", openClFunctionName);
+        throw new OpenClCallFailedException(message, NULL_HANDLE_ERROR_CODE, openClFunctionName);
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClErrorCodeResolver.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClErrorCodeResolver.java
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.ToString;
+import org.lwjgl.opencl.CL10;
+import org.lwjgl.opencl.CL11;
+import org.lwjgl.opencl.CL12;
+
+/**
+ * Translates {@code cl_int} error codes into their symbolic OpenCL names.
+ *
+ * <p>The LWJGL binding exposes the error constants but offers no reverse lookup, so a failed call
+ * would otherwise be reported as a bare negative number. Resolving {@code -30} to
+ * {@code CL_INVALID_VALUE} is the difference between a log line that can be acted upon and one that
+ * has to be looked up in the specification first.
+ *
+ * <p>The numeric values are never spelled out here — every entry references the corresponding LWJGL
+ * constant, so the mapping cannot drift away from the binding it describes.
+ *
+ * <p>An instance class rather than a static utility, per the project convention on helper classes:
+ * collaborators receive it through the constructor and can substitute it in tests.
+ */
+@ToString
+public class ClErrorCodeResolver {
+
+    /** The OpenCL success code. Every entry point returns this when the call succeeded. */
+    public static final int CL_SUCCESS = CL10.CL_SUCCESS;
+
+    /** Number of entries in {@link #ERROR_NAMES_BY_CODE}; used only to presize the map. */
+    private static final int ERROR_NAME_COUNT = 54;
+
+    /**
+     * Symbolic names of every error code defined by OpenCL 1.0 through 1.2, which is the range the
+     * project's kernels and host code are built against ({@code -cl-std=CL1.2}). Codes outside this
+     * range fall back to a numeric-only description.
+     *
+     * <p>Deliberately populated through a static block with explicit {@code put} calls rather than
+     * {@code Map.ofEntries(...)}: the latter forced the Checker Framework into roughly a minute of
+     * generic type inference for this many entries, which it reported as {@code [slow.typechecking]}
+     * and {@code -Werror} then turned into a build failure.
+     */
+    private static final Map<Integer, String> ERROR_NAMES_BY_CODE;
+
+    static {
+        // Presized: the table below is a fixed set, so let it start at its final capacity.
+        final Map<Integer, String> names = new HashMap<>(ERROR_NAME_COUNT * 2);
+        names.put(CL10.CL_SUCCESS, "CL_SUCCESS");
+        names.put(CL10.CL_DEVICE_NOT_FOUND, "CL_DEVICE_NOT_FOUND");
+        names.put(CL10.CL_DEVICE_NOT_AVAILABLE, "CL_DEVICE_NOT_AVAILABLE");
+        names.put(CL10.CL_COMPILER_NOT_AVAILABLE, "CL_COMPILER_NOT_AVAILABLE");
+        names.put(CL10.CL_MEM_OBJECT_ALLOCATION_FAILURE, "CL_MEM_OBJECT_ALLOCATION_FAILURE");
+        names.put(CL10.CL_OUT_OF_RESOURCES, "CL_OUT_OF_RESOURCES");
+        names.put(CL10.CL_OUT_OF_HOST_MEMORY, "CL_OUT_OF_HOST_MEMORY");
+        names.put(CL10.CL_PROFILING_INFO_NOT_AVAILABLE, "CL_PROFILING_INFO_NOT_AVAILABLE");
+        names.put(CL10.CL_MEM_COPY_OVERLAP, "CL_MEM_COPY_OVERLAP");
+        names.put(CL10.CL_IMAGE_FORMAT_MISMATCH, "CL_IMAGE_FORMAT_MISMATCH");
+        names.put(CL10.CL_IMAGE_FORMAT_NOT_SUPPORTED, "CL_IMAGE_FORMAT_NOT_SUPPORTED");
+        names.put(CL10.CL_BUILD_PROGRAM_FAILURE, "CL_BUILD_PROGRAM_FAILURE");
+        names.put(CL10.CL_MAP_FAILURE, "CL_MAP_FAILURE");
+        names.put(CL11.CL_MISALIGNED_SUB_BUFFER_OFFSET, "CL_MISALIGNED_SUB_BUFFER_OFFSET");
+        names.put(CL11.CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST, "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST");
+        names.put(CL12.CL_COMPILE_PROGRAM_FAILURE, "CL_COMPILE_PROGRAM_FAILURE");
+        names.put(CL12.CL_LINKER_NOT_AVAILABLE, "CL_LINKER_NOT_AVAILABLE");
+        names.put(CL12.CL_LINK_PROGRAM_FAILURE, "CL_LINK_PROGRAM_FAILURE");
+        names.put(CL12.CL_DEVICE_PARTITION_FAILED, "CL_DEVICE_PARTITION_FAILED");
+        names.put(CL12.CL_KERNEL_ARG_INFO_NOT_AVAILABLE, "CL_KERNEL_ARG_INFO_NOT_AVAILABLE");
+        names.put(CL10.CL_INVALID_VALUE, "CL_INVALID_VALUE");
+        names.put(CL10.CL_INVALID_DEVICE_TYPE, "CL_INVALID_DEVICE_TYPE");
+        names.put(CL10.CL_INVALID_PLATFORM, "CL_INVALID_PLATFORM");
+        names.put(CL10.CL_INVALID_DEVICE, "CL_INVALID_DEVICE");
+        names.put(CL10.CL_INVALID_CONTEXT, "CL_INVALID_CONTEXT");
+        names.put(CL10.CL_INVALID_QUEUE_PROPERTIES, "CL_INVALID_QUEUE_PROPERTIES");
+        names.put(CL10.CL_INVALID_COMMAND_QUEUE, "CL_INVALID_COMMAND_QUEUE");
+        names.put(CL10.CL_INVALID_HOST_PTR, "CL_INVALID_HOST_PTR");
+        names.put(CL10.CL_INVALID_MEM_OBJECT, "CL_INVALID_MEM_OBJECT");
+        names.put(CL10.CL_INVALID_BINARY, "CL_INVALID_BINARY");
+        names.put(CL10.CL_INVALID_BUILD_OPTIONS, "CL_INVALID_BUILD_OPTIONS");
+        names.put(CL10.CL_INVALID_PROGRAM, "CL_INVALID_PROGRAM");
+        names.put(CL10.CL_INVALID_PROGRAM_EXECUTABLE, "CL_INVALID_PROGRAM_EXECUTABLE");
+        names.put(CL10.CL_INVALID_KERNEL_NAME, "CL_INVALID_KERNEL_NAME");
+        names.put(CL10.CL_INVALID_KERNEL_DEFINITION, "CL_INVALID_KERNEL_DEFINITION");
+        names.put(CL10.CL_INVALID_KERNEL, "CL_INVALID_KERNEL");
+        names.put(CL10.CL_INVALID_ARG_INDEX, "CL_INVALID_ARG_INDEX");
+        names.put(CL10.CL_INVALID_ARG_VALUE, "CL_INVALID_ARG_VALUE");
+        names.put(CL10.CL_INVALID_ARG_SIZE, "CL_INVALID_ARG_SIZE");
+        names.put(CL10.CL_INVALID_KERNEL_ARGS, "CL_INVALID_KERNEL_ARGS");
+        names.put(CL10.CL_INVALID_WORK_DIMENSION, "CL_INVALID_WORK_DIMENSION");
+        names.put(CL10.CL_INVALID_WORK_GROUP_SIZE, "CL_INVALID_WORK_GROUP_SIZE");
+        names.put(CL10.CL_INVALID_WORK_ITEM_SIZE, "CL_INVALID_WORK_ITEM_SIZE");
+        names.put(CL10.CL_INVALID_GLOBAL_OFFSET, "CL_INVALID_GLOBAL_OFFSET");
+        names.put(CL10.CL_INVALID_EVENT_WAIT_LIST, "CL_INVALID_EVENT_WAIT_LIST");
+        names.put(CL10.CL_INVALID_EVENT, "CL_INVALID_EVENT");
+        names.put(CL10.CL_INVALID_OPERATION, "CL_INVALID_OPERATION");
+        names.put(CL10.CL_INVALID_BUFFER_SIZE, "CL_INVALID_BUFFER_SIZE");
+        names.put(CL10.CL_INVALID_GLOBAL_WORK_SIZE, "CL_INVALID_GLOBAL_WORK_SIZE");
+        names.put(CL11.CL_INVALID_PROPERTY, "CL_INVALID_PROPERTY");
+        names.put(CL12.CL_INVALID_IMAGE_DESCRIPTOR, "CL_INVALID_IMAGE_DESCRIPTOR");
+        names.put(CL12.CL_INVALID_COMPILER_OPTIONS, "CL_INVALID_COMPILER_OPTIONS");
+        names.put(CL12.CL_INVALID_LINKER_OPTIONS, "CL_INVALID_LINKER_OPTIONS");
+        names.put(CL12.CL_INVALID_DEVICE_PARTITION_COUNT, "CL_INVALID_DEVICE_PARTITION_COUNT");
+        ERROR_NAMES_BY_CODE = Collections.unmodifiableMap(names);
+    }
+
+    /** Creates a new {@link ClErrorCodeResolver}. */
+    public ClErrorCodeResolver() {}
+
+    /**
+     * Reports whether the given error code denotes success.
+     *
+     * @param errorCode the {@code cl_int} value returned by an OpenCL entry point
+     * @return {@code true} if the call succeeded
+     */
+    public boolean isSuccess(int errorCode) {
+        return errorCode == CL_SUCCESS;
+    }
+
+    /**
+     * Describes the given error code as its symbolic name plus the numeric value.
+     *
+     * @param errorCode the {@code cl_int} value returned by an OpenCL entry point
+     * @return a description such as {@code "CL_INVALID_VALUE (-30)"}, or a numeric fallback if the
+     *         code is not part of the OpenCL 1.0-1.2 error set
+     */
+    public String describe(int errorCode) {
+        final String name = ERROR_NAMES_BY_CODE.get(errorCode);
+        if (name == null) {
+            return String.format("unknown OpenCL error code (%d)", errorCode);
+        }
+        return String.format("%s (%d)", name, errorCode);
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClEvent.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClEvent.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * Handle to an OpenCL event, used to await and to profile an enqueued command.
+ *
+ * <p>Corresponds to the OpenCL C type {@code cl_event}.
+ *
+ * @param handle the native handle value
+ */
+@Immutable
+public record ClEvent(long handle) implements ClHandle {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClHandle.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClHandle.java
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+/**
+ * A handle to a native OpenCL object.
+ *
+ * <p>The OpenCL C API identifies every object — platforms, devices, contexts, queues, programs,
+ * kernels, buffers, events — by an opaque pointer, and the LWJGL binding surfaces all of them as a
+ * bare {@code long}. To the compiler, a command queue and a buffer are then the same thing, so
+ * swapping two arguments produces code that builds cleanly and fails inside the driver with an error
+ * that points nowhere useful.
+ *
+ * <p>The implementations of this interface restore the per-object types that JOCL provided through
+ * its {@code cl_mem} / {@code cl_kernel} / ... classes, at the cost of one small object per handle.
+ * They are deliberately plain value carriers: whether a handle is valid is decided when it is
+ * created, by {@link ClErrorChecker}, not by the record.
+ *
+ * <p>Sealed because the set of OpenCL object types is fixed by the specification, not by this
+ * project.
+ */
+public sealed interface ClHandle
+        permits ClCommandQueue, ClContext, ClDeviceId, ClEvent, ClKernel, ClMem, ClPlatformId, ClProgram {
+
+    /**
+     * Returns the native handle value.
+     *
+     * @return the opaque pointer value as passed to and from the OpenCL runtime
+     */
+    long handle();
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClKernel.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClKernel.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * Handle to an OpenCL kernel, one entry point of a program.
+ *
+ * <p>Corresponds to the OpenCL C type {@code cl_kernel}.
+ *
+ * @param handle the native handle value
+ */
+@Immutable
+public record ClKernel(long handle) implements ClHandle {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClLibraryInitializer.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClLibraryInitializer.java
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+/**
+ * Loads the native OpenCL library into the binding.
+ *
+ * <p>Exists purely as a seam: the underlying binding performs library loading through static methods
+ * that either succeed or throw {@link UnsatisfiedLinkError}, which makes the failure path impossible
+ * to exercise on a machine where loading happens to work. Behind this interface,
+ * {@link OpenClLibraryLoader} can be tested against a substitute that fails on demand.
+ *
+ * @see OpenClLibraryLoader
+ */
+public interface ClLibraryInitializer {
+
+    /**
+     * Loads the OpenCL library using the binding's default name resolution.
+     *
+     * @throws UnsatisfiedLinkError if the library cannot be located or loaded
+     */
+    void create();
+
+    /**
+     * Loads the OpenCL library from an explicitly named shared library.
+     *
+     * @param libraryName the platform-specific library name, e.g. {@code libOpenCL.so.1}
+     * @throws UnsatisfiedLinkError if the library cannot be located or loaded
+     */
+    void create(String libraryName);
+
+    /**
+     * Reports whether the native library has already been loaded.
+     *
+     * @return {@code true} if a previous load succeeded and the binding is usable
+     */
+    boolean isCreated();
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClMem.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClMem.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * Handle to an OpenCL memory object, i.e. a device-side buffer.
+ *
+ * <p>Corresponds to the OpenCL C type {@code cl_mem}.
+ *
+ * @param handle the native handle value
+ */
+@Immutable
+public record ClMem(long handle) implements ClHandle {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClPlatformId.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClPlatformId.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * Handle to an OpenCL platform - one installed implementation (ICD).
+ *
+ * <p>Corresponds to the OpenCL C type {@code cl_platform_id}.
+ *
+ * @param handle the native handle value
+ */
+@Immutable
+public record ClPlatformId(long handle) implements ClHandle {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClProgram.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClProgram.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * Handle to a compiled OpenCL program, the container of one or more kernels.
+ *
+ * <p>Corresponds to the OpenCL C type {@code cl_program}.
+ *
+ * @param handle the native handle value
+ */
+@Immutable
+public record ClProgram(long handle) implements ClHandle {}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/LwjglClApi.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/LwjglClApi.java
@@ -1,0 +1,584 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.ToString;
+import org.jspecify.annotations.Nullable;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.opencl.CL10;
+import org.lwjgl.opencl.CL20;
+import org.lwjgl.opencl.KHRICD;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+
+/**
+ * {@link ClApi} implementation backed by LWJGL.
+ *
+ * <p>The only class in the project that calls into the binding library directly. Everything it does
+ * beyond forwarding falls into three categories: it checks every returned error code, it wraps raw
+ * handles into their typed counterparts, and it manages the off-heap scratch memory that the
+ * pointer-based queries need.
+ *
+ * <p>Scratch buffers come from {@link MemoryStack}, which allocates from a per-thread stack and
+ * releases on scope exit. That is deliberate for the two-call query pattern OpenCL uses everywhere
+ * (ask for the size, then ask for the value): it keeps those short-lived buffers off both the Java
+ * heap and the allocator. The one exception is the chunked-write staging buffer, which is too large
+ * for the stack and is therefore allocated and freed explicitly.
+ */
+@ToString
+public class LwjglClApi implements ClApi {
+
+    /** Number of bytes the OpenCL runtime appends to every string property as the C terminator. */
+    private static final int NUL_TERMINATOR_BYTES = 1;
+
+    /** Passed as the value pointer when a query should report the required size only. */
+    private static final @Nullable ByteBuffer SIZE_QUERY_ONLY = null;
+
+    /** Terminator of a {@code cl_context_properties} / {@code cl_queue_properties} list. */
+    private static final long PROPERTY_LIST_TERMINATOR = 0L;
+
+    /** Blocking flag for the enqueue calls; every transfer in this project is synchronous. */
+    private static final boolean BLOCKING = true;
+
+    /** Number of dimensions used for every kernel launch in this project. */
+    private static final int WORK_DIMENSIONS = 1;
+
+    /**
+     * Size of the staging buffer used by the chunked host-to-device writes. Large enough that the
+     * per-write overhead is negligible, small enough that it never competes with the device buffer
+     * for host memory — the payloads it stages reach gigabytes.
+     */
+    private static final int STAGING_BUFFER_BYTES = 8 * 1024 * 1024;
+
+    private final ClErrorChecker errorChecker;
+    private final OpenClLibraryLoader libraryLoader;
+
+    /**
+     * Creates a new LWJGL-backed API.
+     *
+     * @param errorChecker  converts returned error codes into exceptions
+     * @param libraryLoader ensures the native library is loaded before the first call
+     */
+    public LwjglClApi(ClErrorChecker errorChecker, OpenClLibraryLoader libraryLoader) {
+        this.errorChecker = errorChecker;
+        this.libraryLoader = libraryLoader;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Discovery
+    // ---------------------------------------------------------------------------------------
+
+    @Override
+    public List<ClPlatformId> getPlatformIds() {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final IntBuffer platformCount = stack.mallocInt(1);
+            final int countErrorCode = CL10.clGetPlatformIDs(null, platformCount);
+            // An ICD loader can be installed while no implementation is: on a bare machine the
+            // loader answers CL_PLATFORM_NOT_FOUND_KHR. That is "nothing to offer", not a fault,
+            // so callers get an empty list and can skip the GPU path instead of failing.
+            if (countErrorCode == KHRICD.CL_PLATFORM_NOT_FOUND_KHR) {
+                return List.of();
+            }
+            errorChecker.checkSuccess(countErrorCode, "clGetPlatformIDs");
+
+            final int count = platformCount.get(0);
+            if (count == 0) {
+                return List.of();
+            }
+
+            final PointerBuffer platforms = stack.mallocPointer(count);
+            errorChecker.checkSuccess(CL10.clGetPlatformIDs(platforms, (IntBuffer) null), "clGetPlatformIDs");
+
+            final List<ClPlatformId> platformIds = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                platformIds.add(new ClPlatformId(platforms.get(i)));
+            }
+            return platformIds;
+        }
+    }
+
+    @Override
+    public String getPlatformInfoString(ClPlatformId platform, int paramName) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final PointerBuffer valueSize = stack.mallocPointer(1);
+            errorChecker.checkSuccess(
+                    CL10.clGetPlatformInfo(platform.handle(), paramName, SIZE_QUERY_ONLY, valueSize),
+                    "clGetPlatformInfo");
+
+            final int byteCount = (int) valueSize.get(0);
+            final ByteBuffer value = stack.malloc(byteCount);
+            errorChecker.checkSuccess(
+                    CL10.clGetPlatformInfo(platform.handle(), paramName, value, null), "clGetPlatformInfo");
+
+            return MemoryUtil.memUTF8(value, byteCount - NUL_TERMINATOR_BYTES);
+        }
+    }
+
+    @Override
+    public List<ClDeviceId> getDeviceIds(ClPlatformId platform, long deviceType) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final IntBuffer deviceCount = stack.mallocInt(1);
+            final int countErrorCode = CL10.clGetDeviceIDs(platform.handle(), deviceType, null, deviceCount);
+            // A platform that exposes no device of the requested type answers CL_DEVICE_NOT_FOUND.
+            // Same reasoning as for platforms above: an empty result, not an error.
+            if (countErrorCode == CL10.CL_DEVICE_NOT_FOUND) {
+                return List.of();
+            }
+            errorChecker.checkSuccess(countErrorCode, "clGetDeviceIDs");
+
+            final int count = deviceCount.get(0);
+            if (count == 0) {
+                return List.of();
+            }
+
+            final PointerBuffer devices = stack.mallocPointer(count);
+            errorChecker.checkSuccess(
+                    CL10.clGetDeviceIDs(platform.handle(), deviceType, devices, (IntBuffer) null), "clGetDeviceIDs");
+
+            final List<ClDeviceId> deviceIds = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                deviceIds.add(new ClDeviceId(devices.get(i)));
+            }
+            return deviceIds;
+        }
+    }
+
+    @Override
+    public String getDeviceInfoString(ClDeviceId device, int paramName) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final PointerBuffer valueSize = stack.mallocPointer(1);
+            errorChecker.checkSuccess(
+                    CL10.clGetDeviceInfo(device.handle(), paramName, SIZE_QUERY_ONLY, valueSize), "clGetDeviceInfo");
+
+            final int byteCount = (int) valueSize.get(0);
+            final ByteBuffer value = stack.malloc(byteCount);
+            errorChecker.checkSuccess(CL10.clGetDeviceInfo(device.handle(), paramName, value, null), "clGetDeviceInfo");
+
+            return MemoryUtil.memUTF8(value, byteCount - NUL_TERMINATOR_BYTES);
+        }
+    }
+
+    @Override
+    public int getDeviceInfoInt(ClDeviceId device, int paramName) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final IntBuffer value = stack.mallocInt(1);
+            errorChecker.checkSuccess(CL10.clGetDeviceInfo(device.handle(), paramName, value, null), "clGetDeviceInfo");
+            return value.get(0);
+        }
+    }
+
+    @Override
+    public long getDeviceInfoLong(ClDeviceId device, int paramName) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final LongBuffer value = stack.mallocLong(1);
+            errorChecker.checkSuccess(CL10.clGetDeviceInfo(device.handle(), paramName, value, null), "clGetDeviceInfo");
+            return value.get(0);
+        }
+    }
+
+    @Override
+    public long[] getDeviceInfoSizes(ClDeviceId device, int paramName, int valueCount) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            // PointerBuffer already models size_t width per platform, which removes the manual
+            // 4-versus-8-byte branch the previous binding required at every such call site.
+            final PointerBuffer value = stack.mallocPointer(valueCount);
+            errorChecker.checkSuccess(CL10.clGetDeviceInfo(device.handle(), paramName, value, null), "clGetDeviceInfo");
+
+            final long[] sizes = new long[valueCount];
+            for (int i = 0; i < valueCount; i++) {
+                sizes[i] = value.get(i);
+            }
+            return sizes;
+        }
+    }
+
+    @Override
+    public byte[] getDeviceInfoBytesOrEmpty(ClDeviceId device, int paramName, int byteCount) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final ByteBuffer value = stack.malloc(byteCount);
+            final int errorCode = CL10.clGetDeviceInfo(device.handle(), paramName, value, null);
+            if (errorCode != ClErrorCodeResolver.CL_SUCCESS) {
+                return new byte[0];
+            }
+            final byte[] payload = new byte[byteCount];
+            value.get(payload);
+            return payload;
+        } catch (RuntimeException | LinkageError e) {
+            // Identity properties come from optional extensions; any refusal means "unknown", which
+            // callers must handle anyway. Never let it fail the enumeration.
+            return new byte[0];
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Context and command queue
+    // ---------------------------------------------------------------------------------------
+
+    @Override
+    public ClContext createContext(ClPlatformId platform, ClDeviceId device) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final PointerBuffer properties = stack.mallocPointer(3);
+            properties
+                    .put(0, CL10.CL_CONTEXT_PLATFORM)
+                    .put(1, platform.handle())
+                    .put(2, PROPERTY_LIST_TERMINATOR);
+
+            final IntBuffer errorCode = stack.mallocInt(1);
+            final long handle = CL10.clCreateContext(properties, device.handle(), null, 0L, errorCode);
+            errorChecker.checkSuccess(errorCode.get(0), "clCreateContext");
+            return new ClContext(errorChecker.requireCreated(handle, "clCreateContext"));
+        }
+    }
+
+    @Override
+    public ClCommandQueue createCommandQueue(ClContext context, ClDeviceId device, boolean enableProfiling) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            // cl_queue_properties is a 64-bit cl_bitfield list, not a pointer list, so this one
+            // takes a LongBuffer where the context properties above take a PointerBuffer.
+            final LongBuffer properties;
+            if (enableProfiling) {
+                properties = stack.mallocLong(3);
+                properties
+                        .put(0, CL20.CL_QUEUE_PROPERTIES)
+                        .put(1, CL10.CL_QUEUE_PROFILING_ENABLE)
+                        .put(2, PROPERTY_LIST_TERMINATOR);
+            } else {
+                properties = stack.mallocLong(1);
+                properties.put(0, PROPERTY_LIST_TERMINATOR);
+            }
+
+            final IntBuffer errorCode = stack.mallocInt(1);
+            final long handle =
+                    CL20.clCreateCommandQueueWithProperties(context.handle(), device.handle(), properties, errorCode);
+            errorChecker.checkSuccess(errorCode.get(0), "clCreateCommandQueueWithProperties");
+            return new ClCommandQueue(errorChecker.requireCreated(handle, "clCreateCommandQueueWithProperties"));
+        }
+    }
+
+    @Override
+    public void finish(ClCommandQueue commandQueue) {
+        errorChecker.checkSuccess(CL10.clFinish(commandQueue.handle()), "clFinish");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Program and kernel
+    // ---------------------------------------------------------------------------------------
+
+    @Override
+    public ClProgram createProgramWithSource(ClContext context, String[] sources) {
+        libraryLoader.ensureLoaded();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final IntBuffer errorCode = stack.mallocInt(1);
+            final long handle = CL10.clCreateProgramWithSource(context.handle(), sources, errorCode);
+            errorChecker.checkSuccess(errorCode.get(0), "clCreateProgramWithSource");
+            return new ClProgram(errorChecker.requireCreated(handle, "clCreateProgramWithSource"));
+        }
+    }
+
+    @Override
+    public void buildProgram(ClProgram program, ClDeviceId device, String options) {
+        errorChecker.checkSuccess(
+                CL10.clBuildProgram(program.handle(), device.handle(), options, null, 0L), "clBuildProgram");
+    }
+
+    @Override
+    public String getProgramBuildLog(ClProgram program, ClDeviceId device) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final PointerBuffer logSize = stack.mallocPointer(1);
+            errorChecker.checkSuccess(
+                    CL10.clGetProgramBuildInfo(
+                            program.handle(), device.handle(), CL10.CL_PROGRAM_BUILD_LOG, SIZE_QUERY_ONLY, logSize),
+                    "clGetProgramBuildInfo");
+
+            final int byteCount = (int) logSize.get(0);
+            if (byteCount <= NUL_TERMINATOR_BYTES) {
+                return "";
+            }
+            final ByteBuffer log = MemoryUtil.memAlloc(byteCount);
+            try {
+                errorChecker.checkSuccess(
+                        CL10.clGetProgramBuildInfo(
+                                program.handle(), device.handle(), CL10.CL_PROGRAM_BUILD_LOG, log, null),
+                        "clGetProgramBuildInfo");
+                return MemoryUtil.memUTF8(log, byteCount - NUL_TERMINATOR_BYTES);
+            } finally {
+                // Off the stack on purpose: a verbose NVIDIA build log can be far larger than the
+                // per-thread stack region MemoryStack carves out.
+                MemoryUtil.memFree(log);
+            }
+        }
+    }
+
+    @Override
+    public ClKernel createKernel(ClProgram program, String kernelName) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final IntBuffer errorCode = stack.mallocInt(1);
+            final long handle = CL10.clCreateKernel(program.handle(), kernelName, errorCode);
+            errorChecker.checkSuccess(errorCode.get(0), "clCreateKernel");
+            return new ClKernel(errorChecker.requireCreated(handle, "clCreateKernel"));
+        }
+    }
+
+    @Override
+    public long getKernelWorkGroupInfoSize(ClKernel kernel, ClDeviceId device, int paramName) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final PointerBuffer value = stack.mallocPointer(1);
+            errorChecker.checkSuccess(
+                    CL10.clGetKernelWorkGroupInfo(kernel.handle(), device.handle(), paramName, value, null),
+                    "clGetKernelWorkGroupInfo");
+            return value.get(0);
+        }
+    }
+
+    @Override
+    public long getKernelWorkGroupInfoUlong(ClKernel kernel, ClDeviceId device, int paramName) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final LongBuffer value = stack.mallocLong(1);
+            errorChecker.checkSuccess(
+                    CL10.clGetKernelWorkGroupInfo(kernel.handle(), device.handle(), paramName, value, null),
+                    "clGetKernelWorkGroupInfo");
+            return value.get(0);
+        }
+    }
+
+    @Override
+    public void setKernelArg(ClKernel kernel, int argIndex, ClMem value) {
+        errorChecker.checkSuccess(CL10.clSetKernelArg1p(kernel.handle(), argIndex, value.handle()), "clSetKernelArg");
+    }
+
+    @Override
+    public void setKernelArgInt(ClKernel kernel, int argIndex, int value) {
+        errorChecker.checkSuccess(CL10.clSetKernelArg1i(kernel.handle(), argIndex, value), "clSetKernelArg");
+    }
+
+    @Override
+    public @Nullable ClEvent enqueueNDRangeKernel(
+            ClCommandQueue commandQueue, ClKernel kernel, long[] globalWorkSize, boolean profilingEvent) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final PointerBuffer global = stack.mallocPointer(globalWorkSize.length);
+            for (int i = 0; i < globalWorkSize.length; i++) {
+                global.put(i, globalWorkSize[i]);
+            }
+            // Null local work size: the runtime picks the work-group size, as before.
+            final PointerBuffer event = profilingEvent ? stack.mallocPointer(1) : null;
+            errorChecker.checkSuccess(
+                    CL10.clEnqueueNDRangeKernel(
+                            commandQueue.handle(), kernel.handle(), WORK_DIMENSIONS, null, global, null, null, event),
+                    "clEnqueueNDRangeKernel");
+            return event == null ? null : new ClEvent(event.get(0));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Buffers
+    // ---------------------------------------------------------------------------------------
+
+    @Override
+    public ClMem createBuffer(ClContext context, long flags, long sizeBytes) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final IntBuffer errorCode = stack.mallocInt(1);
+            final long handle = CL10.clCreateBuffer(context.handle(), flags, sizeBytes, errorCode);
+            errorChecker.checkSuccess(errorCode.get(0), "clCreateBuffer");
+            return new ClMem(errorChecker.requireCreated(handle, "clCreateBuffer"));
+        }
+    }
+
+    @Override
+    public ClMem createBufferFromHostMemory(ClContext context, long flags, ByteBuffer hostBuffer) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final IntBuffer errorCode = stack.mallocInt(1);
+            final long handle = CL10.clCreateBuffer(context.handle(), flags, hostBuffer, errorCode);
+            errorChecker.checkSuccess(errorCode.get(0), "clCreateBuffer");
+            return new ClMem(errorChecker.requireCreated(handle, "clCreateBuffer"));
+        }
+    }
+
+    @Override
+    public void writeBufferChunked(ClCommandQueue commandQueue, ClMem mem, byte[] source) {
+        writeChunked(commandQueue, mem, (long) source.length, Byte.BYTES, (staging, elementOffset, elementCount) -> {
+            staging.put(source, (int) elementOffset, elementCount);
+            return elementCount;
+        });
+    }
+
+    @Override
+    public void writeBufferChunked(ClCommandQueue commandQueue, ClMem mem, short[] source) {
+        writeChunked(
+                commandQueue,
+                mem,
+                (long) source.length * Short.BYTES,
+                Short.BYTES,
+                (staging, elementOffset, elementCount) -> {
+                    staging.asShortBuffer().put(source, (int) elementOffset, elementCount);
+                    return elementCount * Short.BYTES;
+                });
+    }
+
+    @Override
+    public void writeBufferChunked(ClCommandQueue commandQueue, ClMem mem, int[] source) {
+        writeChunked(
+                commandQueue,
+                mem,
+                (long) source.length * Integer.BYTES,
+                Integer.BYTES,
+                (staging, elementOffset, elementCount) -> {
+                    staging.asIntBuffer().put(source, (int) elementOffset, elementCount);
+                    return elementCount * Integer.BYTES;
+                });
+    }
+
+    @Override
+    public void writeBufferChunked(ClCommandQueue commandQueue, ClMem mem, long[] source) {
+        writeChunked(
+                commandQueue,
+                mem,
+                (long) source.length * Long.BYTES,
+                Long.BYTES,
+                (staging, elementOffset, elementCount) -> {
+                    staging.asLongBuffer().put(source, (int) elementOffset, elementCount);
+                    return elementCount * Long.BYTES;
+                });
+    }
+
+    @Override
+    public void enqueueWriteBuffer(ClCommandQueue commandQueue, ClMem mem, long deviceOffset, ByteBuffer source) {
+        errorChecker.checkSuccess(
+                CL10.clEnqueueWriteBuffer(
+                        commandQueue.handle(), mem.handle(), BLOCKING, deviceOffset, source, null, null),
+                "clEnqueueWriteBuffer");
+    }
+
+    @Override
+    public @Nullable ClEvent enqueueReadBuffer(
+            ClCommandQueue commandQueue, ClMem mem, long deviceOffset, ByteBuffer destination, boolean profilingEvent) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final PointerBuffer event = profilingEvent ? stack.mallocPointer(1) : null;
+            errorChecker.checkSuccess(
+                    CL10.clEnqueueReadBuffer(
+                            commandQueue.handle(), mem.handle(), BLOCKING, deviceOffset, destination, null, event),
+                    "clEnqueueReadBuffer");
+            return event == null ? null : new ClEvent(event.get(0));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------------------------
+
+    @Override
+    public long getEventElapsedNanos(ClEvent event) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            final LongBuffer start = stack.mallocLong(1);
+            final LongBuffer end = stack.mallocLong(1);
+            final long eventHandle = event.handle();
+            errorChecker.checkSuccess(
+                    CL10.clGetEventProfilingInfo(eventHandle, CL10.CL_PROFILING_COMMAND_START, start, null),
+                    "clGetEventProfilingInfo");
+            errorChecker.checkSuccess(
+                    CL10.clGetEventProfilingInfo(eventHandle, CL10.CL_PROFILING_COMMAND_END, end, null),
+                    "clGetEventProfilingInfo");
+            return end.get(0) - start.get(0);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Release
+    // ---------------------------------------------------------------------------------------
+
+    @Override
+    public void releaseMemObject(ClMem mem) {
+        errorChecker.checkSuccess(CL10.clReleaseMemObject(mem.handle()), "clReleaseMemObject");
+    }
+
+    @Override
+    public void releaseKernel(ClKernel kernel) {
+        errorChecker.checkSuccess(CL10.clReleaseKernel(kernel.handle()), "clReleaseKernel");
+    }
+
+    @Override
+    public void releaseProgram(ClProgram program) {
+        errorChecker.checkSuccess(CL10.clReleaseProgram(program.handle()), "clReleaseProgram");
+    }
+
+    @Override
+    public void releaseCommandQueue(ClCommandQueue commandQueue) {
+        errorChecker.checkSuccess(CL10.clReleaseCommandQueue(commandQueue.handle()), "clReleaseCommandQueue");
+    }
+
+    @Override
+    public void releaseContext(ClContext context) {
+        errorChecker.checkSuccess(CL10.clReleaseContext(context.handle()), "clReleaseContext");
+    }
+
+    @Override
+    public void releaseEvent(ClEvent event) {
+        errorChecker.checkSuccess(CL10.clReleaseEvent(event.handle()), "clReleaseEvent");
+    }
+
+    /**
+     * Copies a host payload into a device buffer through a bounded staging buffer.
+     *
+     * @param commandQueue the queue to submit the writes to
+     * @param mem          the destination device buffer
+     * @param totalBytes   the payload size in bytes
+     * @param elementBytes the width of one payload element, so a chunk never splits an element
+     * @param filler       copies one slice of the payload into the staging buffer
+     */
+    private void writeChunked(
+            ClCommandQueue commandQueue, ClMem mem, long totalBytes, int elementBytes, StagingFiller filler) {
+        if (totalBytes <= 0L) {
+            return;
+        }
+        final int elementsPerChunk = STAGING_BUFFER_BYTES / elementBytes;
+        final ByteBuffer staging = MemoryUtil.memAlloc(STAGING_BUFFER_BYTES).order(ByteOrder.nativeOrder());
+        try {
+            final long totalElements = totalBytes / elementBytes;
+            long writtenElements = 0L;
+            long deviceOffset = 0L;
+            while (writtenElements < totalElements) {
+                final int chunkElements = (int) Math.min(elementsPerChunk, totalElements - writtenElements);
+                staging.clear();
+                final int chunkBytes = filler.fill(staging, writtenElements, chunkElements);
+                staging.position(0).limit(chunkBytes);
+                enqueueWriteBuffer(commandQueue, mem, deviceOffset, staging);
+                writtenElements += chunkElements;
+                deviceOffset += chunkBytes;
+            }
+            finish(commandQueue);
+        } finally {
+            MemoryUtil.memFree(staging);
+        }
+    }
+
+    /** Copies one slice of a primitive host payload into the staging buffer. */
+    private interface StagingFiller {
+
+        /**
+         * Copies {@code elementCount} elements starting at {@code elementOffset} into the staging
+         * buffer.
+         *
+         * @param staging       the staging buffer, already cleared
+         * @param elementOffset index of the first element to copy
+         * @param elementCount  number of elements to copy
+         * @return the number of bytes written into the staging buffer
+         */
+        int fill(ByteBuffer staging, long elementOffset, int elementCount);
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/LwjglClLibraryInitializer.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/LwjglClLibraryInitializer.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import org.lwjgl.opencl.CL;
+import org.lwjgl.system.Configuration;
+
+/**
+ * {@link ClLibraryInitializer} backed by LWJGL's {@link CL} bootstrap.
+ *
+ * <p>Initialisation order matters here. {@link CL} loads the native library from a static
+ * initializer unless {@link Configuration#OPENCL_EXPLICIT_INIT} has been set beforehand, which would
+ * take the choice of library name out of this class's hands and make the fallback in
+ * {@link OpenClLibraryLoader} unreachable. The flag is therefore set from this class's own static
+ * initializer, which runs when this class is first touched — necessarily before any method here
+ * references {@link CL} and thus before {@link CL} is initialised.
+ *
+ * <p>Consequence worth knowing: whichever code touches {@code org.lwjgl.opencl.CL} first in a JVM
+ * decides how the library gets loaded. As long as the {@code opencl} package reaches the binding
+ * only through this seam, that first touch is this class.
+ */
+public class LwjglClLibraryInitializer implements ClLibraryInitializer {
+
+    static {
+        // Must happen before org.lwjgl.opencl.CL is class-initialized; see the class comment.
+        Configuration.OPENCL_EXPLICIT_INIT.set(Boolean.TRUE);
+    }
+
+    /** Creates a new {@link LwjglClLibraryInitializer}. */
+    public LwjglClLibraryInitializer() {}
+
+    @Override
+    public void create() {
+        CL.create();
+    }
+
+    @Override
+    public void create(String libraryName) {
+        CL.create(libraryName);
+    }
+
+    @Override
+    public boolean isCreated() {
+        try {
+            CL.getICD();
+            return true;
+        } catch (IllegalStateException e) {
+            // LWJGL reports "OpenCL library has not been loaded." this way; there is no query API.
+            return false;
+        }
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClBinding.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClBinding.java
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+/**
+ * Assembles the default OpenCL binding stack.
+ *
+ * <p>The pieces of this package are deliberately small and separately injectable, which is what makes
+ * them testable but also means a caller that just wants "the OpenCL API" would otherwise have to
+ * repeat the same four-line wiring. This class is that wiring, kept in one place so a change to the
+ * stack does not have to be chased through every call site.
+ *
+ * <p>Callers that need to substitute a part — a test faking the API, or the library loader — build
+ * the stack themselves instead of going through here.
+ */
+public class OpenClBinding {
+
+    /** Creates a new {@link OpenClBinding}. */
+    public OpenClBinding() {}
+
+    /**
+     * Creates the default OpenCL API: LWJGL-backed, with error checking and the library-name
+     * fallback that a stock Linux runtime needs.
+     *
+     * @return a ready-to-use OpenCL API
+     */
+    public ClApi createClApi() {
+        return new LwjglClApi(
+                new ClErrorChecker(new ClErrorCodeResolver()),
+                new OpenClLibraryLoader(new LwjglClLibraryInitializer()));
+    }
+
+    /**
+     * Convenience for call sites that hold no binding instance of their own, such as the no-argument
+     * constructors that exist for backwards compatibility.
+     *
+     * @return a ready-to-use OpenCL API
+     */
+    public static ClApi defaultClApi() {
+        return new OpenClBinding().createClApi();
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClCallFailedException.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClCallFailedException.java
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+/**
+ * Thrown when a call into the OpenCL runtime reports a failure.
+ *
+ * <p>The OpenCL C API signals failures through {@code cl_int} return values rather than through any
+ * exception mechanism, and the LWJGL binding passes that contract through unchanged. This exception
+ * is what converts such a return value into a normal Java failure, carrying both the numeric error
+ * code and the name of the entry point that produced it so a stack trace identifies the offending
+ * call without further instrumentation.
+ *
+ * @see ClErrorChecker
+ */
+public class OpenClCallFailedException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The {@code cl_int} error code reported by the OpenCL runtime. */
+    private final int errorCode;
+
+    /** Name of the OpenCL entry point that reported the failure, e.g. {@code clCreateBuffer}. */
+    private final String openClFunctionName;
+
+    /**
+     * Creates a new exception describing a failed OpenCL call.
+     *
+     * @param message            the human-readable failure description
+     * @param errorCode          the {@code cl_int} error code reported by the runtime
+     * @param openClFunctionName name of the OpenCL entry point that failed
+     */
+    public OpenClCallFailedException(String message, int errorCode, String openClFunctionName) {
+        super(message);
+        this.errorCode = errorCode;
+        this.openClFunctionName = openClFunctionName;
+    }
+
+    /**
+     * Returns the {@code cl_int} error code reported by the OpenCL runtime.
+     *
+     * @return the numeric OpenCL error code
+     */
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+    /**
+     * Returns the name of the OpenCL entry point that reported the failure.
+     *
+     * @return the OpenCL function name, e.g. {@code clCreateBuffer}
+     */
+    public String getOpenClFunctionName() {
+        return openClFunctionName;
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClLibraryLoader.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClLibraryLoader.java
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.ToString;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Loads the native OpenCL library, falling back to alternative library names when the binding's
+ * default resolution fails.
+ *
+ * <p>The fallback is not defensive padding; it fixes a reproducible failure. A stock Linux install
+ * of an OpenCL driver provides the versioned SONAME {@code libOpenCL.so.1}, while the unversioned
+ * {@code libOpenCL.so} that a plain-name lookup resolves is shipped by the separate development
+ * package. An application that only ever asks for {@code OpenCL} therefore refuses to start on a
+ * perfectly working machine unless a build-time package happens to be installed. Verified in a
+ * Debian container carrying {@code pocl-opencl-icd} but no development package: the plain-name load
+ * fails, the versioned load succeeds.
+ *
+ * <p>Loading is idempotent and cheap after the first success, so callers may invoke
+ * {@link #ensureLoaded()} freely instead of tracking initialisation themselves.
+ */
+@ToString
+public class OpenClLibraryLoader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenClLibraryLoader.class);
+
+    /**
+     * Versioned Linux SONAME of the OpenCL ICD loader. Present on every machine with a working
+     * OpenCL runtime; the unversioned symlink next to it is not.
+     */
+    public static final String VERSIONED_LINUX_LIBRARY_NAME = "libOpenCL.so.1";
+
+    /**
+     * Library names tried, in order, after the binding's own default resolution has failed. Kept as
+     * an ordered list rather than a set so the attempt order stays part of the contract.
+     */
+    private static final ImmutableList<String> FALLBACK_LIBRARY_NAMES = ImmutableList.of(VERSIONED_LINUX_LIBRARY_NAME);
+
+    private final ClLibraryInitializer libraryInitializer;
+
+    /** Guards against repeating the load once it has succeeded through this loader. */
+    private boolean loaded = false;
+
+    /**
+     * Creates a new loader.
+     *
+     * @param libraryInitializer performs the actual native library load
+     */
+    public OpenClLibraryLoader(ClLibraryInitializer libraryInitializer) {
+        this.libraryInitializer = libraryInitializer;
+    }
+
+    /**
+     * Returns the library names tried after default resolution fails.
+     *
+     * @return the ordered fallback library names
+     */
+    public List<String> fallbackLibraryNames() {
+        return FALLBACK_LIBRARY_NAMES;
+    }
+
+    /**
+     * Ensures the native OpenCL library is loaded, trying the default name first and then every
+     * fallback name in turn. Does nothing if the library is already loaded.
+     *
+     * @throws OpenClLibraryUnavailableException if no candidate could be loaded
+     */
+    public void ensureLoaded() {
+        if (loaded || libraryInitializer.isCreated()) {
+            return;
+        }
+
+        @Nullable UnsatisfiedLinkError lastFailure = null;
+        try {
+            libraryInitializer.create();
+            loaded = true;
+            return;
+        } catch (UnsatisfiedLinkError e) {
+            lastFailure = e;
+            LOGGER.debug("Default OpenCL library name did not resolve, trying fallback names", e);
+        }
+
+        for (String libraryName : FALLBACK_LIBRARY_NAMES) {
+            try {
+                libraryInitializer.create(libraryName);
+                loaded = true;
+                LOGGER.info("Loaded the OpenCL library under the fallback name {}", libraryName);
+                return;
+            } catch (UnsatisfiedLinkError e) {
+                lastFailure = e;
+                LOGGER.debug("OpenCL library name {} did not resolve", libraryName, e);
+            }
+        }
+
+        throw new OpenClLibraryUnavailableException(
+                "Unable to load the native OpenCL library. Tried the default name and " + FALLBACK_LIBRARY_NAMES
+                        + ". Install an OpenCL driver (ICD) for your device.",
+                lastFailure);
+    }
+
+    /**
+     * Reports whether the native OpenCL library is loaded and usable.
+     *
+     * @return {@code true} if the library has been loaded
+     */
+    public boolean isLoaded() {
+        return loaded || libraryInitializer.isCreated();
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClLibraryUnavailableException.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClLibraryUnavailableException.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+/**
+ * Thrown when the native OpenCL library cannot be loaded under any of the known library names.
+ *
+ * <p>Distinct from {@link OpenClCallFailedException} on purpose: that one reports a call that
+ * reached the OpenCL runtime and was rejected, while this one reports that no runtime could be
+ * reached at all. The two lead to different conclusions — a driver problem on the host versus a
+ * misuse of the API — and callers that want to degrade gracefully (falling back to a CPU producer,
+ * for instance) only care about the latter.
+ */
+public class OpenClLibraryUnavailableException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new exception describing a failed library load.
+     *
+     * @param message the human-readable failure description, naming the attempted library names
+     * @param cause   the last {@link UnsatisfiedLinkError} encountered while trying the candidates
+     */
+    public OpenClLibraryUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/package-info.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/package-info.java
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Thin, instance-based seam over the OpenCL binding library.
+ *
+ * <p>Everything in this package exists to keep the rest of {@code opencl} free of any direct
+ * dependency on a concrete binding. It provides three things the raw binding does not:
+ *
+ * <ul>
+ *   <li><b>Typed handles.</b> LWJGL represents every OpenCL object as a bare {@code long}, so a
+ *       buffer, a kernel and a command queue are the same type to the compiler. The handle records
+ *       here restore the distinction that JOCL's {@code cl_mem} / {@code cl_kernel} classes provided.
+ *   <li><b>Explicit error checking.</b> LWJGL returns {@code cl_int} error codes and never throws on
+ *       its own, so an unchecked call fails silently. {@link
+ *       net.ladenthin.bitcoinaddressfinder.opencl.binding.ClErrorChecker} turns a non-success code
+ *       into an attributable {@link
+ *       net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClCallFailedException}.
+ *   <li><b>A mockable surface.</b> The binding's own API is entirely static. Wrapping it behind
+ *       instance methods is what allows the layers above to be tested with mocks and spies instead of
+ *       requiring a real OpenCL device.
+ * </ul>
+ *
+ * <p>JSpecify {@code @NullMarked}: see {@link net.ladenthin.bitcoinaddressfinder} for the convention.
+ */
+@NullMarked
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/producer/ProducerJava.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/producer/ProducerJava.java
@@ -52,7 +52,7 @@ public class ProducerJava extends AbstractProducer {
     public void processSecretBase(BigInteger secretBase) {
         try {
             PublicKeyBytes[] publicKeyBytesArray = createGrid(secretBase);
-            consumer.consumeKeys(publicKeyBytesArray);
+            consumer.consumeKeys(publicKeyBytesArray, secretBase);
         } catch (Exception e) {
             logErrorInProduceKeys(e, secretBase);
         }
@@ -65,7 +65,8 @@ public class ProducerJava extends AbstractProducer {
             for (int i = 0; i < secrets.length; i++) {
                 publicKeyBytesArray[i] = PublicKeyBytes.fromPrivate(secrets[i]);
             }
-            consumer.consumeKeys(publicKeyBytesArray);
+            // Independent secrets, so there is no common base to report.
+            consumer.consumeKeys(publicKeyBytesArray, null);
         } catch (Exception e) {
             logErrorInProduceKeys(e);
         }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/producer/ProducerOpenCL.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/producer/ProducerOpenCL.java
@@ -51,7 +51,7 @@ public class ProducerOpenCL extends AbstractProducer {
     @ToString.Exclude
     private final Semaphore submitSlot;
 
-    // OpenCLContext aggregates JOCL native pointers + own state — exposed via the
+    // OpenCLContext aggregates OpenCL native handles + own state — exposed via the
     // isInitialized() getter below instead so callers see "initialized=true/false"
     // without the heavyweight inner dump.
     @ToString.Exclude
@@ -332,7 +332,7 @@ public class ProducerOpenCL extends AbstractProducer {
             try {
                 try {
                     PublicKeyBytes[] publicKeyBytesArray = openCLGridResult.getPublicKeyBytes();
-                    consumer.consumeKeys(publicKeyBytesArray);
+                    consumer.consumeKeys(publicKeyBytesArray, secretBase);
                 } catch (Throwable e) {
                     abstractProducer.logErrorInProduceKeys(e, secretBase);
                 } finally {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/producer/ProducerReleaser.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/producer/ProducerReleaser.java
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.producer;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import lombok.ToString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stops and releases producers, guaranteeing that each one is released exactly once.
+ *
+ * <p>The guarantee is the whole point of this class. Teardown is reached from two directions — the
+ * ordinary completion path once a run has finished, and the JVM shutdown hook — and nothing keeps
+ * those apart: a {@code Ctrl+C} arriving while a finished run is releasing its producers is enough to
+ * have both running at the same moment. Previously each caller took its own snapshot of the producer
+ * list before either had cleared it, so both released the same producer. Releasing an OpenCL producer
+ * twice is rejected by the driver with {@code CL_INVALID_MEM_OBJECT}, which ended an otherwise
+ * successful run with a fatal error.
+ *
+ * <p>Producers are tracked by identity, not by {@code equals}: two distinct producers configured
+ * identically are separate native resources and must each be released, while the same instance handed
+ * in twice must not be.
+ *
+ * <p>An instance class rather than a static utility, per the project convention on helper classes:
+ * the owner holds one and the release history lives with it.
+ */
+@ToString
+public class ProducerReleaser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProducerReleaser.class);
+
+    /**
+     * Producers already released by this instance, compared by identity. Guarded by the instance
+     * lock together with the release itself, so a second caller cannot slip between the check and
+     * the release.
+     */
+    @ToString.Exclude
+    private final Set<Producer> released = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    /** Creates a new {@link ProducerReleaser}. */
+    public ProducerReleaser() {}
+
+    /**
+     * Stops and releases every producer that this releaser has not released before.
+     *
+     * <p>Each producer is interrupted, awaited and then released, in that order: releasing the
+     * resources of a producer that is still running would pull them out from under it.
+     *
+     * @param producers the producers to release; ones already released are skipped
+     */
+    public synchronized void release(Collection<Producer> producers) {
+        for (Producer producer : producers) {
+            if (!released.add(producer)) {
+                LOGGER.debug("Producer already released, skipping: {}", producer);
+                continue;
+            }
+            LOGGER.info("Interrupt Producer: " + producer.toString());
+            producer.interrupt();
+            LOGGER.info("waitTillProducerNotRunning ...");
+            producer.waitTillProducerNotRunning();
+            producer.releaseProducer();
+        }
+    }
+}

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -18,7 +18,7 @@
  * are required for resource access.</p>
  *
  * <p>No non-implicit {@code requires} clauses are declared. The dependency graph
- * (bitcoinj, LMDB, JOCL, Jackson, SLF4J, Guava, etc.) is referenced from ordinary source
+ * (bitcoinj, LMDB, LWJGL, Jackson, SLF4J, Guava, etc.) is referenced from ordinary source
  * files only; consumers that put this jar on the module path resolve those dependencies
  * through their own {@code requires} graph. The fat-jar produced by {@code mvn package
  * -P assembly} runs on the classpath, where the module descriptor is ignored.</p>

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/BitcoinAddressFinderArchitectureTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/BitcoinAddressFinderArchitectureTest.java
@@ -412,17 +412,23 @@ public class BitcoinAddressFinderArchitectureTest {
     // ---------------------------------------------------------------------------------------
 
     /**
-     * The JOCL / OpenCL GPU binding ({@code org.jocl..}) may only be referenced from the
+     * The LWJGL OpenCL GPU binding ({@code org.lwjgl..}) may only be referenced from the
      * {@code opencl} package. No other layer may take a compile dependency on the GPU runtime;
      * everything above consumes the GPU exclusively through {@code opencl}'s own types.
+     *
+     * <p>Within {@code opencl}, the binding is confined further still: only the
+     * {@code opencl.binding} sub-package calls into it, which is what makes the rest of the GPU
+     * layer testable without a device. That inner boundary is a design rule rather than a test,
+     * because the constant classes ({@code CL10} and friends) are legitimately read wherever an
+     * OpenCL parameter name is needed.
      */
     @ArchTest
-    static final ArchRule joclConfinedToOpencl = noClasses()
+    static final ArchRule openClBindingConfinedToOpencl = noClasses()
             .that()
             .resideOutsideOfPackage("net.ladenthin.bitcoinaddressfinder.opencl..")
             .should()
             .dependOnClassesThat()
-            .resideInAPackage("org.jocl..")
+            .resideInAPackage("org.lwjgl..")
             .allowEmptyShould(true);
 
     /**

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/MockConsumer.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/MockConsumer.java
@@ -3,18 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 package net.ladenthin.bitcoinaddressfinder;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import net.ladenthin.bitcoinaddressfinder.consumer.Consumer;
 import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
+import org.jspecify.annotations.Nullable;
 
 public class MockConsumer implements Consumer {
 
     public List<PublicKeyBytes[]> publicKeyBytesArrayList = new ArrayList<>();
 
+    /** Bases seen alongside each batch, so a test can assert what the producer reported. */
+    public List<@Nullable BigInteger> secretBaseList = new ArrayList<>();
+
     @Override
-    public void consumeKeys(PublicKeyBytes[] publicKeyBytes) throws InterruptedException {
+    public void consumeKeys(PublicKeyBytes[] publicKeyBytes, @Nullable BigInteger secretBase)
+            throws InterruptedException {
         publicKeyBytesArrayList.add(publicKeyBytes);
+        secretBaseList.add(secretBase);
     }
 
     @Override

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLAddKernelSmokeTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLAddKernelSmokeTest.java
@@ -5,40 +5,22 @@ package net.ladenthin.bitcoinaddressfinder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.jocl.CL.CL_MEM_COPY_HOST_PTR;
-import static org.jocl.CL.CL_MEM_READ_ONLY;
-import static org.jocl.CL.CL_MEM_WRITE_ONLY;
-import static org.jocl.CL.CL_TRUE;
-import static org.jocl.CL.clBuildProgram;
-import static org.jocl.CL.clCreateBuffer;
-import static org.jocl.CL.clCreateCommandQueueWithProperties;
-import static org.jocl.CL.clCreateContext;
-import static org.jocl.CL.clCreateKernel;
-import static org.jocl.CL.clCreateProgramWithSource;
-import static org.jocl.CL.clEnqueueNDRangeKernel;
-import static org.jocl.CL.clEnqueueReadBuffer;
-import static org.jocl.CL.clFinish;
-import static org.jocl.CL.clReleaseCommandQueue;
-import static org.jocl.CL.clReleaseContext;
-import static org.jocl.CL.clReleaseKernel;
-import static org.jocl.CL.clReleaseMemObject;
-import static org.jocl.CL.clReleaseProgram;
-import static org.jocl.CL.clSetKernelArg;
-import static org.jocl.CL.setExceptionsEnabled;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLBuilder;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDevice;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
-import org.jocl.Pointer;
-import org.jocl.Sizeof;
-import org.jocl.cl_command_queue;
-import org.jocl.cl_context;
-import org.jocl.cl_device_id;
-import org.jocl.cl_kernel;
-import org.jocl.cl_mem;
-import org.jocl.cl_program;
-import org.jocl.cl_queue_properties;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClApi;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClBufferFlags;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClCommandQueue;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClContext;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClDeviceId;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClKernel;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClMem;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClProgram;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClBinding;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
@@ -83,7 +65,7 @@ public class OpenCLAddKernelSmokeTest {
     public void addKernel_allDevices_computeElementwiseSum() {
         new OpenCLPlatformAssume().assumeOpenClLibraryAvailable();
         // arrange
-        setExceptionsEnabled(true);
+        // No global error-reporting switch to flip: every call is checked at the binding seam.
         List<OpenCLPlatform> openCLPlatforms = new OpenCLBuilder().build();
 
         // act + assert: run the add kernel on every discovered device and verify each result.
@@ -108,41 +90,47 @@ public class OpenCLAddKernelSmokeTest {
      * every output element equals the element-wise sum of its inputs. All OpenCL resources created
      * here are released before returning so the test never leaks across devices.
      *
-     * @param openCLPlatform the platform owning the device (provides the context properties)
+     * @param openCLPlatform the platform owning the device
      * @param openCLDevice   the device to build and run the kernel on
      */
     private void runAddKernelOnDevice(OpenCLPlatform openCLPlatform, OpenCLDevice openCLDevice) {
         final int[] a = new int[ELEMENT_COUNT];
         final int[] b = new int[ELEMENT_COUNT];
-        final int[] out = new int[ELEMENT_COUNT];
         for (int i = 0; i < ELEMENT_COUNT; i++) {
             a[i] = i;
             b[i] = 2 * i + 1;
         }
 
-        final cl_device_id deviceId = openCLDevice.device();
-        final cl_context context =
-                clCreateContext(openCLPlatform.contextProperties(), 1, new cl_device_id[] {deviceId}, null, null, null);
-        final cl_command_queue commandQueue =
-                clCreateCommandQueueWithProperties(context, deviceId, new cl_queue_properties(), null);
-        final cl_program program = clCreateProgramWithSource(context, 1, new String[] {ADD_KERNEL_SOURCE}, null, null);
-        clBuildProgram(program, 0, null, BUILD_OPTIONS, null, null);
-        final cl_kernel kernel = clCreateKernel(program, KERNEL_NAME, null);
+        final ClApi clApi = OpenClBinding.defaultClApi();
+        final ClDeviceId deviceId = openCLDevice.device();
+        final ClContext context = clApi.createContext(openCLPlatform.platformId(), deviceId);
+        final ClCommandQueue commandQueue = clApi.createCommandQueue(context, deviceId, false);
+        final ClProgram program = clApi.createProgramWithSource(context, new String[] {ADD_KERNEL_SOURCE});
+        clApi.buildProgram(program, deviceId, BUILD_OPTIONS);
+        final ClKernel kernel = clApi.createKernel(program, KERNEL_NAME);
 
-        final long intBufferBytes = (long) Sizeof.cl_int * ELEMENT_COUNT;
-        final cl_mem aMem =
-                clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, intBufferBytes, Pointer.to(a), null);
-        final cl_mem bMem =
-                clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, intBufferBytes, Pointer.to(b), null);
-        final cl_mem outMem = clCreateBuffer(context, CL_MEM_WRITE_ONLY, intBufferBytes, null, null);
+        final long intBufferBytes = (long) Integer.BYTES * ELEMENT_COUNT;
+        final ClMem aMem = clApi.createBuffer(context, ClBufferFlags.READ_ONLY, intBufferBytes);
+        final ClMem bMem = clApi.createBuffer(context, ClBufferFlags.READ_ONLY, intBufferBytes);
+        final ClMem outMem = clApi.createBuffer(context, ClBufferFlags.WRITE_ONLY, intBufferBytes);
         try {
-            clSetKernelArg(kernel, 0, Sizeof.cl_mem, Pointer.to(aMem));
-            clSetKernelArg(kernel, 1, Sizeof.cl_mem, Pointer.to(bMem));
-            clSetKernelArg(kernel, 2, Sizeof.cl_mem, Pointer.to(outMem));
+            clApi.writeBufferChunked(commandQueue, aMem, a);
+            clApi.writeBufferChunked(commandQueue, bMem, b);
 
-            clEnqueueNDRangeKernel(commandQueue, kernel, 1, null, new long[] {ELEMENT_COUNT}, null, 0, null, null);
-            clEnqueueReadBuffer(commandQueue, outMem, CL_TRUE, 0, intBufferBytes, Pointer.to(out), 0, null, null);
-            clFinish(commandQueue);
+            clApi.setKernelArg(kernel, 0, aMem);
+            clApi.setKernelArg(kernel, 1, bMem);
+            clApi.setKernelArg(kernel, 2, outMem);
+
+            clApi.enqueueNDRangeKernel(commandQueue, kernel, new long[] {ELEMENT_COUNT}, false);
+
+            final ByteBuffer readBack =
+                    ByteBuffer.allocateDirect((int) intBufferBytes).order(ByteOrder.nativeOrder());
+            clApi.enqueueReadBuffer(commandQueue, outMem, 0L, readBack, false);
+            clApi.finish(commandQueue);
+
+            final int[] out = new int[ELEMENT_COUNT];
+            readBack.position(0);
+            readBack.asIntBuffer().get(out);
 
             for (int i = 0; i < ELEMENT_COUNT; i++) {
                 assertThat(
@@ -151,13 +139,13 @@ public class OpenCLAddKernelSmokeTest {
                         is(a[i] + b[i]));
             }
         } finally {
-            clReleaseMemObject(aMem);
-            clReleaseMemObject(bMem);
-            clReleaseMemObject(outMem);
-            clReleaseKernel(kernel);
-            clReleaseProgram(program);
-            clReleaseCommandQueue(commandQueue);
-            clReleaseContext(context);
+            clApi.releaseMemObject(aMem);
+            clApi.releaseMemObject(bMem);
+            clApi.releaseMemObject(outMem);
+            clApi.releaseKernel(kernel);
+            clApi.releaseProgram(program);
+            clApi.releaseCommandQueue(commandQueue);
+            clApi.releaseContext(context);
         }
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLBuilderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLBuilderTest.java
@@ -33,26 +33,25 @@ public class OpenCLBuilderTest {
         assertThat(openCLPlatforms.size(), is(greaterThan(Integer.valueOf(0))));
         assertThat(openCLPlatforms.getFirst().openCLDevices().size(), is(greaterThan(Integer.valueOf(0))));
         System.out.println(openCLPlatforms);
-        System.out.println("isOpenClNativeLibraryLoaded: " + OpenCLBuilder.isOpenClNativeLibraryLoaded());
+        System.out.println("isOpenClNativeLibraryLoaded: " + new OpenCLBuilder().isOpenClLibraryAvailable());
         System.out.println("isOneOpenCL2DeviceAvailable: "
-                + OpenCLBuilder.isOneOpenCL2_0OrGreaterDeviceAvailable(openCLPlatforms));
+                + new OpenCLBuilder().isOneOpenCL2_0OrGreaterDeviceAvailable(openCLPlatforms));
     }
     // </editor-fold>
 
     @Test
     public void isOpenCL2_0OrGreater_OpenCLVersion1_2Given_ReturnFalse() throws IOException {
-        OpenCLBuilder openCLBuilder = new OpenCLBuilder();
         assertThat(
-                OpenCLBuilder.isOpenCL2_0OrGreater(OpenCLDevice.getComparableVersionFromDeviceVersion("OpenCL 1.2")),
+                new OpenCLBuilder()
+                        .isOpenCL2_0OrGreater(OpenCLDevice.getComparableVersionFromDeviceVersion("OpenCL 1.2")),
                 is(equalTo(Boolean.FALSE)));
     }
 
     @Test
     public void isOpenCL2_0OrGreater_OpenCLVersion3_0_CUDA_Given_ReturnFalse() throws IOException {
-        OpenCLBuilder openCLBuilder = new OpenCLBuilder();
         assertThat(
-                OpenCLBuilder.isOpenCL2_0OrGreater(
-                        OpenCLDevice.getComparableVersionFromDeviceVersion("OpenCL 3.0 CUDA")),
+                new OpenCLBuilder()
+                        .isOpenCL2_0OrGreater(OpenCLDevice.getComparableVersionFromDeviceVersion("OpenCL 3.0 CUDA")),
                 is(equalTo(Boolean.TRUE)));
     }
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLDeviceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLDeviceTest.java
@@ -17,12 +17,15 @@ import java.util.List;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLBuilder;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDevice;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClDeviceId;
 import org.apache.maven.artifact.versioning.ComparableVersion;
-import org.jocl.CL;
-import org.jocl.cl_device_id;
 import org.junit.jupiter.api.Test;
+import org.lwjgl.opencl.CL10;
+import org.lwjgl.opencl.CL12;
 
 public class OpenCLDeviceTest {
+    /** Stand-in device handle: these tests describe the value object, never a real device. */
+    private static final ClDeviceId TEST_DEVICE_ID = new ClDeviceId(1L);
 
     // <editor-fold defaultstate="collapsed" desc="getByteOrder">
     @Test
@@ -79,14 +82,14 @@ public class OpenCLDeviceTest {
         new OpenCLPlatformAssume().assumeOpenClLibraryAvailable();
         // arrange
         OpenCLDevice device = new OpenCLDevice(
-                new cl_device_id(),
+                TEST_DEVICE_ID,
                 "NVIDIA GeForce RTX 3070 Laptop GPU",
                 "NVIDIA Corporation",
                 "561.19",
                 "FULL_PROFILE",
                 "OpenCL 3.0 CUDA",
                 "cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_fp64 cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_icd cl_khr_gl_sharing cl_nv_compiler_options cl_nv_device_attribute_query cl_nv_pragma_unroll cl_nv_d3d10_sharing cl_khr_d3d10_sharing cl_nv_d3d11_sharing cl_nv_copy_opts cl_nv_create_buffer cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_device_uuid cl_khr_pci_bus_info cl_khr_external_semaphore cl_khr_external_memory cl_khr_external_semaphore_win32 cl_khr_external_memory_win32",
-                CL.CL_DEVICE_TYPE_GPU,
+                CL10.CL_DEVICE_TYPE_GPU,
                 true,
                 40,
                 3,
@@ -97,20 +100,20 @@ public class OpenCLDeviceTest {
                 2047L * 1024 * 1024,
                 8191L * 1024 * 1024,
                 0,
-                CL.CL_LOCAL,
+                CL10.CL_LOCAL,
                 48L * 1024,
                 64L * 1024,
-                CL.CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL.CL_QUEUE_PROFILING_ENABLE,
+                CL10.CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL10.CL_QUEUE_PROFILING_ENABLE,
                 1,
                 256,
                 32,
-                CL.CL_FP_DENORM
-                        | CL.CL_FP_INF_NAN
-                        | CL.CL_FP_ROUND_TO_NEAREST
-                        | CL.CL_FP_ROUND_TO_ZERO
-                        | CL.CL_FP_ROUND_TO_INF
-                        | CL.CL_FP_FMA
-                        | CL.CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT,
+                CL10.CL_FP_DENORM
+                        | CL10.CL_FP_INF_NAN
+                        | CL10.CL_FP_ROUND_TO_NEAREST
+                        | CL10.CL_FP_ROUND_TO_ZERO
+                        | CL10.CL_FP_ROUND_TO_INF
+                        | CL10.CL_FP_FMA
+                        | CL12.CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT,
                 32768,
                 32768,
                 16384,
@@ -129,7 +132,7 @@ public class OpenCLDeviceTest {
         // assert
         final String expectedString = """
             --- Info for OpenCL device: NVIDIA GeForce RTX 3070 Laptop GPU ---
-            cl_device_id:                          cl_device_id[0x0]
+            cl_device_id:                          cl_device_id[0x1]
             CL_DEVICE_NAME:                        NVIDIA GeForce RTX 3070 Laptop GPU
             CL_DEVICE_VENDOR:                      NVIDIA Corporation
             CL_DRIVER_VERSION:                     561.19
@@ -296,7 +299,7 @@ public class OpenCLDeviceTest {
 
     private static OpenCLDevice createTestDeviceWithEndianness(boolean endianLittle) {
         return new OpenCLDevice(
-                new cl_device_id(),
+                TEST_DEVICE_ID,
                 "TestDevice",
                 "TestVendor",
                 "1.0",

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformAssume.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformAssume.java
@@ -8,8 +8,8 @@ import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLBuilder;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDevice;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
-import org.jocl.CL;
 import org.junit.jupiter.api.Assumptions;
+import org.lwjgl.opencl.CL10;
 
 public class OpenCLPlatformAssume implements PlatformAssume {
 
@@ -30,12 +30,12 @@ public class OpenCLPlatformAssume implements PlatformAssume {
             "net.ladenthin.bitcoinaddressfinder.test.opencl.cpu.maxGridBits";
 
     public void assumeOpenClLibraryAvailable() {
-        Assumptions.assumeTrue(OpenCLBuilder.isOpenClNativeLibraryLoaded(), "OpenCL library not available");
+        Assumptions.assumeTrue(new OpenCLBuilder().isOpenClLibraryAvailable(), "OpenCL library not available");
     }
 
     public void assumeOneOpenCL2_0OrGreaterDeviceAvailable(List<OpenCLPlatform> openCLPlatforms) {
         Assumptions.assumeTrue(
-                OpenCLBuilder.isOneOpenCL2_0OrGreaterDeviceAvailable(openCLPlatforms),
+                new OpenCLBuilder().isOneOpenCL2_0OrGreaterDeviceAvailable(openCLPlatforms),
                 "One OpenCL 2.0 or greater device available");
     }
 
@@ -49,13 +49,13 @@ public class OpenCLPlatformAssume implements PlatformAssume {
     /**
      * Returns whether at least one available OpenCL device is a GPU.
      *
-     * @return {@code true} if any discovered device reports {@link CL#CL_DEVICE_TYPE_GPU}
+     * @return {@code true} if any discovered device reports {@code CL_DEVICE_TYPE_GPU}
      */
     public boolean hasGpuOpenCLDevice() {
         List<OpenCLPlatform> openCLPlatforms = new OpenCLBuilder().build();
         for (OpenCLPlatform openCLPlatform : openCLPlatforms) {
             for (OpenCLDevice openCLDevice : openCLPlatform.openCLDevices()) {
-                if ((openCLDevice.deviceType() & CL.CL_DEVICE_TYPE_GPU) != 0) {
+                if ((openCLDevice.deviceType() & CL10.CL_DEVICE_TYPE_GPU) != 0) {
                     return true;
                 }
             }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformSelectorTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformSelectorTest.java
@@ -16,11 +16,16 @@ import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDevice;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDeviceSelection;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatformSelector;
-import org.jocl.cl_context_properties;
-import org.jocl.cl_device_id;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClDeviceId;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClPlatformId;
 import org.junit.jupiter.api.Test;
 
 public class OpenCLPlatformSelectorTest {
+    /** Stand-in platform handle: these tests describe the value object, never a real platform. */
+    private static final ClPlatformId TEST_PLATFORM_ID = new ClPlatformId(1L);
+
+    /** Stand-in device handle: these tests describe the value object, never a real device. */
+    private static final ClDeviceId TEST_DEVICE_ID = new ClDeviceId(1L);
 
     // CL_DEVICE_TYPE_CPU = (1 << 1) = 2, CL_DEVICE_TYPE_GPU = (1 << 2) = 4
     private static final long DEVICE_TYPE_CPU = 2L;
@@ -142,12 +147,12 @@ public class OpenCLPlatformSelectorTest {
 
     // <editor-fold defaultstate="collapsed" desc="helper">
     private static OpenCLPlatform createTestPlatform(String name, OpenCLDevice... devices) {
-        return new OpenCLPlatform(name, new cl_context_properties(), ImmutableList.copyOf(devices));
+        return new OpenCLPlatform(TEST_PLATFORM_ID, name, ImmutableList.copyOf(devices));
     }
 
     private static OpenCLDevice createTestDevice(long deviceType) {
         return new OpenCLDevice(
-                new cl_device_id(),
+                TEST_DEVICE_ID,
                 "TestDevice",
                 "TestVendor",
                 "1.0",

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformTest.java
@@ -13,11 +13,13 @@ import static org.hamcrest.Matchers.not;
 import com.google.common.collect.ImmutableList;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLDevice;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLPlatform;
-import org.jocl.cl_context_properties;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClPlatformId;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 public class OpenCLPlatformTest {
+    /** Stand-in platform handle: these tests describe the value object, never a real platform. */
+    private static final ClPlatformId TEST_PLATFORM_ID = new ClPlatformId(1L);
 
     // <editor-fold defaultstate="collapsed" desc="constructor and getters">
     @Test
@@ -28,7 +30,7 @@ public class OpenCLPlatformTest {
                 ImmutableList.<OpenCLDevice>builder().build();
 
         // act
-        OpenCLPlatform platform = new OpenCLPlatform(platformName, new cl_context_properties(), devices);
+        OpenCLPlatform platform = new OpenCLPlatform(TEST_PLATFORM_ID, platformName, devices);
 
         // assert
         assertThat(platform, is(notNullValue()));
@@ -44,8 +46,8 @@ public class OpenCLPlatformTest {
         // arrange
         String platformName = "Platform A";
         OpenCLPlatform platform = new OpenCLPlatform(
+                TEST_PLATFORM_ID,
                 platformName,
-                new cl_context_properties(),
                 ImmutableList.<OpenCLDevice>builder().build());
 
         // act

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.jocl.CL.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.io.Resources;
@@ -32,6 +31,16 @@ import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLContext;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenCLGridResult;
 import net.ladenthin.bitcoinaddressfinder.opencl.OpenClTask;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClApi;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClBufferFlags;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClCommandQueue;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClContext;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClDeviceId;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClKernel;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClMem;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClPlatformId;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.ClProgram;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClBinding;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddresses42;
 import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
 import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
@@ -42,7 +51,6 @@ import net.ladenthin.bitcoinaddressfinder.util.PrivateKeyTooLargeException;
 import org.apache.commons.io.FileUtils;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.crypto.ECKey;
-import org.jocl.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -50,6 +58,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.lwjgl.opencl.CL10;
 
 public class ProbeAddressesOpenCLTest {
 
@@ -91,13 +100,11 @@ public class ProbeAddressesOpenCLTest {
 
     @Test
     @OpenCLTest
-    public void joclTest() {
+    public void sampleKernel_elementwiseMultiply_matchesHostComputation() {
         new OpenCLPlatformAssume().assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
 
-        /**
-         * The source code of the OpenCL program to execute
-         */
-        String programSource = "__kernel void "
+        // arrange
+        final String programSource = "__kernel void "
                 + "sampleKernel(__global const float *a,"
                 + "             __global const float *b,"
                 + "             __global float *c)"
@@ -106,108 +113,69 @@ public class ProbeAddressesOpenCLTest {
                 + "    c[gid] = a[gid] * b[gid];"
                 + "}";
 
-        // Create input- and output data
-        int n = 10;
-        float[] srcArrayA = new float[n];
-        float[] srcArrayB = new float[n];
-        float[] dstArray = new float[n];
+        final int n = 10;
+        final float[] srcArrayA = new float[n];
+        final float[] srcArrayB = new float[n];
         for (int i = 0; i < n; i++) {
             srcArrayA[i] = i;
             srcArrayB[i] = i;
         }
-        Pointer srcA = Pointer.to(srcArrayA);
-        Pointer srcB = Pointer.to(srcArrayB);
-        Pointer dst = Pointer.to(dstArray);
 
-        // The platform, device type and device number
-        // that will be used
-        final int platformIndex = 0;
-        final long deviceType = CL_DEVICE_TYPE_ALL;
-        final int deviceIndex = 0;
+        final ClApi clApi = OpenClBinding.defaultClApi();
+        final ClPlatformId platform = clApi.getPlatformIds().get(0);
+        final ClDeviceId device =
+                clApi.getDeviceIds(platform, CL10.CL_DEVICE_TYPE_ALL).get(0);
+        final ClContext context = clApi.createContext(platform, device);
+        final ClCommandQueue commandQueue = clApi.createCommandQueue(context, device, false);
+        final ClProgram program = clApi.createProgramWithSource(context, new String[] {programSource});
+        clApi.buildProgram(program, device, "");
+        final ClKernel kernel = clApi.createKernel(program, "sampleKernel");
 
-        // Enable exceptions and subsequently omit error checks in this sample
-        CL.setExceptionsEnabled(true);
+        final long byteSize = (long) Float.BYTES * n;
+        final ClMem srcMemA = clApi.createBuffer(context, ClBufferFlags.READ_ONLY, byteSize);
+        final ClMem srcMemB = clApi.createBuffer(context, ClBufferFlags.READ_ONLY, byteSize);
+        final ClMem dstMem = clApi.createBuffer(context, ClBufferFlags.READ_WRITE, byteSize);
 
-        // Obtain the number of platforms
-        int[] numPlatformsArray = new int[1];
-        clGetPlatformIDs(0, null, numPlatformsArray);
-        int numPlatforms = numPlatformsArray[0];
+        final float[] dstArray = new float[n];
+        try {
+            // Floats travel as raw bytes: the binding transfers buffers, and a float payload is just
+            // its native-order bit pattern.
+            final ByteBuffer inputA = ByteBuffer.allocateDirect((int) byteSize).order(ByteOrder.nativeOrder());
+            inputA.asFloatBuffer().put(srcArrayA);
+            final ByteBuffer inputB = ByteBuffer.allocateDirect((int) byteSize).order(ByteOrder.nativeOrder());
+            inputB.asFloatBuffer().put(srcArrayB);
+            clApi.enqueueWriteBuffer(commandQueue, srcMemA, 0L, inputA);
+            clApi.enqueueWriteBuffer(commandQueue, srcMemB, 0L, inputB);
 
-        // Obtain a platform ID
-        cl_platform_id[] platforms = new cl_platform_id[numPlatforms];
-        clGetPlatformIDs(platforms.length, platforms, null);
-        cl_platform_id platform = platforms[platformIndex];
+            clApi.setKernelArg(kernel, 0, srcMemA);
+            clApi.setKernelArg(kernel, 1, srcMemB);
+            clApi.setKernelArg(kernel, 2, dstMem);
 
-        // Initialize the context properties
-        cl_context_properties contextProperties = new cl_context_properties();
-        contextProperties.addProperty(CL_CONTEXT_PLATFORM, platform);
+            // act
+            clApi.enqueueNDRangeKernel(commandQueue, kernel, new long[] {n}, false);
 
-        // Obtain the number of devices for the platform
-        int[] numDevicesArray = new int[1];
-        clGetDeviceIDs(platform, deviceType, 0, null, numDevicesArray);
-        int numDevices = numDevicesArray[0];
+            final ByteBuffer output = ByteBuffer.allocateDirect((int) byteSize).order(ByteOrder.nativeOrder());
+            clApi.enqueueReadBuffer(commandQueue, dstMem, 0L, output, false);
+            clApi.finish(commandQueue);
+            output.position(0);
+            output.asFloatBuffer().get(dstArray);
+        } finally {
+            clApi.releaseMemObject(srcMemA);
+            clApi.releaseMemObject(srcMemB);
+            clApi.releaseMemObject(dstMem);
+            clApi.releaseKernel(kernel);
+            clApi.releaseProgram(program);
+            clApi.releaseCommandQueue(commandQueue);
+            clApi.releaseContext(context);
+        }
 
-        // Obtain a device ID
-        cl_device_id[] devices = new cl_device_id[numDevices];
-        clGetDeviceIDs(platform, deviceType, numDevices, devices, null);
-        cl_device_id device = devices[deviceIndex];
-
-        // Create a context for the selected device
-        cl_context context = clCreateContext(contextProperties, 1, new cl_device_id[] {device}, null, null, null);
-
-        // Create a command-queue for the selected device
-        cl_queue_properties properties = new cl_queue_properties();
-        cl_command_queue commandQueue = clCreateCommandQueueWithProperties(context, device, properties, null);
-
-        // Allocate the memory objects for the input- and output data
-        cl_mem srcMemA = clCreateBuffer(
-                context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, (long) Sizeof.cl_float * n, srcA, null);
-        cl_mem srcMemB = clCreateBuffer(
-                context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, (long) Sizeof.cl_float * n, srcB, null);
-        cl_mem dstMem = clCreateBuffer(context, CL_MEM_READ_WRITE, (long) Sizeof.cl_float * n, null, null);
-
-        // Create the program from the source code
-        cl_program program = clCreateProgramWithSource(context, 1, new String[] {programSource}, null, null);
-
-        // Build the program
-        clBuildProgram(program, 0, null, null, null, null);
-
-        // Create the kernel
-        cl_kernel kernel = clCreateKernel(program, "sampleKernel", null);
-
-        // Set the arguments for the kernel
-        int a = 0;
-        clSetKernelArg(kernel, a++, Sizeof.cl_mem, Pointer.to(srcMemA));
-        clSetKernelArg(kernel, a++, Sizeof.cl_mem, Pointer.to(srcMemB));
-        clSetKernelArg(kernel, a++, Sizeof.cl_mem, Pointer.to(dstMem));
-
-        // Set the work-item dimensions
-        long[] global_work_size = new long[] {n};
-
-        // Execute the kernel
-        clEnqueueNDRangeKernel(commandQueue, kernel, 1, null, global_work_size, null, 0, null, null);
-
-        // Read the output data
-        long cb = (long) n * Sizeof.cl_float;
-        clEnqueueReadBuffer(commandQueue, dstMem, CL_TRUE, 0, cb, dst, 0, null, null);
-
-        // Release kernel, program, and memory objects
-        clReleaseMemObject(srcMemA);
-        clReleaseMemObject(srcMemB);
-        clReleaseMemObject(dstMem);
-        clReleaseKernel(kernel);
-        clReleaseProgram(program);
-        clReleaseCommandQueue(commandQueue);
-        clReleaseContext(context);
-
-        // Verify the result
+        // assert
         boolean passed = true;
         final float epsilon = 1e-7f;
         for (int i = 0; i < n; i++) {
-            float x = dstArray[i];
-            float y = srcArrayA[i] * srcArrayB[i];
-            boolean epsilonEqual = Math.abs(x - y) <= epsilon * Math.abs(x);
-            if (!epsilonEqual) {
+            final float x = dstArray[i];
+            final float y = srcArrayA[i] * srcArrayB[i];
+            if (Math.abs(x - y) > epsilon * Math.abs(x)) {
                 passed = false;
                 break;
             }
@@ -264,7 +232,6 @@ public class ProbeAddressesOpenCLTest {
     public void calcAddrsFixZeroCl_loadWithoutErrors() throws IOException {
         // ATTENTION: BLDEBUG
 
-        int CELLS = 64;
         int ROW_SIZE = 2; // x1, y1
         int COL_SIZE = 2; // rx, ry
 
@@ -272,94 +239,34 @@ public class ProbeAddressesOpenCLTest {
         URL url = Resources.getResource(calcAddrsFixZeroClFileName);
         String calcAddrsFixZeroCl = Resources.toString(url, StandardCharsets.UTF_8);
 
-        // Create input- and output data
-        // out:
-        int[] src_points_out = new int[ACCESS_BUNDLE];
-        int[] src_z_heap = new int[ACCESS_BUNDLE];
-        // in:
-        int[] src_row_in = new int[ACCESS_BUNDLE * ACCESS_STRIDE * ROW_SIZE];
-        int[] src_col_in = new int[ACCESS_BUNDLE * COL_SIZE];
+        final int pointsOutInts = ACCESS_BUNDLE;
+        final int zHeapInts = ACCESS_BUNDLE;
+        final int rowInInts = ACCESS_BUNDLE * ACCESS_STRIDE * ROW_SIZE;
+        final int colInInts = ACCESS_BUNDLE * COL_SIZE;
 
-        Pointer pointsOut = Pointer.to(src_points_out);
-        Pointer zHeap = Pointer.to(src_z_heap);
-        Pointer rowIn = Pointer.to(src_row_in);
-        Pointer colIn = Pointer.to(src_col_in);
+        final ClApi clApi = OpenClBinding.defaultClApi();
+        final ClPlatformId platform = clApi.getPlatformIds().get(0);
+        final ClDeviceId device =
+                clApi.getDeviceIds(platform, CL10.CL_DEVICE_TYPE_ALL).get(0);
+        final ClContext context = clApi.createContext(platform, device);
+        final ClCommandQueue commandQueue = clApi.createCommandQueue(context, device, false);
 
-        // The platform, device type and device number
-        // that will be used
-        final int platformIndex = 0;
-        final long deviceType = CL_DEVICE_TYPE_ALL;
-        final int deviceIndex = 0;
+        final ClMem pointsOutMem =
+                clApi.createBuffer(context, ClBufferFlags.READ_WRITE, (long) Integer.BYTES * pointsOutInts);
+        final ClMem zHeapMem = clApi.createBuffer(context, ClBufferFlags.READ_WRITE, (long) Integer.BYTES * zHeapInts);
+        final ClMem rowInMem = clApi.createBuffer(context, ClBufferFlags.READ_ONLY, (long) Integer.BYTES * rowInInts);
+        final ClMem colInMem = clApi.createBuffer(context, ClBufferFlags.READ_ONLY, (long) Integer.BYTES * colInInts);
 
-        // Enable exceptions and subsequently omit error checks in this sample
-        CL.setExceptionsEnabled(true);
+        final ClProgram program = clApi.createProgramWithSource(context, new String[] {calcAddrsFixZeroCl});
+        clApi.buildProgram(program, device, "");
 
-        // Obtain the number of platforms
-        int[] numPlatformsArray = new int[1];
-        clGetPlatformIDs(0, null, numPlatformsArray);
-        int numPlatforms = numPlatformsArray[0];
+        final ClKernel kernelEcAddGrid = clApi.createKernel(program, "ec_add_grid");
+        clApi.setKernelArg(kernelEcAddGrid, 0, pointsOutMem);
+        clApi.setKernelArg(kernelEcAddGrid, 1, zHeapMem);
+        clApi.setKernelArg(kernelEcAddGrid, 2, rowInMem);
+        clApi.setKernelArg(kernelEcAddGrid, 3, colInMem);
 
-        // Obtain a platform ID
-        cl_platform_id[] platforms = new cl_platform_id[numPlatforms];
-        clGetPlatformIDs(platforms.length, platforms, null);
-        cl_platform_id platform = platforms[platformIndex];
-
-        // Initialize the context properties
-        cl_context_properties contextProperties = new cl_context_properties();
-        contextProperties.addProperty(CL_CONTEXT_PLATFORM, platform);
-
-        // Obtain the number of devices for the platform
-        int[] numDevicesArray = new int[1];
-        clGetDeviceIDs(platform, deviceType, 0, null, numDevicesArray);
-        int numDevices = numDevicesArray[0];
-
-        // Obtain a device ID
-        cl_device_id[] devices = new cl_device_id[numDevices];
-        clGetDeviceIDs(platform, deviceType, numDevices, devices, null);
-        cl_device_id device = devices[deviceIndex];
-
-        // Create a context for the selected device
-        cl_context context = clCreateContext(contextProperties, 1, new cl_device_id[] {device}, null, null, null);
-
-        // Create a command-queue for the selected device
-        cl_queue_properties properties = new cl_queue_properties();
-        cl_command_queue commandQueue = clCreateCommandQueueWithProperties(context, device, properties, null);
-
-        // Allocate the memory objects for the input- and output data
-        cl_mem pointsOutMem = clCreateBuffer(
-                context, CL_MEM_READ_WRITE, (long) Sizeof.cl_int * src_points_out.length, pointsOut, null);
-        cl_mem zHeapMem =
-                clCreateBuffer(context, CL_MEM_READ_WRITE, (long) Sizeof.cl_int * src_z_heap.length, zHeap, null);
-        cl_mem rowInMem = clCreateBuffer(
-                context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, (long) Sizeof.cl_int * src_row_in.length, null, null);
-        cl_mem colInMem = clCreateBuffer(
-                context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, (long) Sizeof.cl_int * src_col_in.length, null, null);
-
-        // Create the program from the source code
-        cl_program program = clCreateProgramWithSource(context, 1, new String[] {calcAddrsFixZeroCl}, null, null);
-
-        // Build the program
-        clBuildProgram(program, 0, null, null, null, null);
-
-        // Create the kernel
-        cl_kernel kernel_ec_add_grid = clCreateKernel(program, "ec_add_grid", null);
-        cl_kernel kernel_heap_invert = clCreateKernel(program, "heap_invert", null);
-        cl_kernel kernel_hash_ec_point_get = clCreateKernel(program, "hash_ec_point_get", null);
-
-        // Set the arguments for the kernel
-        int a = 0;
-        clSetKernelArg(kernel_ec_add_grid, a++, Sizeof.cl_mem, Pointer.to(pointsOutMem));
-        clSetKernelArg(kernel_ec_add_grid, a++, Sizeof.cl_mem, Pointer.to(zHeapMem));
-        clSetKernelArg(kernel_ec_add_grid, a++, Sizeof.cl_mem, Pointer.to(rowInMem));
-        clSetKernelArg(kernel_ec_add_grid, a++, Sizeof.cl_mem, Pointer.to(colInMem));
-
-        // Set the work-item dimensions
-        long[] global_work_size = new long[] {
-            ACCESS_BUNDLE,
-        };
-
-        // Execute the kernel
-        clEnqueueNDRangeKernel(commandQueue, kernel_ec_add_grid, 1, null, global_work_size, null, 0, null, null);
+        clApi.enqueueNDRangeKernel(commandQueue, kernelEcAddGrid, new long[] {ACCESS_BUNDLE}, false);
     }
 
     @ParameterizedTest

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfigurationTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/command/TuneConfigurationTest.java
@@ -37,8 +37,8 @@ import net.ladenthin.bitcoinaddressfinder.configuration.GpuFilterType;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesFiles;
 import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesLMDB;
 import nl.altindag.log.LogCaptor;
-import org.jocl.CL;
 import org.junit.jupiter.api.Test;
+import org.lwjgl.opencl.CL10;
 
 /**
  * Tests for {@link TuneConfiguration}.
@@ -175,10 +175,10 @@ public class TuneConfigurationTest extends LMDBBase {
         // The real topology of a Windows AMD box with a duplicate ICD: two platforms, each exposing
         // both physical GPUs, so four entries for two cards. Same PCIe fingerprint => same card.
         List<TuneConfiguration.DetectedDevice> detected = List.of(
-                new TuneConfiguration.DetectedDevice(0, 0, "gfx1100", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"),
-                new TuneConfiguration.DetectedDevice(0, 1, "gfx1036", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:16:0:0"),
-                new TuneConfiguration.DetectedDevice(1, 0, "gfx1100", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"),
-                new TuneConfiguration.DetectedDevice(1, 1, "gfx1036", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:16:0:0"));
+                new TuneConfiguration.DetectedDevice(0, 0, "gfx1100", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"),
+                new TuneConfiguration.DetectedDevice(0, 1, "gfx1036", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:16:0:0"),
+                new TuneConfiguration.DetectedDevice(1, 0, "gfx1100", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"),
+                new TuneConfiguration.DetectedDevice(1, 1, "gfx1036", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:16:0:0"));
 
         List<TuneConfiguration.DetectedDevice> deduped = TuneConfiguration.dedupePhysicalDevices(detected);
 
@@ -195,9 +195,9 @@ public class TuneConfigurationTest extends LMDBBase {
         // A mining rig: several identical cards in one platform share a name but sit in distinct PCIe
         // slots. They must NOT be collapsed — distinct fingerprints keep them all.
         List<TuneConfiguration.DetectedDevice> detected = List.of(
-                new TuneConfiguration.DetectedDevice(0, 0, "gfx1030", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:1:0:0"),
-                new TuneConfiguration.DetectedDevice(0, 1, "gfx1030", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:2:0:0"),
-                new TuneConfiguration.DetectedDevice(0, 2, "gfx1030", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"));
+                new TuneConfiguration.DetectedDevice(0, 0, "gfx1030", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:1:0:0"),
+                new TuneConfiguration.DetectedDevice(0, 1, "gfx1030", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:2:0:0"),
+                new TuneConfiguration.DetectedDevice(0, 2, "gfx1030", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"));
 
         assertThat(TuneConfiguration.dedupePhysicalDevices(detected), hasSize(3));
     }
@@ -207,8 +207,8 @@ public class TuneConfigurationTest extends LMDBBase {
         // No topology available (null fingerprint): the tuner must never merge on the weaker name
         // signal, so every entry is kept — falling back to today's behaviour, not regressing it.
         List<TuneConfiguration.DetectedDevice> detected = List.of(
-                new TuneConfiguration.DetectedDevice(0, 0, "GPU", CL.CL_DEVICE_TYPE_GPU, null),
-                new TuneConfiguration.DetectedDevice(1, 0, "GPU", CL.CL_DEVICE_TYPE_GPU, null));
+                new TuneConfiguration.DetectedDevice(0, 0, "GPU", CL10.CL_DEVICE_TYPE_GPU, null),
+                new TuneConfiguration.DetectedDevice(1, 0, "GPU", CL10.CL_DEVICE_TYPE_GPU, null));
 
         assertThat(TuneConfiguration.dedupePhysicalDevices(detected), hasSize(2));
     }
@@ -235,8 +235,8 @@ public class TuneConfigurationTest extends LMDBBase {
     @Test
     public void dedupePhysicalDevices_sameFingerprintButDifferentNames_keepsBothRatherThanTrustingIt() {
         List<TuneConfiguration.DetectedDevice> detected = List.of(
-                new TuneConfiguration.DetectedDevice(0, 0, "Radeon RX 7900 XTX", CL.CL_DEVICE_TYPE_GPU, "uuid:dead"),
-                new TuneConfiguration.DetectedDevice(0, 1, "Radeon Graphics", CL.CL_DEVICE_TYPE_GPU, "uuid:dead"));
+                new TuneConfiguration.DetectedDevice(0, 0, "Radeon RX 7900 XTX", CL10.CL_DEVICE_TYPE_GPU, "uuid:dead"),
+                new TuneConfiguration.DetectedDevice(0, 1, "Radeon Graphics", CL10.CL_DEVICE_TYPE_GPU, "uuid:dead"));
 
         List<TuneConfiguration.DetectedDevice> unique = TuneConfiguration.dedupePhysicalDevices(detected);
 
@@ -247,8 +247,8 @@ public class TuneConfigurationTest extends LMDBBase {
     @Test
     public void dedupePhysicalDevices_sameFingerprintAndSameName_stillCollapses() {
         List<TuneConfiguration.DetectedDevice> detected = List.of(
-                new TuneConfiguration.DetectedDevice(0, 0, "gfx1100", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"),
-                new TuneConfiguration.DetectedDevice(1, 0, "gfx1100", CL.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"));
+                new TuneConfiguration.DetectedDevice(0, 0, "gfx1100", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"),
+                new TuneConfiguration.DetectedDevice(1, 0, "gfx1100", CL10.CL_DEVICE_TYPE_GPU, "amd-pcie:3:0:0"));
 
         List<TuneConfiguration.DetectedDevice> unique = TuneConfiguration.dedupePhysicalDevices(detected);
 
@@ -542,8 +542,8 @@ public class TuneConfigurationTest extends LMDBBase {
         CProducerOpenCL prototype = new CProducerOpenCL();
         prototype.keyProducerId = "tuneKeyProducer";
         List<TuneConfiguration.DetectedDevice> devices = List.of(
-                new TuneConfiguration.DetectedDevice(0, 0, "NVIDIA RTX 500 Ada", CL.CL_DEVICE_TYPE_GPU),
-                new TuneConfiguration.DetectedDevice(1, 0, "Intel(R) Arc(TM) Pro Graphics", CL.CL_DEVICE_TYPE_GPU));
+                new TuneConfiguration.DetectedDevice(0, 0, "NVIDIA RTX 500 Ada", CL10.CL_DEVICE_TYPE_GPU),
+                new TuneConfiguration.DetectedDevice(1, 0, "Intel(R) Arc(TM) Pro Graphics", CL10.CL_DEVICE_TYPE_GPU));
 
         List<CProducerOpenCL> templates = TuneConfiguration.templatesForDevices(devices, prototype);
 
@@ -568,7 +568,7 @@ public class TuneConfigurationTest extends LMDBBase {
         prototype.gpuFilterType = GpuFilterType.FUSE_16;
 
         List<CProducerOpenCL> templates = TuneConfiguration.templatesForDevices(
-                List.of(new TuneConfiguration.DetectedDevice(2, 1, "GPU", CL.CL_DEVICE_TYPE_GPU)), prototype);
+                List.of(new TuneConfiguration.DetectedDevice(2, 1, "GPU", CL10.CL_DEVICE_TYPE_GPU)), prototype);
 
         assertThat(templates, hasSize(1));
         assertThat(templates.get(0).maxResultReaderThreads, is(equalTo(7)));
@@ -584,8 +584,8 @@ public class TuneConfigurationTest extends LMDBBase {
         prototype.keyProducerId = "tuneKeyProducer";
         List<CProducerOpenCL> templates = TuneConfiguration.templatesForDevices(
                 List.of(
-                        new TuneConfiguration.DetectedDevice(0, 0, "A", CL.CL_DEVICE_TYPE_GPU),
-                        new TuneConfiguration.DetectedDevice(1, 0, "B", CL.CL_DEVICE_TYPE_GPU)),
+                        new TuneConfiguration.DetectedDevice(0, 0, "A", CL10.CL_DEVICE_TYPE_GPU),
+                        new TuneConfiguration.DetectedDevice(1, 0, "B", CL10.CL_DEVICE_TYPE_GPU)),
                 prototype);
 
         templates.get(0).batchSizeInBits = 22;
@@ -601,8 +601,8 @@ public class TuneConfigurationTest extends LMDBBase {
      */
     @Test
     public void detectedDevice_cpuRuntime_isNotTreatedAsAGpu() {
-        assertThat(new TuneConfiguration.DetectedDevice(0, 0, "pocl CPU", CL.CL_DEVICE_TYPE_CPU).isGpu(), is(false));
-        assertThat(new TuneConfiguration.DetectedDevice(0, 0, "Radeon", CL.CL_DEVICE_TYPE_GPU).isGpu(), is(true));
+        assertThat(new TuneConfiguration.DetectedDevice(0, 0, "pocl CPU", CL10.CL_DEVICE_TYPE_CPU).isGpu(), is(false));
+        assertThat(new TuneConfiguration.DetectedDevice(0, 0, "Radeon", CL10.CL_DEVICE_TYPE_GPU).isGpu(), is(true));
     }
     // </editor-fold>
 

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaResultListenerTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaResultListenerTest.java
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.File;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import net.ladenthin.bitcoinaddressfinder.LMDBPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.configuration.CConsumerJava;
+import net.ladenthin.bitcoinaddressfinder.configuration.CLMDBConfigurationReadOnly;
+import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.ResultListener;
+import net.ladenthin.bitcoinaddressfinder.model.PublicKeyBytes;
+import net.ladenthin.bitcoinaddressfinder.persistence.PersistenceUtils;
+import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesFiles;
+import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesLMDB;
+import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
+import net.ladenthin.bitcoinaddressfinder.util.KeyUtility;
+import net.ladenthin.bitcoinaddressfinder.util.NetworkParameterFactory;
+import org.bitcoinj.base.Network;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests that the consumer reports every checked batch, not only the ones that produced a hit.
+ *
+ * <p>This is the feedback channel the browser-driven scanning mode is built on. Reporting only hits
+ * would leave a client unable to tell "range checked, nothing there" from "range never checked" —
+ * indistinguishable states that make an automated from/to sweep unsafe, because a range silently
+ * dropped on shutdown looks exactly like a clean one. One event per checked batch removes the
+ * ambiguity and doubles as the completion signal.
+ *
+ * <p>The event is emitted after the batch has actually been checked against the database, so it is
+ * exact: there is no dispatch-ahead lag for a client to compensate for.
+ */
+class ConsumerJavaResultListenerTest {
+
+    @TempDir
+    public Path folder;
+
+    private final Network network = new NetworkParameterFactory().getNetwork();
+    private final KeyUtility keyUtility = new KeyUtility(network, new ByteBufferUtility(false));
+    private final PersistenceUtils persistenceUtils = new PersistenceUtils(network);
+
+    /** An arbitrary aligned base standing in for the start of a swept grid. */
+    private static final BigInteger SECRET_BASE = BigInteger.valueOf(0x4000L);
+
+    /** Collects every reported batch so the assertions can inspect them in order. */
+    private static final class RecordingResultListener implements ResultListener {
+
+        private final List<BatchResult> received = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onBatchChecked(BatchResult batchResult) {
+            received.add(batchResult);
+        }
+
+        List<BatchResult> received() {
+            return new ArrayList<>(received);
+        }
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="onBatchChecked">
+    @Test
+    void consumeOneCycle_batchWithoutHit_reportsTheCheckedBatchAnyway() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+
+        // arrange
+        final RecordingResultListener listener = new RecordingResultListener();
+        final ConsumerJava consumerJava = createConsumer(listener);
+        try {
+            consumerJava.initLMDB();
+            final PublicKeyBytes[] batch = new PublicKeyBytes[] {PublicKeyBytes.fromPrivate(BigInteger.valueOf(73))};
+
+            // act
+            consumerJava.consumeKeys(batch, SECRET_BASE);
+            consumerJava.consumeOneCycle(ByteBuffer.allocateDirect(OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES));
+
+            // pre-assert
+            assertThat(listener.received(), hasSize(1));
+
+            // assert
+            final BatchResult reported = listener.received().get(0);
+            assertThat(reported.secretBase(), is(equalTo(SECRET_BASE)));
+            assertThat(reported.checkedCount(), is(equalTo(batch.length)));
+            assertThat(reported.hits(), is(empty()));
+        } finally {
+            consumerJava.interrupt();
+        }
+    }
+
+    @Test
+    void consumeOneCycle_batchWithoutSecretBase_reportsTheBatchWithoutABase() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+
+        // arrange
+        final RecordingResultListener listener = new RecordingResultListener();
+        final ConsumerJava consumerJava = createConsumer(listener);
+        try {
+            consumerJava.initLMDB();
+            final PublicKeyBytes[] batch = new PublicKeyBytes[] {PublicKeyBytes.fromPrivate(BigInteger.valueOf(73))};
+
+            // act: the non-increment path supplies independent secrets, so no common base exists
+            consumerJava.consumeKeys(batch, null);
+            consumerJava.consumeOneCycle(ByteBuffer.allocateDirect(OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES));
+
+            // pre-assert
+            assertThat(listener.received(), hasSize(1));
+
+            // assert
+            assertThat(listener.received().get(0).secretBase(), is(nullValue()));
+        } finally {
+            consumerJava.interrupt();
+        }
+    }
+
+    @Test
+    void consumeOneCycle_twoBatches_reportsOneEventPerBatch() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+
+        // arrange
+        final RecordingResultListener listener = new RecordingResultListener();
+        final ConsumerJava consumerJava = createConsumer(listener);
+        try {
+            consumerJava.initLMDB();
+            final ByteBuffer reuseable = ByteBuffer.allocateDirect(OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES);
+            final BigInteger secondBase = SECRET_BASE.add(BigInteger.valueOf(0x4000L));
+
+            // act
+            consumerJava.consumeKeys(
+                    new PublicKeyBytes[] {PublicKeyBytes.fromPrivate(BigInteger.valueOf(73))}, SECRET_BASE);
+            consumerJava.consumeOneCycle(reuseable);
+            consumerJava.consumeKeys(
+                    new PublicKeyBytes[] {PublicKeyBytes.fromPrivate(BigInteger.valueOf(74))}, secondBase);
+            consumerJava.consumeOneCycle(reuseable);
+
+            // assert
+            final List<BigInteger> reportedBases =
+                    listener.received().stream().map(BatchResult::secretBase).toList();
+            assertThat(reportedBases, contains(SECRET_BASE, secondBase));
+        } finally {
+            consumerJava.interrupt();
+        }
+    }
+
+    @Test
+    void consumeOneCycle_noListenerConfigured_noExceptionThrown() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+
+        // arrange: without a configured listener nothing about the pipeline may change
+        final ConsumerJava consumerJava = createConsumer();
+        try {
+            consumerJava.initLMDB();
+
+            // act
+            consumerJava.consumeKeys(
+                    new PublicKeyBytes[] {PublicKeyBytes.fromPrivate(BigInteger.valueOf(73))}, SECRET_BASE);
+            consumerJava.consumeOneCycle(ByteBuffer.allocateDirect(OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES));
+
+            // assert
+            assertThat(consumerJava.persistence, is(notNullValue()));
+        } finally {
+            consumerJava.interrupt();
+        }
+    }
+    // </editor-fold>
+
+    /**
+     * Builds a consumer backed by a small on-disk database.
+     *
+     * @param resultListeners the listeners to notify, possibly none
+     * @return the consumer under test
+     * @throws Exception if the test database cannot be created
+     */
+    private ConsumerJava createConsumer(ResultListener... resultListeners) throws Exception {
+        final TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
+        final TestAddressesFiles testAddresses = new TestAddressesFiles(false);
+        final File lmdbFolderPath = testAddressesLMDB.createTestLMDB(folder, testAddresses, true, false);
+
+        final CConsumerJava cConsumerJava = new CConsumerJava();
+        cConsumerJava.lmdbConfigurationReadOnly = new CLMDBConfigurationReadOnly();
+        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = lmdbFolderPath.getAbsolutePath();
+
+        return new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils, List.of(resultListeners));
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/ConsumerJavaTest.java
@@ -135,7 +135,7 @@ public class ConsumerJavaTest {
             // through the live env rather than throwing Env$AlreadyClosedException.
             assertThat(consumerJava.persistence, is(notNullValue()));
             ByteBuffer buffer = ByteBuffer.allocateDirect(OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES);
-            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73());
+            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73(), null);
             consumerJava.consumeOneCycle(buffer);
         } finally {
             consumerJava.interrupt();
@@ -166,7 +166,7 @@ public class ConsumerJavaTest {
             // through the live env rather than throwing Env$AlreadyClosedException.
             assertThat(consumerJava.persistence, is(notNullValue()));
             ByteBuffer buffer = ByteBuffer.allocateDirect(OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES);
-            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73());
+            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73(), null);
             consumerJava.consumeOneCycle(buffer);
         } finally {
             consumerJava.interrupt();
@@ -315,7 +315,7 @@ public class ConsumerJavaTest {
         consumerJava.initLMDB();
         try {
             // enqueue one batch the cycle must drain and process
-            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73());
+            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73(), null);
             ByteBuffer buffer = ByteBuffer.allocateDirect(OpenClKernelConstants.RIPEMD160_HASH_NUM_BYTES);
 
             // act
@@ -340,14 +340,14 @@ public class ConsumerJavaTest {
         ConsumerJava consumerJava = new ConsumerJava(cConsumerJava, keyUtility, persistenceUtils);
 
         // first enqueue fills the only slot; remaining capacity was 1 beforehand -> not counted
-        consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73());
+        consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73(), null);
         assertThat(consumerJava.producerBlockedCount.get(), is(equalTo(0L)));
 
         // a second producer finds the queue full -> counts the block, then parks in put()
         ExecutorService producer = Executors.newSingleThreadExecutor();
         try {
             producer.submit(() -> {
-                consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73());
+                consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73(), null);
                 return null;
             });
 
@@ -471,7 +471,7 @@ public class ConsumerJavaTest {
         consumerJava.initLMDB();
 
         // add keys
-        consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73());
+        consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73(), null);
 
         // pre-assert, assert the keys queue is not empty
         assertThat(consumerJava.keysQueueSize(), is(equalTo(1)));
@@ -738,7 +738,7 @@ public class ConsumerJavaTest {
 
         PublicKeyBytes invalidPublicKeyBytes = PublicKeyBytes.INVALID_KEY_ONE;
         PublicKeyBytes[] publicKeyBytesArray = new PublicKeyBytes[] {invalidPublicKeyBytes};
-        consumerJava.consumeKeys(publicKeyBytesArray);
+        consumerJava.consumeKeys(publicKeyBytesArray, null);
         consumerJava.consumeKeys(createHash160ByteBuffer());
         consumerJava.interrupt();
     }
@@ -769,7 +769,7 @@ public class ConsumerJavaTest {
         PublicKeyBytes[] publicKeyBytesArray = new PublicKeyBytes[] {invalidPublicKeyBytes};
 
         try (LogCaptor logCaptor = LogCaptor.forClass(PublicKeyBytes.class)) {
-            consumerJava.consumeKeys(publicKeyBytesArray);
+            consumerJava.consumeKeys(publicKeyBytesArray, null);
             consumerJava.consumeKeys(createHash160ByteBuffer());
 
             // assert
@@ -845,7 +845,7 @@ public class ConsumerJavaTest {
         consumerJava.initLMDB();
 
         try (LogCaptor logCaptor = LogCaptor.forClass(ConsumerJava.class)) {
-            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73());
+            consumerJava.consumeKeys(createExamplePublicKeyBytesfromPrivateKey73(), null);
             consumerJava.consumeKeys(createHash160ByteBuffer());
 
             // assert

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/LMDBPersistencePerformanceTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/consumer/LMDBPersistencePerformanceTest.java
@@ -122,7 +122,7 @@ public class LMDBPersistencePerformanceTest {
             threadPoolExecutor.submit(() -> {
                 while (producerShouldRun.get()) {
                     try {
-                        consumerJava.consumeKeys(publicKeyByteses);
+                        consumerJava.consumeKeys(publicKeyByteses, null);
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/engine/FinderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/engine/FinderTest.java
@@ -178,6 +178,52 @@ public class FinderTest {
         // assert the waiting time is over, substract imprecision
         assertThat(waitTime, is(greaterThan(AwaitTimeTests.AWAIT_DURATION.minus(AwaitTimeTests.IMPRECISION))));
     }
+    /**
+     * A completed run must leave nothing of the finder's own running.
+     *
+     * <p>This is the unit-level guard for a reproduced defect: after a producer exhausted its key
+     * range the process logged {@code Main#run end.} and then never exited. The threads holding it
+     * open were ones the finder had started and never released - a producer's result-reader pool and
+     * the key producers' reader threads, all non-daemon. Releasing them happened only in
+     * {@link Finder#interrupt()}, which on the ordinary completion path ran solely from the JVM
+     * shutdown hook; and a shutdown hook cannot run until every non-daemon thread has already ended,
+     * so the release that would have ended them was unreachable.
+     *
+     * <p>The two collections asserted here are emptied by exactly that release step, which makes them
+     * the observable proxy for "the JVM can now exit" in a test that must not depend on a GPU or on
+     * counting live threads.
+     */
+    @Test
+    public void shutdownAndAwaitTermination_producerFinished_producersAndKeyProducersReleased() throws Exception {
+        // arrange
+        CFinder cFinder = new CFinder();
+        String keyProducerId = "exampleId";
+        final CProducerJava cProducerJava = new CProducerJava();
+        cProducerJava.keyProducerId = keyProducerId;
+        // One batch, then the producer ends by itself - the completion path under test.
+        cProducerJava.runOnce = true;
+        cFinder.producerJava.add(cProducerJava);
+        configureKeyProducerJavaRandom(keyProducerId, cFinder);
+        configureConsumerJava(cFinder);
+
+        Finder finder = new Finder(cFinder);
+        finder.startKeyProducer();
+        finder.startConsumer();
+        finder.configureProducer();
+        finder.initProducer();
+        finder.startProducer();
+
+        // pre-assert
+        assertThat(finder.getAllProducers(), is(not(empty())));
+        assertThat(finder.getKeyProducers().values(), is(not(empty())));
+
+        // act
+        finder.shutdownAndAwaitTermination();
+
+        // assert
+        assertThat(finder.getAllProducers(), is(empty()));
+        assertThat(finder.getKeyProducers().values(), is(empty()));
+    }
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="getAllProducers">

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/engine/FinderWebSocketRoundtripTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/engine/FinderWebSocketRoundtripTest.java
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.engine;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.math.BigInteger;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.LMDBPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.configuration.CConsumerJava;
+import net.ladenthin.bitcoinaddressfinder.configuration.CFinder;
+import net.ladenthin.bitcoinaddressfinder.configuration.CKeyProducerJavaWebSocket;
+import net.ladenthin.bitcoinaddressfinder.configuration.CLMDBConfigurationReadOnly;
+import net.ladenthin.bitcoinaddressfinder.configuration.CProducerJava;
+import net.ladenthin.bitcoinaddressfinder.constants.OpenClKernelConstants;
+import net.ladenthin.bitcoinaddressfinder.keyproducer.ConnectionUtils;
+import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesFiles;
+import net.ladenthin.bitcoinaddressfinder.staticaddresses.TestAddressesLMDB;
+import net.ladenthin.bitcoinaddressfinder.util.ByteBufferUtility;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Feeds a range in and reads the outcome back out — over one WebSocket, as a browser page would.
+ *
+ * <p>The pieces are covered separately elsewhere; what only shows up here is whether they line up:
+ * the server accepting a base before the producers exist, the grid configuration reaching a client
+ * that connected first, and the checked batch coming back on the very same connection.
+ */
+class FinderWebSocketRoundtripTest {
+
+    /** Upper bound for every wait; exceeding it is a failure, not a slow machine. */
+    private static final int AWAIT_SECONDS = 30;
+
+    /** A small grid keeps the CPU producer's single batch fast. */
+    private static final int BATCH_SIZE_IN_BITS = 8;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @TempDir
+    public Path folder;
+
+    /** Collects everything the server sends, in order. */
+    private static final class RecordingClient extends WebSocketClient {
+
+        private final LinkedBlockingQueue<String> messages = new LinkedBlockingQueue<>();
+
+        RecordingClient(URI uri) {
+            super(uri);
+        }
+
+        @Override
+        public void onOpen(ServerHandshake handshake) {
+            // nothing to do
+        }
+
+        @Override
+        public void onMessage(String message) {
+            messages.add(message);
+        }
+
+        @Override
+        public void onClose(int code, String reason, boolean remote) {
+            // nothing to do
+        }
+
+        @Override
+        public void onError(Exception ex) {
+            // surfaced through a missing expected message
+        }
+
+        String awaitMessageOfType(String type, ObjectMapper mapper) throws Exception {
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(AWAIT_SECONDS);
+            while (System.nanoTime() < deadline) {
+                final String raw = messages.poll(1, TimeUnit.SECONDS);
+                if (raw == null) {
+                    continue;
+                }
+                final JsonNode node = mapper.readTree(raw);
+                if (type.equals(node.path("type").asText())) {
+                    return raw;
+                }
+            }
+            return null;
+        }
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="roundtrip">
+    @Test
+    void webSocket_baseSentByClient_checkedBatchComesBackOnTheSameConnection() throws Exception {
+        new LMDBPlatformAssume().assumeLMDBExecution();
+
+        // arrange
+        final int port = freePort();
+        final CFinder cFinder = buildConfiguration(port);
+        final Finder finder = new Finder(cFinder);
+        final RecordingClient client = new RecordingClient(URI.create("ws://127.0.0.1:" + port));
+        try {
+            finder.startKeyProducer();
+            // The server binds on a background thread, so wait for the port rather than racing it.
+            ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_SECONDS * 1000);
+
+            // The client is deliberately here before the producers exist, which is the situation the
+            // catch-up greeting is for.
+            assertThat(client.connectBlocking(AWAIT_SECONDS, TimeUnit.SECONDS), is(true));
+
+            finder.startConsumer();
+            finder.configureProducer();
+            finder.initProducer();
+
+            // assert: the grid configuration arrives even though the client connected first
+            final String configMessage = client.awaitMessageOfType("config", objectMapper);
+            assertThat(configMessage, is(notNullValue()));
+            final JsonNode config = objectMapper.readTree(configMessage);
+            assertThat(config.get("batchSizeInBits").asInt(), is(equalTo(BATCH_SIZE_IN_BITS)));
+
+            // act: send one base, exactly as the page does
+            finder.startProducer();
+            client.send(secretBaseMessage(BigInteger.valueOf(0x100L)));
+
+            // assert: the checked batch comes back on the same connection
+            final String batchMessage = client.awaitMessageOfType("batch", objectMapper);
+            assertThat(batchMessage, is(notNullValue()));
+            final JsonNode batch = objectMapper.readTree(batchMessage);
+            assertThat(batch.get("checkedCount").asInt(), is(equalTo(1 << BATCH_SIZE_IN_BITS)));
+            assertThat(batch.get("secretBase"), is(notNullValue()));
+        } finally {
+            client.closeBlocking();
+            // An interactively fed run never exhausts its source, so it ends the way the user ends
+            // it: the shutdown hook interrupts, and the awaiting main thread then completes. Calling
+            // only the await would wait for a producer that is parked on the next base forever.
+            finder.interrupt();
+            finder.shutdownAndAwaitTermination();
+        }
+    }
+    // </editor-fold>
+
+    /**
+     * Encodes a secret base the way the WebSocket key producer expects it: fixed-width raw bytes.
+     *
+     * @param secretBase the base to send
+     * @return the message payload
+     */
+    private static ByteBuffer secretBaseMessage(BigInteger secretBase) {
+        return ByteBuffer.wrap(ByteBufferUtility.bigIntegerToFixedLengthBytes(
+                secretBase, OpenClKernelConstants.PRIVATE_KEY_MAX_NUM_BYTES));
+    }
+
+    /**
+     * Builds a configuration whose only key source is the WebSocket, as the browser-driven mode uses.
+     *
+     * @param port the port to serve on
+     * @return the finder configuration
+     * @throws Exception if the test database cannot be created
+     */
+    private CFinder buildConfiguration(int port) throws Exception {
+        final TestAddressesLMDB testAddressesLMDB = new TestAddressesLMDB();
+        final TestAddressesFiles testAddresses = new TestAddressesFiles(false);
+        final File lmdbFolderPath = testAddressesLMDB.createTestLMDB(folder, testAddresses, true, false);
+
+        final CFinder cFinder = new CFinder();
+        // Bound the wait so a regression shows up as a failing test rather than a killed fork.
+        cFinder.awaitTerminateSeconds = AWAIT_SECONDS;
+
+        final CKeyProducerJavaWebSocket webSocket = new CKeyProducerJavaWebSocket();
+        webSocket.keyProducerId = "browser";
+        webSocket.port = port;
+        // Block instead of ending the run when the user pauses; the browser drives the pace.
+        webSocket.timeoutMillis = -1;
+        webSocket.broadcastResults = true;
+        cFinder.keyProducerJavaWebSocket.add(webSocket);
+
+        final CProducerJava producerJava = new CProducerJava();
+        producerJava.keyProducerId = "browser";
+        producerJava.batchSizeInBits = BATCH_SIZE_IN_BITS;
+        producerJava.batchUsePrivateKeyIncrement = true;
+        cFinder.producerJava.add(producerJava);
+
+        final CConsumerJava cConsumerJava = new CConsumerJava();
+        cConsumerJava.lmdbConfigurationReadOnly = new CLMDBConfigurationReadOnly();
+        cConsumerJava.lmdbConfigurationReadOnly.lmdbDirectory = lmdbFolderPath.getAbsolutePath();
+        cFinder.consumerJava = cConsumerJava;
+
+        return cFinder;
+    }
+
+    /**
+     * Picks a free TCP port, so parallel runs cannot collide on a fixed one.
+     *
+     * @return a port that was free at the moment of asking
+     * @throws Exception if no port could be reserved
+     */
+    private static int freePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/BatchResultJsonFormatterTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/BatchResultJsonFormatterTest.java
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigInteger;
+import java.util.List;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.Hit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link BatchResultJsonFormatter}.
+ *
+ * <p>The wire format is shared by every transport that reports results, so it is pinned here once
+ * rather than re-asserted per transport. Clients parse these field names; changing one silently
+ * breaks every consumer, which is why the assertions name each of them explicitly.
+ */
+class BatchResultJsonFormatterTest {
+
+    private final BatchResultJsonFormatter formatter = new BatchResultJsonFormatter();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // <editor-fold defaultstate="collapsed" desc="formatBatch">
+    @Test
+    void formatBatch_withoutHits_reportsTheRangeAndAnEmptyHitList() throws Exception {
+        // act
+        final JsonNode node = objectMapper.readTree(
+                formatter.formatBatch(new BatchResult(BigInteger.valueOf(0x4000L), 4096, List.of())));
+
+        // assert
+        assertThat(node.get("type").asText(), is(equalTo("batch")));
+        assertThat(node.get("secretBase").asText(), is(equalTo("4000")));
+        assertThat(node.get("checkedCount").asInt(), is(equalTo(4096)));
+        assertThat(node.get("hits").size(), is(equalTo(0)));
+    }
+
+    @Test
+    void formatBatch_withoutSecretBase_reportsNull() throws Exception {
+        // act
+        final JsonNode node = objectMapper.readTree(formatter.formatBatch(new BatchResult(null, 1, List.of())));
+
+        // assert
+        assertThat(node.get("secretBase").isNull(), is(true));
+    }
+
+    @Test
+    void formatBatch_withHit_reportsEveryHitField() throws Exception {
+        // arrange
+        final Hit hit = new Hit(BigInteger.valueOf(73), "aabb", "1TestAddress", true, false);
+
+        // act
+        final JsonNode node =
+                objectMapper.readTree(formatter.formatBatch(new BatchResult(BigInteger.ONE, 1, List.of(hit))));
+
+        // assert
+        final JsonNode reported = node.get("hits").get(0);
+        assertThat(reported.get("privateKey").asText(), is(equalTo("49")));
+        assertThat(reported.get("hash160Hex").asText(), is(equalTo("aabb")));
+        assertThat(reported.get("address").asText(), is(equalTo("1TestAddress")));
+        assertThat(reported.get("compressed").asBoolean(), is(true));
+        assertThat(reported.get("vanity").asBoolean(), is(false));
+    }
+
+    @Test
+    void formatBatch_anyBatch_isASingleLine() throws Exception {
+        // Line-delimited transports frame on the newline, so an embedded one would split a message.
+        // act
+        final String json = formatter.formatBatch(
+                new BatchResult(BigInteger.ONE, 1, List.of(new Hit(BigInteger.ONE, "aa", "addr", false, false))));
+
+        // assert
+        assertThat(json.contains("\n"), is(false));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="formatConfiguration">
+    @Test
+    void formatConfiguration_whenCalled_reportsGridAndSecretLength() throws Exception {
+        // act
+        final JsonNode node = objectMapper.readTree(formatter.formatConfiguration(18, true));
+
+        // assert
+        assertThat(node.get("type").asText(), is(equalTo("config")));
+        assertThat(node.get("batchSizeInBits").asInt(), is(equalTo(18)));
+        assertThat(node.get("batchUsePrivateKeyIncrement").asBoolean(), is(true));
+        assertThat(node.get("secretByteLength").asInt(), is(equalTo(32)));
+    }
+    // </editor-fold>
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/SocketResultBroadcasterTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/SocketResultBroadcasterTest.java
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.Hit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives {@link SocketResultBroadcaster} through real TCP clients.
+ *
+ * <p>Two properties matter here and nowhere else. First, this transport had no notion of several
+ * peers at all — the key producer serves exactly one — so "reaches every listener" is new behaviour
+ * and is asserted with two clients at once. Second, the outbound direction needs framing that the
+ * inbound one does not: secrets arrive as fixed-width records, results are variable-length JSON, so
+ * they are newline-delimited and a reader must be able to rely on that.
+ */
+class SocketResultBroadcasterTest {
+
+    /** Upper bound for every read; exceeding it is a failure, not a slow machine. */
+    private static final int AWAIT_MILLIS = 15_000;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // <editor-fold defaultstate="collapsed" desc="onBatchChecked">
+    @Test
+    void onBatchChecked_twoConnectedClients_bothReceiveTheSameLine() throws Exception {
+        // arrange
+        final int port = freePort();
+        final SocketResultBroadcaster broadcaster = new SocketResultBroadcaster(port);
+        try {
+            broadcaster.start();
+            ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_MILLIS);
+
+            try (Socket first = connect(port);
+                    Socket second = connect(port)) {
+                final BufferedReader firstReader = reader(first);
+                final BufferedReader secondReader = reader(second);
+                broadcaster.awaitClientCount(2, AWAIT_MILLIS);
+
+                // act
+                broadcaster.onBatchChecked(new BatchResult(BigInteger.valueOf(0x4000L), 4096, List.of()));
+
+                // assert
+                for (BufferedReader clientReader : List.of(firstReader, secondReader)) {
+                    final String line = clientReader.readLine();
+                    assertThat(line, is(notNullValue()));
+                    final JsonNode message = objectMapper.readTree(line);
+                    assertThat(message.get("type").asText(), is(equalTo("batch")));
+                    assertThat(message.get("checkedCount").asInt(), is(equalTo(4096)));
+                }
+            }
+        } finally {
+            broadcaster.close();
+        }
+    }
+
+    @Test
+    void onBatchChecked_batchWithHit_clientReceivesTheKeyMaterial() throws Exception {
+        // arrange
+        final int port = freePort();
+        final SocketResultBroadcaster broadcaster = new SocketResultBroadcaster(port);
+        try {
+            broadcaster.start();
+            ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_MILLIS);
+
+            try (Socket client = connect(port)) {
+                final BufferedReader clientReader = reader(client);
+                broadcaster.awaitClientCount(1, AWAIT_MILLIS);
+                final Hit hit = new Hit(BigInteger.valueOf(73), "aabb", "1TestAddress", true, false);
+
+                // act
+                broadcaster.onBatchChecked(new BatchResult(BigInteger.ONE, 1, List.of(hit)));
+
+                // assert
+                final JsonNode message = objectMapper.readTree(clientReader.readLine());
+                assertThat(message.get("hits").get(0).get("privateKey").asText(), is(equalTo("49")));
+            }
+        } finally {
+            broadcaster.close();
+        }
+    }
+
+    @Test
+    void onBatchChecked_clientDisconnected_remainingClientStillReceives() throws Exception {
+        // A dead peer must not take the channel down with it: the write to it fails, and the healthy
+        // client must still be served.
+
+        // arrange
+        final int port = freePort();
+        final SocketResultBroadcaster broadcaster = new SocketResultBroadcaster(port);
+        try {
+            broadcaster.start();
+            ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_MILLIS);
+
+            final Socket leaving = connect(port);
+            try (Socket staying = connect(port)) {
+                final BufferedReader stayingReader = reader(staying);
+                broadcaster.awaitClientCount(2, AWAIT_MILLIS);
+                leaving.close();
+
+                // act: the first send may still succeed into the dead socket's buffer
+                broadcaster.onBatchChecked(new BatchResult(BigInteger.ONE, 1, List.of()));
+                broadcaster.onBatchChecked(new BatchResult(BigInteger.TWO, 2, List.of()));
+
+                // assert
+                assertThat(stayingReader.readLine(), is(notNullValue()));
+                assertThat(stayingReader.readLine(), is(notNullValue()));
+            }
+        } finally {
+            broadcaster.close();
+        }
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="announceConfiguration">
+    @Test
+    void announceConfiguration_clientConnectsAfterwards_receivesItOnConnect() throws Exception {
+        // arrange
+        final int port = freePort();
+        final SocketResultBroadcaster broadcaster = new SocketResultBroadcaster(port);
+        try {
+            broadcaster.announceConfiguration(18, true);
+            broadcaster.start();
+            ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_MILLIS);
+
+            // act
+            try (Socket client = connect(port)) {
+                final JsonNode message = objectMapper.readTree(reader(client).readLine());
+
+                // assert
+                assertThat(message.get("type").asText(), is(equalTo("config")));
+                assertThat(message.get("batchSizeInBits").asInt(), is(equalTo(18)));
+            }
+        } finally {
+            broadcaster.close();
+        }
+    }
+
+    @Test
+    void announceConfiguration_clientConnectedBefore_isCaughtUp() throws Exception {
+        // arrange
+        final int port = freePort();
+        final SocketResultBroadcaster broadcaster = new SocketResultBroadcaster(port);
+        try {
+            broadcaster.start();
+            ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_MILLIS);
+
+            try (Socket client = connect(port)) {
+                final BufferedReader clientReader = reader(client);
+                broadcaster.awaitClientCount(1, AWAIT_MILLIS);
+
+                // act: the configuration only becomes known now
+                broadcaster.announceConfiguration(18, true);
+
+                // assert
+                final JsonNode message = objectMapper.readTree(clientReader.readLine());
+                assertThat(message.get("type").asText(), is(equalTo("config")));
+            }
+        } finally {
+            broadcaster.close();
+        }
+    }
+    // </editor-fold>
+
+    /**
+     * Opens a client connection with a bounded read timeout.
+     *
+     * @param port the port to connect to
+     * @return the connected socket
+     * @throws Exception if the connection cannot be established
+     */
+    private static Socket connect(int port) throws Exception {
+        final Socket socket = new Socket("127.0.0.1", port);
+        socket.setSoTimeout(AWAIT_MILLIS);
+        return socket;
+    }
+
+    /**
+     * Wraps a socket in a line reader, matching the newline framing of the outbound direction.
+     *
+     * @param socket the connected socket
+     * @return a reader over its input
+     * @throws Exception if the stream cannot be opened
+     */
+    private static BufferedReader reader(Socket socket) throws Exception {
+        return new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Picks a free TCP port, so parallel runs cannot collide on a fixed one.
+     *
+     * @return a port that was free at the moment of asking
+     * @throws Exception if no port could be reserved
+     */
+    private static int freePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/WebSocketResultBroadcasterTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/WebSocketResultBroadcasterTest.java
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigInteger;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.Hit;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives {@link WebSocketResultBroadcaster} through a real WebSocket connection.
+ *
+ * <p>A real client rather than a mocked transport, because the parts that actually break live in the
+ * transport: whether a client that connects before the configuration is known still receives it, and
+ * whether a batch without a hit is reported at all. Both are the difference between a browser page
+ * that can sweep a range safely and one that silently loses ground.
+ */
+class WebSocketResultBroadcasterTest {
+
+    /** Upper bound for every wait on a message; exceeding it is a failure, not a slow machine. */
+    private static final int AWAIT_SECONDS = 15;
+
+    /** Grid size announced in the greeting, mirroring a producer's batchSizeInBits. */
+    private static final int BATCH_SIZE_IN_BITS = 12;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Collects everything the server sends, in order. */
+    private static final class RecordingClient extends WebSocketClient {
+
+        private final LinkedBlockingQueue<String> messages = new LinkedBlockingQueue<>();
+
+        RecordingClient(URI uri) {
+            super(uri);
+        }
+
+        @Override
+        public void onOpen(ServerHandshake handshake) {
+            // nothing to do
+        }
+
+        @Override
+        public void onMessage(String message) {
+            messages.add(message);
+        }
+
+        @Override
+        public void onClose(int code, String reason, boolean remote) {
+            // nothing to do
+        }
+
+        @Override
+        public void onError(Exception ex) {
+            // recorded through the absence of expected messages
+        }
+
+        String awaitMessage() throws InterruptedException {
+            return messages.poll(AWAIT_SECONDS, TimeUnit.SECONDS);
+        }
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="onBatchChecked">
+    @Test
+    void onBatchChecked_batchWithoutHit_clientReceivesTheCheckedRangeAnyway() throws Exception {
+        // arrange
+        final int port = freePort();
+        final WebSocketEndpoint endpoint = new WebSocketEndpoint(port);
+        final WebSocketResultBroadcaster broadcaster = new WebSocketResultBroadcaster(endpoint);
+        endpoint.start();
+        // The server binds on a background thread, so wait for the port rather than racing it.
+        ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_SECONDS * 1000);
+
+        final RecordingClient client = new RecordingClient(URI.create("ws://127.0.0.1:" + port));
+        try {
+            assertThat(client.connectBlocking(AWAIT_SECONDS, TimeUnit.SECONDS), is(true));
+
+            // act
+            broadcaster.onBatchChecked(new BatchResult(BigInteger.valueOf(0x4000L), 4096, List.of()));
+
+            // assert
+            final JsonNode message = objectMapper.readTree(client.awaitMessage());
+            assertThat(message.get("type").asText(), is(equalTo("batch")));
+            assertThat(message.get("secretBase").asText(), is(equalTo("4000")));
+            assertThat(message.get("checkedCount").asInt(), is(equalTo(4096)));
+            assertThat(message.get("hits").size(), is(equalTo(0)));
+        } finally {
+            client.closeBlocking();
+            endpoint.stop();
+        }
+    }
+
+    @Test
+    void onBatchChecked_batchWithHit_clientReceivesTheKeyMaterial() throws Exception {
+        // arrange
+        final int port = freePort();
+        final WebSocketEndpoint endpoint = new WebSocketEndpoint(port);
+        final WebSocketResultBroadcaster broadcaster = new WebSocketResultBroadcaster(endpoint);
+        endpoint.start();
+        // The server binds on a background thread, so wait for the port rather than racing it.
+        ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_SECONDS * 1000);
+
+        final RecordingClient client = new RecordingClient(URI.create("ws://127.0.0.1:" + port));
+        try {
+            assertThat(client.connectBlocking(AWAIT_SECONDS, TimeUnit.SECONDS), is(true));
+            final Hit hit = new Hit(BigInteger.valueOf(73), "aabb", "1TestAddress", true, false);
+
+            // act
+            broadcaster.onBatchChecked(new BatchResult(BigInteger.valueOf(0x4000L), 4096, List.of(hit)));
+
+            // assert
+            final JsonNode message = objectMapper.readTree(client.awaitMessage());
+            final JsonNode reportedHit = message.get("hits").get(0);
+            assertThat(reportedHit.get("privateKey").asText(), is(equalTo("49")));
+            assertThat(reportedHit.get("address").asText(), is(equalTo("1TestAddress")));
+            assertThat(reportedHit.get("hash160Hex").asText(), is(equalTo("aabb")));
+            assertThat(reportedHit.get("compressed").asBoolean(), is(true));
+        } finally {
+            client.closeBlocking();
+            endpoint.stop();
+        }
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="greeting">
+    @Test
+    void greeting_clientConnectedBeforeConfigurationKnown_stillReceivesIt() throws Exception {
+        // The server accepts connections before the producers are configured, so a client can be
+        // there first. Without the catch-up it would never learn the grid size and could only guess
+        // its step, silently rescanning one block over and over.
+
+        // arrange
+        final int port = freePort();
+        final WebSocketEndpoint endpoint = new WebSocketEndpoint(port);
+        final WebSocketResultBroadcaster broadcaster = new WebSocketResultBroadcaster(endpoint);
+        endpoint.start();
+        // The server binds on a background thread, so wait for the port rather than racing it.
+        ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_SECONDS * 1000);
+
+        final RecordingClient client = new RecordingClient(URI.create("ws://127.0.0.1:" + port));
+        try {
+            assertThat(client.connectBlocking(AWAIT_SECONDS, TimeUnit.SECONDS), is(true));
+
+            // act: the configuration only becomes known now
+            broadcaster.announceConfiguration(BATCH_SIZE_IN_BITS, true);
+
+            // assert
+            final String raw = client.awaitMessage();
+            assertThat(raw, is(notNullValue()));
+            final JsonNode greeting = objectMapper.readTree(raw);
+            assertThat(greeting.get("type").asText(), is(equalTo("config")));
+            assertThat(greeting.get("batchSizeInBits").asInt(), is(equalTo(BATCH_SIZE_IN_BITS)));
+            assertThat(greeting.get("batchUsePrivateKeyIncrement").asBoolean(), is(true));
+            assertThat(greeting.get("secretByteLength").asInt(), is(equalTo(32)));
+        } finally {
+            client.closeBlocking();
+            endpoint.stop();
+        }
+    }
+
+    @Test
+    void greeting_clientConnectsAfterConfigurationKnown_receivesItOnConnect() throws Exception {
+        // arrange
+        final int port = freePort();
+        final WebSocketEndpoint endpoint = new WebSocketEndpoint(port);
+        final WebSocketResultBroadcaster broadcaster = new WebSocketResultBroadcaster(endpoint);
+        broadcaster.announceConfiguration(BATCH_SIZE_IN_BITS, true);
+        endpoint.start();
+        // The server binds on a background thread, so wait for the port rather than racing it.
+        ConnectionUtils.waitUntilTcpPortOpen("127.0.0.1", port, AWAIT_SECONDS * 1000);
+
+        final RecordingClient client = new RecordingClient(URI.create("ws://127.0.0.1:" + port));
+        try {
+            // act
+            assertThat(client.connectBlocking(AWAIT_SECONDS, TimeUnit.SECONDS), is(true));
+
+            // assert
+            assertThat(client.awaitMessage(), containsString("\"type\":\"config\""));
+        } finally {
+            client.closeBlocking();
+            endpoint.stop();
+        }
+    }
+    // </editor-fold>
+
+    /**
+     * Picks a free TCP port, so parallel test runs cannot collide on a fixed one.
+     *
+     * @return a port that was free at the moment of asking
+     * @throws Exception if no port could be reserved
+     */
+    private static int freePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/ZmqResultBroadcasterTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/keyproducer/ZmqResultBroadcasterTest.java
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.keyproducer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigInteger;
+import java.net.ServerSocket;
+import java.util.List;
+import net.ladenthin.bitcoinaddressfinder.core.BatchResult;
+import net.ladenthin.bitcoinaddressfinder.core.Hit;
+import org.junit.jupiter.api.Test;
+import org.zeromq.SocketType;
+import org.zeromq.ZContext;
+import org.zeromq.ZMQ;
+
+/**
+ * Drives {@link ZmqResultBroadcaster} through a real ZeroMQ subscriber.
+ *
+ * <p>Both tests fight the same property of {@code PUB}/{@code SUB}: a message published before the
+ * subscriber has finished connecting is dropped, and the publisher has no way to learn that anyone
+ * subscribed. There is no handshake to wait on, so the tests publish repeatedly until a message
+ * arrives. That is not test scaffolding around a bug — it is how a real subscriber has to behave,
+ * and the reason the grid configuration is republished rather than sent once.
+ */
+class ZmqResultBroadcasterTest {
+
+    /** Upper bound for the retry loop; exceeding it is a failure, not a slow machine. */
+    private static final int AWAIT_MILLIS = 15_000;
+
+    /** How long a single receive attempt waits before the next publish. */
+    private static final int RECEIVE_TIMEOUT_MILLIS = 100;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // <editor-fold defaultstate="collapsed" desc="onBatchChecked">
+    @Test
+    void onBatchChecked_batchWithoutHit_subscriberReceivesTheCheckedRange() throws Exception {
+        // arrange
+        final String address = "tcp://127.0.0.1:" + freePort();
+        final ZmqResultBroadcaster broadcaster = new ZmqResultBroadcaster(address);
+        try (ZContext context = new ZContext()) {
+            final ZMQ.Socket subscriber = context.createSocket(SocketType.SUB);
+            subscriber.connect(address);
+            subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
+            subscriber.setReceiveTimeOut(RECEIVE_TIMEOUT_MILLIS);
+
+            // act, assert
+            final String received = receiveWhilePublishing(
+                    subscriber,
+                    () -> broadcaster.onBatchChecked(new BatchResult(BigInteger.valueOf(0x4000L), 4096, List.of())));
+            assertThat(received, is(notNullValue()));
+
+            final JsonNode message = objectMapper.readTree(received);
+            assertThat(message.get("type").asText(), is(equalTo("batch")));
+            assertThat(message.get("secretBase").asText(), is(equalTo("4000")));
+            assertThat(message.get("checkedCount").asInt(), is(equalTo(4096)));
+        } finally {
+            broadcaster.close();
+        }
+    }
+
+    @Test
+    void onBatchChecked_batchWithHit_subscriberReceivesTheKeyMaterial() throws Exception {
+        // arrange
+        final String address = "tcp://127.0.0.1:" + freePort();
+        final ZmqResultBroadcaster broadcaster = new ZmqResultBroadcaster(address);
+        try (ZContext context = new ZContext()) {
+            final ZMQ.Socket subscriber = context.createSocket(SocketType.SUB);
+            subscriber.connect(address);
+            subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
+            subscriber.setReceiveTimeOut(RECEIVE_TIMEOUT_MILLIS);
+            final Hit hit = new Hit(BigInteger.valueOf(73), "aabb", "1TestAddress", true, false);
+
+            // act, assert
+            final String received = receiveWhilePublishing(
+                    subscriber, () -> broadcaster.onBatchChecked(new BatchResult(BigInteger.ONE, 1, List.of(hit))));
+            assertThat(received, is(notNullValue()));
+
+            final JsonNode message = objectMapper.readTree(received);
+            assertThat(message.get("hits").get(0).get("privateKey").asText(), is(equalTo("49")));
+        } finally {
+            broadcaster.close();
+        }
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="announceConfiguration">
+    @Test
+    void announceConfiguration_subscriberJoinsLate_stillReceivesItThroughRepublishing() throws Exception {
+        // The publisher cannot detect a subscriber, so a configuration sent once would be lost to
+        // anyone who was not already connected. Republishing is what makes it reachable at all.
+
+        // arrange
+        final String address = "tcp://127.0.0.1:" + freePort();
+        final ZmqResultBroadcaster broadcaster = new ZmqResultBroadcaster(address);
+        try (ZContext context = new ZContext()) {
+            broadcaster.announceConfiguration(18, true);
+
+            // act: only now does the subscriber appear
+            final ZMQ.Socket subscriber = context.createSocket(SocketType.SUB);
+            subscriber.connect(address);
+            subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
+            subscriber.setReceiveTimeOut(RECEIVE_TIMEOUT_MILLIS);
+
+            final String received = receiveWhilePublishing(subscriber, broadcaster::republishConfiguration);
+
+            // assert
+            assertThat(received, is(notNullValue()));
+            final JsonNode message = objectMapper.readTree(received);
+            assertThat(message.get("type").asText(), is(equalTo("config")));
+            assertThat(message.get("batchSizeInBits").asInt(), is(equalTo(18)));
+        } finally {
+            broadcaster.close();
+        }
+    }
+    // </editor-fold>
+
+    /**
+     * Publishes repeatedly until the subscriber receives something or the budget runs out.
+     *
+     * @param subscriber the connected subscriber
+     * @param publish    the action that publishes one message
+     * @return the received message, or {@code null} if none arrived in time
+     */
+    private static String receiveWhilePublishing(ZMQ.Socket subscriber, Runnable publish) {
+        final long deadline = System.currentTimeMillis() + AWAIT_MILLIS;
+        while (System.currentTimeMillis() < deadline) {
+            publish.run();
+            final byte[] received = subscriber.recv(0);
+            if (received != null) {
+                return new String(received, java.nio.charset.StandardCharsets.UTF_8);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Picks a free TCP port, so parallel runs cannot collide on a fixed one.
+     *
+     * @return a port that was free at the moment of asking
+     * @throws Exception if no port could be reserved
+     */
+    private static int freePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContextAllocationFailureTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContextAllocationFailureTest.java
@@ -14,8 +14,8 @@ import java.io.IOException;
 import net.ladenthin.bitcoinaddressfinder.OpenCLPlatformAssume;
 import net.ladenthin.bitcoinaddressfinder.OpenCLTest;
 import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
+import net.ladenthin.bitcoinaddressfinder.opencl.binding.OpenClCallFailedException;
 import net.ladenthin.bitcoinaddressfinder.util.BitHelper;
-import org.jocl.CLException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
  * (~1.8&nbsp;GB at 24). A card too small to serve that buffer must skip the arm, not abort the run.
  * Whether {@code catch (Exception)} is enough hinges on <em>what type</em> the driver throws. This
  * test answers it by measurement rather than assumption: with JOCL exceptions enabled it is a JOCL
- * {@link CLException} (a {@link RuntimeException}), <b>not</b> an {@link OutOfMemoryError}. So the
+ * {@link OpenClCallFailedException} (a {@link RuntimeException}), <b>not</b> an {@link OutOfMemoryError}. So the
  * pre-existing {@code catch (Exception)} already covered it; the failure is an ordinary skipped arm.
  *
  * <p>The buffer size requested here is deliberately larger than any device's global memory rather
@@ -44,20 +44,20 @@ public class OpenCLContextAllocationFailureTest {
      * A single buffer of 2<sup>60</sup> bytes (~1.15&nbsp;EB) — far beyond the global memory of any
      * real OpenCL device, and beyond the practically addressable range — so every conforming driver
      * rejects it with {@code CL_INVALID_BUFFER_SIZE} (or, if it clamps to available memory first,
-     * {@code CL_MEM_OBJECT_ALLOCATION_FAILURE}). Both are {@code CLException} statuses; neither is an
+     * {@code CL_MEM_OBJECT_ALLOCATION_FAILURE}). Both are OpenCL error statuses; neither is an
      * {@code OutOfMemoryError}.
      */
     private static final long IMPOSSIBLE_BUFFER_BYTES = 1L << 60;
 
     /**
-     * The core assertion: an impossible device allocation throws a JOCL {@link CLException} that is a
+     * The core assertion: an impossible device allocation throws an {@link OpenClCallFailedException} that is a
      * {@link RuntimeException}. This is precisely why {@code TuneConfiguration.runArm} can rely on
      * {@code catch (Exception)} to demote an over-large {@code batchSizeInBits} arm to "unusable" and
      * carry on to the next candidate — no {@code OutOfMemoryError} (an {@link Error}) is involved.
      */
     @OpenCLTest
     @Test
-    public void oversizedDeviceAllocation_throwsClExceptionNotOutOfMemoryError() throws IOException {
+    public void oversizedDeviceAllocation_throwsOpenClCallFailedExceptionNotOutOfMemoryError() throws IOException {
         OpenCLPlatformAssume assume = new OpenCLPlatformAssume();
         assume.assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable();
 
@@ -68,10 +68,11 @@ public class OpenCLContextAllocationFailureTest {
         try {
             context.init();
 
-            CLException ex = assertThrows(
-                    CLException.class, () -> context.allocateDeviceReadWriteBufferForTesting(IMPOSSIBLE_BUFFER_BYTES));
+            OpenClCallFailedException ex = assertThrows(
+                    OpenClCallFailedException.class,
+                    () -> context.allocateDeviceReadWriteBufferForTesting(IMPOSSIBLE_BUFFER_BYTES));
 
-            // A CLException is a RuntimeException, so catch (Exception) in the tuner covers it.
+            // It is a RuntimeException, so catch (Exception) in the tuner covers it.
             assertThat(ex, is(instanceOf(RuntimeException.class)));
             // Drivers reject an impossible buffer with one of these two OpenCL status codes.
             assertThat(

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDeviceTopologyTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLDeviceTopologyTest.java
@@ -23,6 +23,13 @@ import org.junit.jupiter.api.Test;
  */
 public class OpenCLDeviceTopologyTest {
 
+    /**
+     * The resolver under test. An instance rather than a static entry point since the migration:
+     * reading the identity properties needs an OpenCL API, and injecting it is what makes that
+     * substitutable. The parsers exercised below touch no device.
+     */
+    private static final OpenCLDeviceTopology TOPOLOGY = new OpenCLDeviceTopology();
+
     public OpenCLDeviceTopologyTest() {}
 
     // <editor-fold defaultstate="collapsed" desc="cl_khr_device_uuid">
@@ -39,18 +46,18 @@ public class OpenCLDeviceTopologyTest {
             (byte) 0x76, (byte) 0x54, (byte) 0x32, (byte) 0x10
         };
 
-        assertThat(OpenCLDeviceTopology.parseDeviceUuid(uuid), is(equalTo("uuid:0123456789abcdeffedcba9876543210")));
+        assertThat(TOPOLOGY.parseDeviceUuid(uuid), is(equalTo("uuid:0123456789abcdeffedcba9876543210")));
     }
 
     /** An all-zero UUID is what a driver returns when it has nothing to report. It identifies nothing. */
     @Test
     public void parseDeviceUuid_allZero_isRejected() {
-        assertThat(OpenCLDeviceTopology.parseDeviceUuid(new byte[16]), is(nullValue()));
+        assertThat(TOPOLOGY.parseDeviceUuid(new byte[16]), is(nullValue()));
     }
 
     @Test
     public void parseDeviceUuid_wrongLength_isRejected() {
-        assertThat(OpenCLDeviceTopology.parseDeviceUuid(new byte[8]), is(nullValue()));
+        assertThat(TOPOLOGY.parseDeviceUuid(new byte[8]), is(nullValue()));
     }
 
     /** Two different devices must not collide. */
@@ -61,9 +68,7 @@ public class OpenCLDeviceTopologyTest {
         byte[] second = new byte[16];
         second[15] = 1;
 
-        assertThat(
-                OpenCLDeviceTopology.parseDeviceUuid(first),
-                is(not(equalTo(OpenCLDeviceTopology.parseDeviceUuid(second)))));
+        assertThat(TOPOLOGY.parseDeviceUuid(first), is(not(equalTo(TOPOLOGY.parseDeviceUuid(second)))));
     }
     // </editor-fold>
 
@@ -78,7 +83,7 @@ public class OpenCLDeviceTopologyTest {
         ByteBuffer buffer = ByteBuffer.allocate(16).order(ByteOrder.nativeOrder());
         buffer.putInt(0).putInt(0x0B).putInt(0x00).putInt(0x01);
 
-        assertThat(OpenCLDeviceTopology.parsePciBusInfo(buffer.array()), is(equalTo("pci:0:11:0:1")));
+        assertThat(TOPOLOGY.parsePciBusInfo(buffer.array()), is(equalTo("pci:0:11:0:1")));
     }
 
     /**
@@ -92,14 +97,12 @@ public class OpenCLDeviceTopologyTest {
         ByteBuffer second = ByteBuffer.allocate(16).order(ByteOrder.nativeOrder());
         second.putInt(0).putInt(0x0C).putInt(0).putInt(0);
 
-        assertThat(
-                OpenCLDeviceTopology.parsePciBusInfo(first.array()),
-                is(not(equalTo(OpenCLDeviceTopology.parsePciBusInfo(second.array())))));
+        assertThat(TOPOLOGY.parsePciBusInfo(first.array()), is(not(equalTo(TOPOLOGY.parsePciBusInfo(second.array())))));
     }
 
     @Test
     public void parsePciBusInfo_wrongLength_isRejected() {
-        assertThat(OpenCLDeviceTopology.parsePciBusInfo(new byte[12]), is(nullValue()));
+        assertThat(TOPOLOGY.parsePciBusInfo(new byte[12]), is(nullValue()));
     }
     // </editor-fold>
 
@@ -117,7 +120,7 @@ public class OpenCLDeviceTopologyTest {
         topology[22] = (byte) 0x00;
         topology[23] = (byte) 0x01;
 
-        assertThat(OpenCLDeviceTopology.parseAmdTopology(topology), is(equalTo("amd-pcie:11:0:1")));
+        assertThat(TOPOLOGY.parseAmdTopology(topology), is(equalTo("amd-pcie:11:0:1")));
     }
 
     /** Bus numbers above 127 must not come back negative. */
@@ -127,7 +130,7 @@ public class OpenCLDeviceTopologyTest {
         ByteBuffer.wrap(topology).order(ByteOrder.nativeOrder()).putInt(1);
         topology[21] = (byte) 0xC1;
 
-        assertThat(OpenCLDeviceTopology.parseAmdTopology(topology), is(equalTo("amd-pcie:193:0:0")));
+        assertThat(TOPOLOGY.parseAmdTopology(topology), is(equalTo("amd-pcie:193:0:0")));
     }
 
     /** Any topology type other than PCIe carries no slot information this can use. */
@@ -137,12 +140,12 @@ public class OpenCLDeviceTopologyTest {
         ByteBuffer.wrap(topology).order(ByteOrder.nativeOrder()).putInt(0);
         topology[21] = (byte) 0x0B;
 
-        assertThat(OpenCLDeviceTopology.parseAmdTopology(topology), is(nullValue()));
+        assertThat(TOPOLOGY.parseAmdTopology(topology), is(nullValue()));
     }
 
     @Test
     public void parseAmdTopology_wrongLength_isRejected() {
-        assertThat(OpenCLDeviceTopology.parseAmdTopology(new byte[16]), is(nullValue()));
+        assertThat(TOPOLOGY.parseAmdTopology(new byte[16]), is(nullValue()));
     }
     // </editor-fold>
 
@@ -157,18 +160,18 @@ public class OpenCLDeviceTopologyTest {
     public void supportedQuery_khronosExtensionsPresent_arePreferredOverTheVendorOne() {
         String extensions = "cl_khr_device_uuid cl_khr_pci_bus_info cl_amd_device_attribute_query";
 
-        assertThat(OpenCLDeviceTopology.supportsDeviceUuid(extensions), is(true));
-        assertThat(OpenCLDeviceTopology.supportsPciBusInfo(extensions), is(true));
-        assertThat(OpenCLDeviceTopology.supportsAmdTopology(extensions), is(true));
+        assertThat(TOPOLOGY.supportsDeviceUuid(extensions), is(true));
+        assertThat(TOPOLOGY.supportsPciBusInfo(extensions), is(true));
+        assertThat(TOPOLOGY.supportsAmdTopology(extensions), is(true));
     }
 
     @Test
     public void supportedQuery_noIdentityExtensions_reportsNoneSupported() {
         String extensions = "cl_khr_fp64 cl_khr_icd cl_khr_global_int32_base_atomics";
 
-        assertThat(OpenCLDeviceTopology.supportsDeviceUuid(extensions), is(false));
-        assertThat(OpenCLDeviceTopology.supportsPciBusInfo(extensions), is(false));
-        assertThat(OpenCLDeviceTopology.supportsAmdTopology(extensions), is(false));
+        assertThat(TOPOLOGY.supportsDeviceUuid(extensions), is(false));
+        assertThat(TOPOLOGY.supportsPciBusInfo(extensions), is(false));
+        assertThat(TOPOLOGY.supportsAmdTopology(extensions), is(false));
     }
 
     /**
@@ -177,7 +180,7 @@ public class OpenCLDeviceTopologyTest {
      */
     @Test
     public void supportedQuery_extensionNameIsASubstringOfAnother_isNotMistakenForSupport() {
-        assertThat(OpenCLDeviceTopology.supportsDeviceUuid("cl_khr_device_uuid_extended"), is(false));
+        assertThat(TOPOLOGY.supportsDeviceUuid("cl_khr_device_uuid_extended"), is(false));
     }
     // </editor-fold>
 }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClDeviceInfoFormatterTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClDeviceInfoFormatterTest.java
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.lwjgl.opencl.CL10;
+import org.lwjgl.opencl.CL11;
+import org.lwjgl.opencl.CL12;
+
+/**
+ * Tests {@link ClDeviceInfoFormatter}.
+ *
+ * <p>The previous binding shipped {@code CL.stringFor_*} helpers that rendered OpenCL bit fields as
+ * their symbolic names; LWJGL has no equivalent, so the project has to provide them. The expected
+ * strings below are exactly what the old helpers produced, because {@code OpenCLDevice.toStringPretty()}
+ * is compared line by line against a fixed sample in {@code OpenCLDeviceTest} — a formatting change
+ * here silently breaks that test, and worse, changes user-visible device reports.
+ *
+ * <p>Note the trailing space in every non-empty expectation: the old helpers terminated each flag
+ * name with one, and {@link ClDeviceInfoFormatterJoclParityTest} holds the new implementation to
+ * that byte for byte.
+ *
+ * <p>Pure bit-field rendering, so no OpenCL runtime is required.
+ */
+class ClDeviceInfoFormatterTest {
+
+    private final ClDeviceInfoFormatter formatter = new ClDeviceInfoFormatter();
+
+    // <editor-fold defaultstate="collapsed" desc="formatDeviceType">
+    @Test
+    void formatDeviceType_gpu_returnsSymbolicName() {
+        // act, assert
+        assertThat(formatter.formatDeviceType(CL10.CL_DEVICE_TYPE_GPU), is(equalTo("CL_DEVICE_TYPE_GPU ")));
+    }
+
+    @Test
+    void formatDeviceType_cpu_returnsSymbolicName() {
+        // act, assert
+        assertThat(formatter.formatDeviceType(CL10.CL_DEVICE_TYPE_CPU), is(equalTo("CL_DEVICE_TYPE_CPU ")));
+    }
+
+    @Test
+    void formatDeviceType_severalBitsSet_returnsNamesInAscendingBitOrder() {
+        // arrange
+        final long deviceType = CL10.CL_DEVICE_TYPE_CPU | CL10.CL_DEVICE_TYPE_GPU;
+
+        // act, assert
+        assertThat(formatter.formatDeviceType(deviceType), is(equalTo("CL_DEVICE_TYPE_CPU CL_DEVICE_TYPE_GPU ")));
+    }
+
+    @Test
+    void formatDeviceType_customType_returnsSymbolicName() {
+        // act, assert
+        assertThat(formatter.formatDeviceType(CL12.CL_DEVICE_TYPE_CUSTOM), is(equalTo("CL_DEVICE_TYPE_CUSTOM ")));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="formatLocalMemType">
+    @Test
+    void formatLocalMemType_local_returnsSymbolicName() {
+        // act, assert
+        assertThat(formatter.formatLocalMemType(CL10.CL_LOCAL), is(equalTo("CL_LOCAL")));
+    }
+
+    @Test
+    void formatLocalMemType_global_returnsSymbolicName() {
+        // act, assert
+        assertThat(formatter.formatLocalMemType(CL10.CL_GLOBAL), is(equalTo("CL_GLOBAL")));
+    }
+
+    @Test
+    void formatLocalMemType_noneValue_reportedAsInvalid() {
+        // CL_NONE shares the value 0 but is not a valid local-memory type; a parity sweep against
+        // the previous binding showed it reports this as invalid rather than as a name.
+        // act, assert
+        assertThat(formatter.formatLocalMemType(CL10.CL_NONE), is(equalTo("INVALID cl_device_local_mem_type: 0")));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="formatCommandQueueProperties">
+    @Test
+    void formatCommandQueueProperties_outOfOrderAndProfiling_returnsBothNames() {
+        // arrange
+        final long properties = CL10.CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL10.CL_QUEUE_PROFILING_ENABLE;
+
+        // act, assert
+        assertThat(
+                formatter.formatCommandQueueProperties(properties),
+                is(equalTo("CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE CL_QUEUE_PROFILING_ENABLE ")));
+    }
+
+    @Test
+    void formatCommandQueueProperties_noBitSet_returnsNoneLiteral() {
+        // act, assert
+        assertThat(formatter.formatCommandQueueProperties(0L), is(equalTo("(none)")));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="formatDeviceFpConfig">
+    @Test
+    void formatDeviceFpConfig_fullNvidiaConfig_returnsNamesInAscendingBitOrder() {
+        // arrange
+        final long fpConfig = CL10.CL_FP_DENORM
+                | CL10.CL_FP_INF_NAN
+                | CL10.CL_FP_ROUND_TO_NEAREST
+                | CL10.CL_FP_ROUND_TO_ZERO
+                | CL10.CL_FP_ROUND_TO_INF
+                | CL10.CL_FP_FMA
+                | CL12.CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT;
+
+        // act, assert
+        assertThat(
+                formatter.formatDeviceFpConfig(fpConfig),
+                is(equalTo("CL_FP_DENORM CL_FP_INF_NAN CL_FP_ROUND_TO_NEAREST CL_FP_ROUND_TO_ZERO"
+                        + " CL_FP_ROUND_TO_INF CL_FP_FMA CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT ")));
+    }
+
+    @Test
+    void formatDeviceFpConfig_softFloat_isOrderedBeforeCorrectlyRounded() {
+        // arrange
+        final long fpConfig = CL11.CL_FP_SOFT_FLOAT | CL12.CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT;
+
+        // act, assert
+        assertThat(
+                formatter.formatDeviceFpConfig(fpConfig),
+                is(equalTo("CL_FP_SOFT_FLOAT CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT ")));
+    }
+    // </editor-fold>
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClErrorCheckerTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClErrorCheckerTest.java
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ClErrorChecker}.
+ *
+ * <p>This class exists because of a behavioural difference between the two OpenCL bindings that is
+ * easy to overlook: JOCL raised a {@code CLException} on its own once exceptions were enabled, while
+ * LWJGL only ever <em>returns</em> an {@code cl_int} error code. Every LWJGL call therefore has to be
+ * checked explicitly, and an unchecked call fails silently and corrupts state later. These tests pin
+ * that the checker turns a non-success code into a loud, attributable failure.
+ *
+ * <p>No OpenCL runtime is involved — the checker operates on plain error codes and handles.
+ */
+class ClErrorCheckerTest {
+
+    /** Name of the OpenCL entry point used in the failure assertions. */
+    private static final String FUNCTION_NAME = "clCreateBuffer";
+
+    /** An arbitrary non-zero value standing in for a successfully created OpenCL object. */
+    private static final long VALID_HANDLE = 0x7F00_1234L;
+
+    /** The OpenCL NULL handle: what a failed create call returns. */
+    private static final long NULL_HANDLE = 0L;
+
+    private final ClErrorChecker checker = new ClErrorChecker(new ClErrorCodeResolver());
+
+    // <editor-fold defaultstate="collapsed" desc="checkSuccess">
+    @Test
+    void checkSuccess_successCode_noExceptionThrown() {
+        // act, assert
+        assertDoesNotThrow(() -> checker.checkSuccess(ClErrorCodeResolver.CL_SUCCESS, FUNCTION_NAME));
+    }
+
+    @Test
+    void checkSuccess_failureCode_throwsException() {
+        // act, assert
+        assertThrows(OpenClCallFailedException.class, () -> checker.checkSuccess(-30, FUNCTION_NAME));
+    }
+
+    @Test
+    void checkSuccess_failureCode_exceptionCarriesErrorCodeAndFunctionName() {
+        // act
+        final OpenClCallFailedException e =
+                assertThrows(OpenClCallFailedException.class, () -> checker.checkSuccess(-30, FUNCTION_NAME));
+
+        // assert
+        assertThat(e.getErrorCode(), is(equalTo(-30)));
+        assertThat(e.getOpenClFunctionName(), is(equalTo(FUNCTION_NAME)));
+    }
+
+    @Test
+    void checkSuccess_failureCode_exceptionMessageNamesFunctionAndSymbolicError() {
+        // act
+        final OpenClCallFailedException e =
+                assertThrows(OpenClCallFailedException.class, () -> checker.checkSuccess(-30, FUNCTION_NAME));
+
+        // assert
+        assertThat(e.getMessage(), containsString(FUNCTION_NAME));
+        assertThat(e.getMessage(), containsString("CL_INVALID_VALUE"));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="requireCreated">
+    @Test
+    void requireCreated_nonNullHandle_returnsHandleUnchanged() {
+        // act
+        final long created = checker.requireCreated(VALID_HANDLE, FUNCTION_NAME);
+
+        // assert
+        assertThat(created, is(equalTo(VALID_HANDLE)));
+    }
+
+    @Test
+    void requireCreated_nullHandle_throwsException() {
+        // act, assert
+        assertThrows(OpenClCallFailedException.class, () -> checker.requireCreated(NULL_HANDLE, FUNCTION_NAME));
+    }
+
+    @Test
+    void requireCreated_nullHandle_exceptionMessageNamesFunction() {
+        // act
+        final OpenClCallFailedException e =
+                assertThrows(OpenClCallFailedException.class, () -> checker.requireCreated(NULL_HANDLE, FUNCTION_NAME));
+
+        // assert
+        assertThat(e.getMessage(), containsString(FUNCTION_NAME));
+    }
+    // </editor-fold>
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClErrorCodeResolverTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClErrorCodeResolverTest.java
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests {@link ClErrorCodeResolver}.
+ *
+ * <p>No OpenCL runtime is touched here: the resolver is a pure lookup over the error-code constants,
+ * which is exactly why it is a separate class from {@link ClErrorChecker}.
+ */
+class ClErrorCodeResolverTest {
+
+    /** An error code that is not defined by any OpenCL version, used for the fallback path. */
+    private static final int UNDEFINED_ERROR_CODE = -9999;
+
+    private final ClErrorCodeResolver resolver = new ClErrorCodeResolver();
+
+    // <editor-fold defaultstate="collapsed" desc="describe">
+    @ParameterizedTest
+    @MethodSource("knownErrorCodes")
+    void describe_knownErrorCode_containsSymbolicNameAndNumericCode(int errorCode, String expectedName) {
+        // act
+        final String description = resolver.describe(errorCode);
+
+        // assert
+        assertThat(description, containsString(expectedName));
+        assertThat(description, containsString(Integer.toString(errorCode)));
+    }
+
+    @Test
+    void describe_undefinedErrorCode_containsNumericCode() {
+        // act
+        final String description = resolver.describe(UNDEFINED_ERROR_CODE);
+
+        // assert
+        assertThat(description, containsString(Integer.toString(UNDEFINED_ERROR_CODE)));
+    }
+
+    @Test
+    void describe_successCode_returnsSuccessName() {
+        // act
+        final String description = resolver.describe(ClErrorCodeResolver.CL_SUCCESS);
+
+        // assert
+        assertThat(description, containsString("CL_SUCCESS"));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="isSuccess">
+    @Test
+    void isSuccess_successCode_returnsTrue() {
+        // act, assert
+        assertThat(resolver.isSuccess(ClErrorCodeResolver.CL_SUCCESS), is(true));
+    }
+
+    @Test
+    void isSuccess_failureCode_returnsFalse() {
+        // act, assert
+        assertThat(resolver.isSuccess(UNDEFINED_ERROR_CODE), is(false));
+    }
+    // </editor-fold>
+
+    /**
+     * Error codes that must resolve to their symbolic OpenCL name. Deliberately a small, stable
+     * selection covering the failures this project can realistically provoke: a bad argument, an
+     * exhausted device, an exhausted host, and a kernel that fails to build.
+     *
+     * @return pairs of error code and expected symbolic name
+     */
+    static Stream<Arguments> knownErrorCodes() {
+        return Stream.of(
+                Arguments.of(-5, "CL_OUT_OF_RESOURCES"),
+                Arguments.of(-6, "CL_OUT_OF_HOST_MEMORY"),
+                Arguments.of(-11, "CL_BUILD_PROGRAM_FAILURE"),
+                Arguments.of(-30, "CL_INVALID_VALUE"));
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClHandleTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/ClHandleTest.java
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the typed OpenCL handle records.
+ *
+ * <p>The property under test is the one the migration would otherwise lose. JOCL modelled every
+ * OpenCL object as its own class ({@code cl_mem}, {@code cl_kernel}, ...), so passing a buffer where
+ * a kernel was expected could not compile. LWJGL represents all of them as a bare {@code long},
+ * which makes that mistake invisible to the compiler and turns it into an undiagnosable runtime
+ * fault deep inside the driver. These records restore the distinction.
+ */
+class ClHandleTest {
+
+    /** An arbitrary non-zero value standing in for a native OpenCL object address. */
+    private static final long HANDLE_VALUE = 0x7F00_1234L;
+
+    /** A second, different address used to check that value equality actually compares the handle. */
+    private static final long OTHER_HANDLE_VALUE = 0x7F00_5678L;
+
+    // <editor-fold defaultstate="collapsed" desc="handle">
+    @Test
+    void handle_created_returnsTheWrappedValue() {
+        // act, assert
+        assertThat(new ClMem(HANDLE_VALUE).handle(), is(equalTo(HANDLE_VALUE)));
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="equals">
+    @Test
+    void equals_sameTypeAndSameHandle_areEqual() {
+        // act, assert
+        assertThat(new ClMem(HANDLE_VALUE), is(equalTo(new ClMem(HANDLE_VALUE))));
+    }
+
+    @Test
+    void equals_sameTypeAndDifferentHandle_areNotEqual() {
+        // act, assert
+        assertThat(new ClMem(HANDLE_VALUE), is(not(equalTo(new ClMem(OTHER_HANDLE_VALUE)))));
+    }
+
+    @Test
+    void equals_differentTypeAndSameHandle_areNotEqual() {
+        // arrange
+        final ClMem memory = new ClMem(HANDLE_VALUE);
+        final ClKernel kernel = new ClKernel(HANDLE_VALUE);
+
+        // act, assert
+        assertThat(memory, is(not(equalTo((Object) kernel))));
+    }
+    // </editor-fold>
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/LwjglClApiBufferTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/LwjglClApiBufferTest.java
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import net.ladenthin.bitcoinaddressfinder.OpenCLPlatformAssume;
+import net.ladenthin.bitcoinaddressfinder.OpenCLTest;
+import org.junit.jupiter.api.Test;
+import org.lwjgl.opencl.CL10;
+
+/**
+ * Round-trips host payloads through device memory using {@link LwjglClApi}.
+ *
+ * <p>These tests exist because the migration had to change <em>how</em> host data reaches the device.
+ * The previous binding could hand a Java array straight to the driver, so a filter was uploaded with
+ * a single {@code CL_MEM_COPY_HOST_PTR} allocation. LWJGL can only transfer from direct buffers, and
+ * staging a whole payload off-heap is not an option here: the 16-bit fingerprint filter reaches
+ * multiple gigabytes at the Full-DB tier, beyond what a Java {@code byte[]} can even represent. The
+ * replacement writes through a small reusable staging buffer instead.
+ *
+ * <p>That makes chunk arithmetic — offsets, the final short chunk, element widths — load-bearing for
+ * correctness of every filter upload. A payload deliberately larger than one chunk is therefore
+ * round-tripped and compared byte for byte; an off-by-one in the offset would silently corrupt a
+ * filter and show up only as missed addresses.
+ *
+ * <p>{@code @OpenCLTest}: needs a real device to write to.
+ */
+class LwjglClApiBufferTest {
+
+    /**
+     * Payload size in bytes, chosen to exceed the implementation's staging buffer so at least one
+     * chunk boundary is crossed and the second chunk's device offset is exercised.
+     */
+    private static final int PAYLOAD_BYTES = 12 * 1024 * 1024;
+
+    /** Number of 16-bit elements used for the short-payload round trip. */
+    private static final int SHORT_ELEMENT_COUNT = 7 * 1024 * 1024;
+
+    private final ClApi clApi = new LwjglClApi(
+            new ClErrorChecker(new ClErrorCodeResolver()), new OpenClLibraryLoader(new LwjglClLibraryInitializer()));
+
+    // <editor-fold defaultstate="collapsed" desc="writeBufferChunked">
+    @Test
+    @OpenCLTest
+    void writeBufferChunked_payloadLargerThanOneChunk_roundTripsUnchanged() {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailable();
+
+        // arrange
+        final byte[] source = new byte[PAYLOAD_BYTES];
+        for (int i = 0; i < source.length; i++) {
+            source[i] = (byte) (i * 31);
+        }
+
+        // act
+        final byte[] readBack = roundTripBytes(source);
+
+        // assert
+        assertArrayEquals(source, readBack);
+    }
+
+    @Test
+    @OpenCLTest
+    void writeBufferChunked_shortPayload_roundTripsInNativeByteOrder() {
+        new OpenCLPlatformAssume().assumeOpenClLibraryAvailable();
+
+        // arrange
+        final short[] source = new short[SHORT_ELEMENT_COUNT];
+        for (int i = 0; i < source.length; i++) {
+            source[i] = (short) (i * 7);
+        }
+
+        // act
+        final short[] readBack = roundTripShorts(source);
+
+        // assert
+        assertThat(readBack.length, is(equalTo(source.length)));
+        for (int i = 0; i < source.length; i++) {
+            assertThat("element " + i, readBack[i], is(equalTo(source[i])));
+        }
+    }
+    // </editor-fold>
+
+    /**
+     * Writes a byte payload to a device buffer and reads it back.
+     *
+     * @param source the payload to round-trip
+     * @return the bytes read back from the device
+     */
+    private byte[] roundTripBytes(byte[] source) {
+        final ClPlatformId platform = clApi.getPlatformIds().get(0);
+        final List<ClDeviceId> devices = clApi.getDeviceIds(platform, CL10.CL_DEVICE_TYPE_ALL);
+        final ClContext context = clApi.createContext(platform, devices.get(0));
+        try {
+            final ClCommandQueue queue = clApi.createCommandQueue(context, devices.get(0), false);
+            try {
+                final ClMem mem = clApi.createBuffer(context, ClBufferFlags.READ_WRITE, source.length);
+                try {
+                    clApi.writeBufferChunked(queue, mem, source);
+
+                    final ByteBuffer destination =
+                            ByteBuffer.allocateDirect(source.length).order(ByteOrder.nativeOrder());
+                    clApi.enqueueReadBuffer(queue, mem, 0L, destination, false);
+                    clApi.finish(queue);
+
+                    final byte[] readBack = new byte[source.length];
+                    destination.position(0);
+                    destination.get(readBack);
+                    return readBack;
+                } finally {
+                    clApi.releaseMemObject(mem);
+                }
+            } finally {
+                clApi.releaseCommandQueue(queue);
+            }
+        } finally {
+            clApi.releaseContext(context);
+        }
+    }
+
+    /**
+     * Writes a 16-bit payload to a device buffer and reads it back.
+     *
+     * @param source the payload to round-trip
+     * @return the values read back from the device
+     */
+    private short[] roundTripShorts(short[] source) {
+        final ClPlatformId platform = clApi.getPlatformIds().get(0);
+        final List<ClDeviceId> devices = clApi.getDeviceIds(platform, CL10.CL_DEVICE_TYPE_ALL);
+        final ClContext context = clApi.createContext(platform, devices.get(0));
+        final long byteSize = (long) source.length * Short.BYTES;
+        try {
+            final ClCommandQueue queue = clApi.createCommandQueue(context, devices.get(0), false);
+            try {
+                final ClMem mem = clApi.createBuffer(context, ClBufferFlags.READ_WRITE, byteSize);
+                try {
+                    clApi.writeBufferChunked(queue, mem, source);
+
+                    final ByteBuffer destination =
+                            ByteBuffer.allocateDirect((int) byteSize).order(ByteOrder.nativeOrder());
+                    clApi.enqueueReadBuffer(queue, mem, 0L, destination, false);
+                    clApi.finish(queue);
+
+                    final short[] readBack = new short[source.length];
+                    destination.position(0);
+                    destination.asShortBuffer().get(readBack);
+                    return readBack;
+                } finally {
+                    clApi.releaseMemObject(mem);
+                }
+            } finally {
+                clApi.releaseCommandQueue(queue);
+            }
+        } finally {
+            clApi.releaseContext(context);
+        }
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClLibraryLoaderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/OpenClLibraryLoaderTest.java
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.opencl.binding;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link OpenClLibraryLoader}.
+ *
+ * <p>These tests exist because of a concrete failure observed while preparing the migration off
+ * JOCL. On a stock Linux install the OpenCL runtime package ships only the versioned SONAME
+ * {@code libOpenCL.so.1}; the unversioned {@code libOpenCL.so} symlink comes from the separate
+ * development package. JOCL never noticed, because its own JNI shim is linked against the SONAME.
+ * LWJGL resolves the library by plain name and therefore fails with
+ * {@code UnsatisfiedLinkError: Failed to locate library: libOpenCL.so} on any machine that has a
+ * working OpenCL driver but no development package installed. Reproduced in a Debian container with
+ * {@code pocl-opencl-icd} before this loader existed.
+ *
+ * <p>The fallback chain is what keeps the application runnable there, so it is tested against a
+ * mocked initializer rather than against a real driver: the failure path cannot be provoked on a
+ * machine where the default name happens to resolve.
+ */
+class OpenClLibraryLoaderTest {
+
+    /** Message of the failure LWJGL raises when the library name cannot be resolved. */
+    private static final String LINK_ERROR_MESSAGE = "Failed to locate library: libOpenCL.so";
+
+    /**
+     * Creates the failure LWJGL raises when a library name cannot be resolved. A factory rather than
+     * a shared constant: a {@link Throwable} kept in a static field accumulates a stack trace from
+     * whichever test happened to create it first.
+     *
+     * @return a fresh link error carrying {@link #LINK_ERROR_MESSAGE}
+     */
+    private static UnsatisfiedLinkError linkError() {
+        return new UnsatisfiedLinkError(LINK_ERROR_MESSAGE);
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="ensureLoaded">
+    @Test
+    void ensureLoaded_defaultNameResolves_noFallbackAttempted() {
+        // arrange
+        final ClLibraryInitializer initializer = mock(ClLibraryInitializer.class);
+        final OpenClLibraryLoader loader = new OpenClLibraryLoader(initializer);
+
+        // act
+        loader.ensureLoaded();
+
+        // assert
+        verify(initializer, times(1)).create();
+        verify(initializer, never()).create(anyString());
+    }
+
+    @Test
+    void ensureLoaded_defaultNameFails_versionedSonameUsedAsFallback() {
+        // arrange
+        final ClLibraryInitializer initializer = mock(ClLibraryInitializer.class);
+        doThrow(linkError()).when(initializer).create();
+        final OpenClLibraryLoader loader = new OpenClLibraryLoader(initializer);
+
+        // act
+        loader.ensureLoaded();
+
+        // assert
+        verify(initializer).create(eq(OpenClLibraryLoader.VERSIONED_LINUX_LIBRARY_NAME));
+    }
+
+    @Test
+    void ensureLoaded_everyCandidateFails_throwsException() {
+        // arrange
+        final ClLibraryInitializer initializer = mock(ClLibraryInitializer.class);
+        doThrow(linkError()).when(initializer).create();
+        doThrow(linkError()).when(initializer).create(anyString());
+        final OpenClLibraryLoader loader = new OpenClLibraryLoader(initializer);
+
+        // act, assert
+        assertThrows(OpenClLibraryUnavailableException.class, loader::ensureLoaded);
+    }
+
+    @Test
+    void ensureLoaded_everyCandidateFails_exceptionNamesTheAttemptedCandidate() {
+        // arrange
+        final ClLibraryInitializer initializer = mock(ClLibraryInitializer.class);
+        doThrow(linkError()).when(initializer).create();
+        doThrow(linkError()).when(initializer).create(anyString());
+        final OpenClLibraryLoader loader = new OpenClLibraryLoader(initializer);
+
+        // act
+        final OpenClLibraryUnavailableException e =
+                assertThrows(OpenClLibraryUnavailableException.class, loader::ensureLoaded);
+
+        // assert
+        assertThat(e.getMessage(), containsString(OpenClLibraryLoader.VERSIONED_LINUX_LIBRARY_NAME));
+    }
+
+    @Test
+    void ensureLoaded_everyCandidateFails_originalLinkErrorIsRetainedAsCause() {
+        // arrange
+        final ClLibraryInitializer initializer = mock(ClLibraryInitializer.class);
+        doThrow(linkError()).when(initializer).create();
+        doThrow(linkError()).when(initializer).create(anyString());
+        final OpenClLibraryLoader loader = new OpenClLibraryLoader(initializer);
+
+        // act
+        final OpenClLibraryUnavailableException e =
+                assertThrows(OpenClLibraryUnavailableException.class, loader::ensureLoaded);
+
+        // pre-assert
+        assertThat(e.getCause(), is(notNullValue()));
+
+        // assert
+        assertThat(e.getCause().getMessage(), containsString("libOpenCL.so"));
+    }
+
+    @Test
+    void ensureLoaded_calledTwice_initializesOnlyOnce() {
+        // arrange
+        final ClLibraryInitializer initializer = mock(ClLibraryInitializer.class);
+        final OpenClLibraryLoader loader = new OpenClLibraryLoader(initializer);
+
+        // act
+        loader.ensureLoaded();
+        loader.ensureLoaded();
+
+        // assert
+        verify(initializer, times(1)).create();
+    }
+
+    @Test
+    void ensureLoaded_initializerAlreadyReportsCreated_noInitializationAttempted() {
+        // arrange
+        final ClLibraryInitializer initializer = mock(ClLibraryInitializer.class);
+        when(initializer.isCreated()).thenReturn(true);
+        final OpenClLibraryLoader loader = new OpenClLibraryLoader(initializer);
+
+        // act
+        assertDoesNotThrow(loader::ensureLoaded);
+
+        // assert
+        verify(initializer, never()).create();
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="fallbackLibraryNames">
+    @Test
+    void fallbackLibraryNames_whenCalled_containsVersionedLinuxSoname() {
+        // arrange
+        final OpenClLibraryLoader loader = new OpenClLibraryLoader(mock(ClLibraryInitializer.class));
+
+        // act, assert
+        assertThat(loader.fallbackLibraryNames(), hasItem(OpenClLibraryLoader.VERSIONED_LINUX_LIBRARY_NAME));
+    }
+    // </editor-fold>
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/producer/ProducerReleaserTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/producer/ProducerReleaserTest.java
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: 2017-2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package net.ladenthin.bitcoinaddressfinder.producer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ProducerReleaser}.
+ *
+ * <p>The invariant here used to be implicit — the orchestrator released whatever its producer list
+ * held and then cleared the list, so "exactly once" held only as long as nobody else was doing the
+ * same thing at the same time. Two callers can arrive at once in practice: the teardown runs both on
+ * the ordinary completion path and from the JVM shutdown hook, and a {@code Ctrl+C} landing while a
+ * finished run releases its producers is enough to overlap them. Both then read the list before
+ * either cleared it and both released the same producer. Against a real driver the second release of
+ * an OpenCL producer failed with {@code CL_INVALID_MEM_OBJECT}, turning a successful run into a fatal
+ * error at the very end.
+ *
+ * <p>Making the guarantee an object of its own is what allows it to be stated as a test at all: the
+ * assertions below need no GPU, no database and no configuration.
+ */
+class ProducerReleaserTest {
+
+    /** Number of threads that tear down simultaneously in the concurrency test. */
+    private static final int CONCURRENT_CALLERS = 2;
+
+    /** Number of producers released per call. */
+    private static final int PRODUCER_COUNT = 3;
+
+    /** Upper bound for the concurrent teardown; a hang here is a failure, not a slow machine. */
+    private static final int AWAIT_SECONDS = 30;
+
+    // <editor-fold defaultstate="collapsed" desc="release">
+    @Test
+    void release_singleCall_releasesEveryProducerOnce() {
+        // arrange
+        final ProducerReleaser releaser = new ProducerReleaser();
+        final List<CountingProducer> producers = createProducers();
+
+        // act
+        releaser.release(List.copyOf(producers));
+
+        // assert
+        for (CountingProducer producer : producers) {
+            assertThat(producer.releaseCount(), is(equalTo(1)));
+        }
+    }
+
+    @Test
+    void release_calledTwiceSequentially_releasesEveryProducerOnce() {
+        // arrange
+        final ProducerReleaser releaser = new ProducerReleaser();
+        final List<CountingProducer> producers = createProducers();
+
+        // act
+        releaser.release(List.copyOf(producers));
+        releaser.release(List.copyOf(producers));
+
+        // assert
+        for (CountingProducer producer : producers) {
+            assertThat(producer.releaseCount(), is(equalTo(1)));
+        }
+    }
+
+    @Test
+    void release_calledConcurrentlyFromTwoThreads_releasesEveryProducerOnce() throws Exception {
+        // arrange
+        final ProducerReleaser releaser = new ProducerReleaser();
+        final List<CountingProducer> producers = createProducers();
+        // Both callers see the very same producers, which is exactly the situation that produced the
+        // double release: each had its own snapshot taken before either had finished.
+        final List<Producer> snapshot = List.copyOf(producers);
+        final CountDownLatch startLine = new CountDownLatch(1);
+        final ExecutorService callers = Executors.newFixedThreadPool(CONCURRENT_CALLERS);
+
+        // act
+        try {
+            final List<Future<?>> futures = new ArrayList<>(CONCURRENT_CALLERS);
+            for (int i = 0; i < CONCURRENT_CALLERS; i++) {
+                futures.add(callers.submit(() -> {
+                    awaitStartLine(startLine);
+                    releaser.release(snapshot);
+                }));
+            }
+            startLine.countDown();
+            for (Future<?> future : futures) {
+                future.get(AWAIT_SECONDS, TimeUnit.SECONDS);
+            }
+        } finally {
+            callers.shutdownNow();
+        }
+
+        // assert
+        for (CountingProducer producer : producers) {
+            assertThat(producer.releaseCount(), is(equalTo(1)));
+        }
+    }
+    // </editor-fold>
+
+    /**
+     * Creates the producers used by every test in this class.
+     *
+     * @return freshly created counting producers
+     */
+    private List<CountingProducer> createProducers() {
+        final List<CountingProducer> producers = new ArrayList<>(PRODUCER_COUNT);
+        for (int i = 0; i < PRODUCER_COUNT; i++) {
+            producers.add(new CountingProducer());
+        }
+        return producers;
+    }
+
+    /**
+     * Blocks until every caller has been released at the same moment.
+     *
+     * @param startLine the latch the callers wait on
+     */
+    private static void awaitStartLine(CountDownLatch startLine) {
+        try {
+            startLine.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("interrupted while waiting for the start line", e);
+        }
+    }
+
+    /** Producer stand-in that records how often it was released. */
+    private static final class CountingProducer implements Producer {
+
+        private final AtomicInteger releaseCount = new AtomicInteger();
+
+        @Override
+        public void releaseProducer() {
+            releaseCount.incrementAndGet();
+        }
+
+        /**
+         * Returns how often {@link #releaseProducer()} was called.
+         *
+         * @return the release count
+         */
+        int releaseCount() {
+            return releaseCount.get();
+        }
+
+        @Override
+        public void run() {
+            // never started: these tests only exercise the teardown
+        }
+
+        @Override
+        public void interrupt() {
+            // no work to stop
+        }
+
+        @Override
+        public void initProducer() {
+            // nothing to initialise
+        }
+
+        @Override
+        public void produceKeys() {
+            // never produces
+        }
+
+        @Override
+        public void processSecretBase(BigInteger secretBase) {
+            // never produces
+        }
+
+        @Override
+        public void processSecrets(BigInteger[] secrets) {
+            // never produces
+        }
+
+        @Override
+        public void waitTillProducerNotRunning() {
+            // never ran, so it is already not running
+        }
+
+        @Override
+        public ProducerState getState() {
+            return ProducerState.NOT_RUNNING;
+        }
+
+        @Override
+        public Throwable getLastFailure() {
+            throw new UnsupportedOperationException("no run, so no failure to report");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three changes that arrived together; the second was found while testing the first, and the third builds on it.

- **The OpenCL binding moved from JOCL to LWJGL 3** (3.4.2) and `org.jocl` is gone from the build. Calls no longer reach a binding library directly: a new `opencl/binding/` package holds an instance-based `ClApi` (mockable, unlike a static binding surface), typed handle records restoring the per-object types LWJGL collapses into a bare `long`, and explicit error checking — LWJGL only *returns* `cl_int` codes and never throws, so an unchecked call would fail silently. Two findings are worth knowing: **a stock Linux install would not have started** (LWJGL resolves the library by plain name, but an OpenCL runtime package ships only the versioned SONAME `libOpenCL.so.1` — the unversioned symlink comes from the separate `-dev` package, and JOCL never noticed because its JNI shim links against the SONAME), and **host-to-device uploads are now written in bounded slices**, because LWJGL cannot hand a Java array to the driver and a single-shot upload would need an off-heap staging copy the size of the payload — several GB for the Full-DB filter, whose byte image does not even fit a Java `byte[]`.
- **Two shutdown bugs fixed.** A finished run logged `Main#run end.` and never exited, and a run fed by a blocking key producer could not be shut down at all. Both were reported against incremental scans, and **both reproduce against unmodified `main`** — they predate the migration. Fixing them exposed a third: two overlapping teardowns released the same producer twice, which the OpenCL driver rejects with `CL_INVALID_MEM_OBJECT`.
- **Results can be broadcast, not just logged** — one message per *checked batch*, sent whether or not anything was found, over all three existing transports (each off by default via `broadcastResults`). `examples/websocket_scanner.html` makes the browser the whole user interface: it produces the ranges and renders the outcome over one connection. **The payload contains private keys and every connected client receives every result** — this is why each transport is opt-in.

## Test plan

- [x] Affected unit / integration tests pass locally — `mvn verify` on Windows: **2210 tests, 0 failures**, plus SpotBugs (Max/Low), Spotless and Enforcer
- [x] Release javadoc build (`-P release package`) clean, javadoc jar produced, zero warnings
- [x] Linux + pocl in a container against this branch: **2193 tests, 0 failures**. `MainTest` crashes the fork with SIGSEGV there, but that reproduces **identically on unmodified `main`** (same pocl, both freshly cloned) with the faulting frame inside pocl's own JIT-compiled kernel object — and CI's `Test OpenCL (pocl CPU)` job is green on `main`, so it is an artefact of that container's pocl build
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated — CHANGELOG, README (WebSocket key producer + broadcasting sections), CLAUDE.md (binding seam + result broadcast), TODO.md, `SECURITY.md` / `TEST_WRITING_GUIDE.md` corrected where they still named JOCL types

## Related issues / PRs

Closes the "pluggable OpenCL backend" item migrated from #22 — with a different outcome than planned there: JOCL was **replaced** by LWJGL rather than joined by JogAmp as a selectable second backend, because OpenCL handles cannot cross a binding boundary, which makes discovery, context creation and kernel execution one indivisible migration unit. Adding another backend later is now a matter of writing one more `ClApi`. Refs #6.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes — with one thing to flag explicitly: the result broadcast sends **private keys** in plaintext to every connected client, and its server is unencrypted. It is off by default and documented as localhost / trusted-LAN only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVnLgfgzxe31guE3D7fVwc