### PR TITLE
fix(test): assume an OpenCL device, not just a loadable library

### DIFF
--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLBuilderTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLBuilderTest.java
@@ -33,7 +33,7 @@ public class OpenCLBuilderTest {
         assertThat(openCLPlatforms.size(), is(greaterThan(Integer.valueOf(0))));
         assertThat(openCLPlatforms.getFirst().openCLDevices().size(), is(greaterThan(Integer.valueOf(0))));
         System.out.println(openCLPlatforms);
-        System.out.println("isOpenClNativeLibraryLoaded: " + new OpenCLBuilder().isOpenClLibraryAvailable());
+        System.out.println("isOpenClLibraryAvailable: " + new OpenCLBuilder().isOpenClLibraryAvailable());
         System.out.println("isOneOpenCL2DeviceAvailable: "
                 + new OpenCLBuilder().isOneOpenCL2_0OrGreaterDeviceAvailable(openCLPlatforms));
     }

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformAssume.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLPlatformAssume.java
@@ -33,6 +33,30 @@ public class OpenCLPlatformAssume implements PlatformAssume {
         Assumptions.assumeTrue(new OpenCLBuilder().isOpenClLibraryAvailable(), "OpenCL library not available");
     }
 
+    /**
+     * Assumes at least one OpenCL device is present, at any version.
+     *
+     * <p>Deliberately distinct from {@link #assumeOpenClLibraryAvailable()}: the library loading and
+     * a device existing are two different conditions, and on Windows they come apart. Windows ships
+     * the OpenCL <em>loader</em> ({@code OpenCL.dll}) as part of the system, so the library resolves
+     * even where no ICD is registered at all — a stock GitHub {@code windows-latest} runner is
+     * exactly that case. A test that only checks loadability and then reaches for
+     * {@code getPlatformIds().get(0)} therefore does not skip there; it fails with an index error.
+     *
+     * <p>Prefer this over
+     * {@link #assumeOpenClLibraryAvailableAndOneOpenCL2_0OrGreaterDeviceAvailable()} whenever the
+     * test does not actually need OpenCL 2.0 — requiring 2.0 would needlessly skip on an older
+     * device that can run the test perfectly well.
+     */
+    public void assumeOneOpenClDeviceAvailable() {
+        assumeOpenClLibraryAvailable();
+        int deviceCount = 0;
+        for (OpenCLPlatform openCLPlatform : new OpenCLBuilder().build()) {
+            deviceCount += openCLPlatform.openCLDevices().size();
+        }
+        Assumptions.assumeTrue(deviceCount > 0, "No OpenCL device available");
+    }
+
     public void assumeOneOpenCL2_0OrGreaterDeviceAvailable(List<OpenCLPlatform> openCLPlatforms) {
         Assumptions.assumeTrue(
                 new OpenCLBuilder().isOneOpenCL2_0OrGreaterDeviceAvailable(openCLPlatforms),

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/LwjglClApiBufferTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/opencl/binding/LwjglClApiBufferTest.java
@@ -31,7 +31,9 @@ import org.lwjgl.opencl.CL10;
  * round-tripped and compared byte for byte; an off-by-one in the offset would silently corrupt a
  * filter and show up only as missed addresses.
  *
- * <p>{@code @OpenCLTest}: needs a real device to write to.
+ * <p>{@code @OpenCLTest}: needs a real device to write to — hence
+ * {@link OpenCLPlatformAssume#assumeOneOpenClDeviceAvailable()} rather than the loadability check,
+ * which on Windows is satisfied by the system loader even with no ICD installed.
  */
 class LwjglClApiBufferTest {
 
@@ -51,7 +53,7 @@ class LwjglClApiBufferTest {
     @Test
     @OpenCLTest
     void writeBufferChunked_payloadLargerThanOneChunk_roundTripsUnchanged() {
-        new OpenCLPlatformAssume().assumeOpenClLibraryAvailable();
+        new OpenCLPlatformAssume().assumeOneOpenClDeviceAvailable();
 
         // arrange
         final byte[] source = new byte[PAYLOAD_BYTES];
@@ -69,7 +71,7 @@ class LwjglClApiBufferTest {
     @Test
     @OpenCLTest
     void writeBufferChunked_shortPayload_roundTripsInNativeByteOrder() {
-        new OpenCLPlatformAssume().assumeOpenClLibraryAvailable();
+        new OpenCLPlatformAssume().assumeOneOpenClDeviceAvailable();
 
         // arrange
         final short[] source = new short[SHORT_ELEMENT_COUNT];


### PR DESCRIPTION
## Summary

- `main` is red on `windows-latest`: `LwjglClApiBufferTest` fails with `ArrayIndexOutOfBounds` on `getPlatformIds().get(0)`. It asserted only that the OpenCL library *loads*, and on Windows that is not the same as having a device — Windows ships the OpenCL loader (`OpenCL.dll`) as part of the system, so the library resolves even where no ICD is registered. The test did not skip on a stock runner; it ran and indexed into an empty platform list.
- Linux never showed this because there the loader itself is absent without an ICD package, so the loadability check already skipped — and it passed locally and on the pocl job because both have a real device. That is exactly why it slipped through.
- Adds `assumeOneOpenClDeviceAvailable()`, which requires a device at any version. Deliberately **not** the existing 2.0-or-greater assume: this test round-trips a buffer and has no use for 2.0, so requiring it would needlessly skip on older devices that can run it fine.
- The three other users of the loadability check are correct as they stand — two iterate over the discovered devices (empty list, no iterations) and one only builds a value object — so they are left alone.

## Test plan

- [x] Reproduced the exact CI condition in a Linux container by removing the ICD while leaving the loader in place (`libOpenCL.so.1` still resolves, zero platforms), which is the Windows-runner situation:
  - `main`: `Tests run: 2, Errors: 2` — `ArrayIndexOutOfBounds Index 0 out of bounds for length 0`
  - this branch: `Tests run: 2, Skipped: 2`, BUILD SUCCESS
- [x] With a real device present (local Windows, NVIDIA): `LwjglClApiBufferTest`, `OpenCLBuilderTest`, `OpenCLAddKernelSmokeTest` all pass — the tests still actually run where they can
- [ ] CI is green on this branch

## Related issues / PRs

Follow-up to #328, which introduced the test.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVnLgfgzxe31guE3D7fVwc