### PR TITLE
Fix JPMS module-mode javadoc trap in fat-jar build steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -559,10 +559,23 @@ jobs:
       # reaching `deploy`), so the central-publishing plugin's publish goal — bound to the deploy phase —
       # does nothing here. `verify` runs: package (assembly `single` attaches the fat jar) → verify
       # (maven-gpg-plugin signs every attached artifact, incl. the fat jar → .jar.asc). It rebuilds and
-      # re-signs the main/sources/javadoc jars in target/ too (harmless), so the Collect step below now
+      # re-signs the main/sources jars in target/ too (harmless), so the Collect step below now
       # also finds the fat jar + its .asc. Runs only if the deploy succeeded.
+      #
+      # -Dmaven.javadoc.skip=true is REQUIRED here: this invocation shares target/ with the Deploy
+      # step above with no `mvn clean` between them. That step's own module-info-compile execution
+      # already left target/classes/module-info.class on disk, so THIS invocation's attach-javadocs
+      # would see the module descriptor and flip into JPMS module mode — before this invocation's own
+      # module-info-compile even runs, since attach-javadocs is ordered first (see CLAUDE.md "JPMS
+      # module descriptor" section). The single-invocation "javadoc before module-info-compile"
+      # ordering fix protects against a fresh compile within one invocation; it does nothing against
+      # a *prior* invocation's leftover module-info.class (2026-08-02 incident, run 30768800950:
+      # "error: No source files for package net.ladenthin.bitcoinaddressfinder.io"). Safe to skip:
+      # the Deploy step already built + signed a correct, classpath-mode javadoc jar, and this
+      # invocation never touches or re-signs it — the untouched javadoc.jar + javadoc.jar.asc from
+      # the Deploy step are what the Collect step below picks up.
       - name: Build & sign fat jar (GitHub asset only — not deployed to Central)
-        run: mvn --batch-mode --no-transfer-progress -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true -P release,assembly verify -DskipTests
+        run: mvn --batch-mode --no-transfer-progress -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true -Dmaven.javadoc.skip=true -P release,assembly verify -DskipTests
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       # Runs even when the deploy step failed: a Central publish-poll timeout reds the
@@ -648,10 +661,23 @@ jobs:
       # reaching `deploy`), so the central-publishing plugin's publish goal — bound to the deploy phase —
       # does nothing here. `verify` runs: package (assembly `single` attaches the fat jar) → verify
       # (maven-gpg-plugin signs every attached artifact, incl. the fat jar → .jar.asc). It rebuilds and
-      # re-signs the main/sources/javadoc jars in target/ too (harmless), so the Collect step below now
+      # re-signs the main/sources jars in target/ too (harmless), so the Collect step below now
       # also finds the fat jar + its .asc. Runs only if the deploy succeeded.
+      #
+      # -Dmaven.javadoc.skip=true is REQUIRED here: this invocation shares target/ with the Deploy
+      # step above with no `mvn clean` between them. That step's own module-info-compile execution
+      # already left target/classes/module-info.class on disk, so THIS invocation's attach-javadocs
+      # would see the module descriptor and flip into JPMS module mode — before this invocation's own
+      # module-info-compile even runs, since attach-javadocs is ordered first (see CLAUDE.md "JPMS
+      # module descriptor" section). The single-invocation "javadoc before module-info-compile"
+      # ordering fix protects against a fresh compile within one invocation; it does nothing against
+      # a *prior* invocation's leftover module-info.class (2026-08-02 incident, run 30768800950:
+      # "error: No source files for package net.ladenthin.bitcoinaddressfinder.io"). Safe to skip:
+      # the Deploy step already built + signed a correct, classpath-mode javadoc jar, and this
+      # invocation never touches or re-signs it — the untouched javadoc.jar + javadoc.jar.asc from
+      # the Deploy step are what the Collect step below picks up.
       - name: Build & sign fat jar (GitHub asset only — not deployed to Central)
-        run: mvn --batch-mode --no-transfer-progress -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true -P release,assembly verify -DskipTests
+        run: mvn --batch-mode --no-transfer-progress -Dnet.ladenthin.bitcoinaddressfinder.disableLMDBTest=true -Dmaven.javadoc.skip=true -P release,assembly verify -DskipTests
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       # Runs even when the deploy step failed: a Central publish-poll timeout reds the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,20 +77,29 @@ mode is unusable here — the module declares no `requires` and `module-info.jav
 in `src/main/java9`, off javadoc's source path). See the extensive comments on those two
 `pom.xml` executions before touching their phase or ordering.
 
-**The single surviving `-Dmaven.javadoc.skip=true` in CI (BAF-only, do not remove blindly).**
-After a cross-repo cleanup that deleted every other javadoc-skip flag from all four sibling
-pipelines, exactly **one** remains: the `build` job in `.github/workflows/publish.yml`. It is
-necessary because that job runs plain `mvn package`, which triggers `attach-javadocs` at
-`prepare-package`; BAF's javadoc is module-aware (`<source>21</source>` + `module-info.java`
-in `src/main/java9`), so an unguarded run can flip into JPMS module mode and fail with
-`No source files for package net.ladenthin...`. The Java-8 siblings (java-llama.cpp,
-streambuffer, llamacpp-ai-index — all `<source>8>`) stay in classpath mode regardless and
-therefore carry **no** skip flag; the redundant/no-op flags they used to have were removed,
-and streambuffer/llamacpp let javadoc build during their `verify` test job so it is gated in
-PR CI. BAF cannot do the same cheaply (the module-mode trap needs the full `-P release
-package` ordering), which is why BAF's javadoc is validated only at publish. Before dropping
-this last flag, prove `mvn package` builds BAF's javadoc clean — a standalone `mvn
-javadoc:jar` cannot, it always runs classpath mode and hides the trap.
+**The `-Dmaven.javadoc.skip=true` flags in CI (BAF-only, do not remove blindly).** After a
+cross-repo cleanup that deleted every other javadoc-skip flag from all four sibling pipelines,
+BAF still carries three: the `build` job's flag (guards a single `mvn package` invocation —
+that job runs plain `mvn package`, which triggers `attach-javadocs` at `prepare-package`; an
+unguarded run can flip into JPMS module mode) and one flag each on the `publish-snapshot` /
+`publish-release` jobs' "Build & sign fat jar" steps (guards a **second** `mvn -P
+release,assembly verify` invocation that shares `target/` with the preceding `mvn -P release
+deploy` invocation in the same job, with no `mvn clean` in between). The fat-jar flags guard a
+*different* trigger of the same trap than the `build` job's flag — see
+[`../workspace/policies/jpms-module-descriptor.md`](../workspace/policies/jpms-module-descriptor.md)
+"A second trigger: multiple Maven invocations sharing `target/`" for the general mechanism
+(incident: 2026-08-02, CI run 30768800950, `error: No source files for package
+net.ladenthin.bitcoinaddressfinder.io`). The Java-8 siblings (java-llama.cpp, streambuffer,
+srcmorph — all `<source>8>`) stay in classpath mode regardless and therefore carry **no** skip
+flag; the redundant/no-op flags they used to have were removed, and streambuffer/llamacpp let
+javadoc build during their `verify` test job so it is gated in PR CI. BAF cannot do the same
+cheaply (the module-mode trap needs the full `-P release package` ordering), which is why
+BAF's javadoc is validated only at publish. Before dropping the `build` job's flag, prove `mvn
+package` builds BAF's javadoc clean — a standalone `mvn javadoc:jar` cannot, it always runs
+classpath mode and hides the trap. Before dropping either fat-jar flag, prove the
+**two-invocation, no-`clean`** sequence (`mvn -P release package` then, without `clean`, `mvn
+-P release,assembly verify`) builds javadoc clean — a single-invocation `mvn -P release clean
+package` proves nothing about this trigger, since `clean` is exactly what makes it disappear.
 
 ### JPMS module descriptor (`module-info.java`) handling — why it's hidden until the end
 


### PR DESCRIPTION
## Summary

- Add `-Dmaven.javadoc.skip=true` to the "Build & sign fat jar" steps in both `publish-snapshot` and `publish-release` jobs in `.github/workflows/publish.yml`
- Update `CLAUDE.md` to document the two distinct triggers of the JPMS module-mode javadoc failure and explain why three skip flags are now necessary (not just one)
- The fat-jar steps share `target/` with the preceding Deploy step with no `mvn clean` between them, causing `module-info.class` from the Deploy step to remain on disk and flip the fat-jar invocation into JPMS module mode before its own `module-info-compile` runs

## Motivation

The fat-jar build steps (`mvn -P release,assembly verify`) run after the Deploy step (`mvn -P release deploy`) in the same job without an intervening `mvn clean`. This means `target/classes/module-info.class` from the Deploy step remains on disk. When the fat-jar step's `attach-javadocs` execution runs (ordered before `module-info-compile`), it sees the leftover module descriptor and flips into JPMS module mode, causing the same "No source files for package" failure that the `build` job's skip flag prevents.

This is a *different* trigger than the `build` job's single-invocation scenario: the `build` job guards against a fresh compile within one invocation, while the fat-jar flags guard against a *prior* invocation's leftover `module-info.class`. Both are necessary because the single-invocation ordering fix (javadoc before module-info-compile) does not protect against cross-invocation state.

Incident: 2026-08-02, CI run 30768800950, error: `No source files for package net.ladenthin.bitcoinaddressfinder.io`

## Test plan

- [x] CI is green on this branch (the fix prevents the documented failure mode)
- [x] Docs updated: `CLAUDE.md` now explains both triggers and all three skip flags

## Related issues / PRs

Incident: 2026-08-02, CI run 30768800950

## Checklist

- [x] I have read `CLAUDE.md` and understand the JPMS module-descriptor handling invariants
- [x] Docs updated to reflect the change and its rationale
- [x] No security-sensitive changes

https://claude.ai/code/session_017poQZZuCsH2i9eZyZYuv2r