### PR TITLE
Upgrade dependencies and add jspecify to dependencyManagement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,7 +314,7 @@ See `examples/config_*.json` for all configuration variants.
 
 ### Frameworks
 
-- **JUnit 6** (6.1.2) — `junit-jupiter` (JUnit Jupiter) for all tests
+- **JUnit 6** (6.1.3) — `junit-jupiter` (JUnit Jupiter) for all tests
 - **Hamcrest** (3.0) — matchers
 - **Mockito** (5.23.0) — mocking
 
@@ -569,7 +569,7 @@ No other sibling repo has OpenCL code, so this distinction is BAF-only.
 | Dependency | Version | Purpose |
 |---|---|---|
 | `bitcoinj-core` | 0.17.1 | Bitcoin crypto, address derivation |
-| `bcprov-jdk15to18` | 1.85.1 | Bouncy Castle crypto provider (bitcoinj transitive; pinned to fix GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) |
+| `bcprov-jdk15to18` | 1.85.2 | Bouncy Castle crypto provider (bitcoinj transitive; pinned to fix GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) |
 | `protobuf-javalite` | 4.35.1 | Protocol Buffers (bitcoinj transitive; pinned to latest) |
 | `jsr305` | 3.0.2 | Findbugs nullability annotations (bitcoinj transitive, runtime) |
 | `jcip-annotations` | 1.0 | JCIP concurrency annotations (bitcoinj transitive, runtime) |
@@ -587,7 +587,7 @@ No other sibling repo has OpenCL code, so this distinction is BAF-only.
 | `logback-classic` | 1.6.1 | SLF4J implementation |
 
 Test-only:
-| `junit-jupiter` | 6.1.2 | JUnit 6 (Jupiter) test framework |
+| `junit-jupiter` | 6.1.3 | JUnit 6 (Jupiter) test framework |
 | `hamcrest` | 3.0 | Assertion matchers |
 | `mockito-core` | 5.23.0 | Mocking |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -694,6 +694,13 @@ second `mvn -P release,assembly verify` (which stops before `deploy`, so `centra
 uploads it). The cross-repo convention + per-repo shapes are documented in
 [`../workspace/policies/fat-jar-release-assets.md`](../workspace/policies/fat-jar-release-assets.md).
 
+## Dependency Convergence Pinning
+
+`dependencyConvergence` is enabled (maven-enforcer). Convention for pinning a direct-vs-transitive
+version mismatch in `dependencyManagement`, the `excludedScopes=[test,provided]` enforcer default
+gotcha, and merge-discipline guidance are in
+[`../workspace/policies/dependency-convergence-pinning.md`](../workspace/policies/dependency-convergence-pinning.md).
+
 ## Open TODOs
 
 Open TODOs for this repo live in [`TODO.md`](TODO.md). Cross-repo status

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ SPDX-License-Identifier: Apache-2.0
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <errorprone.version>2.50.0</errorprone.version>
         <nullaway.version>0.13.8</nullaway.version>
-        <checker.version>4.2.1</checker.version>
+        <checker.version>4.2.2</checker.version>
         <java-websocket.version>1.6.0</java-websocket.version>
         <jeromq.version>0.6.0</jeromq.version>
         <jspecify.version>1.0.1</jspecify.version>
@@ -88,7 +88,7 @@ SPDX-License-Identifier: Apache-2.0
         <commons-io.version>2.22.0</commons-io.version>
         <commons-codec.version>1.22.1</commons-codec.version>
         <maven-artifact.version>3.9.16</maven-artifact.version>
-        <junit.version>6.1.2</junit.version>
+        <junit.version>6.1.3</junit.version>
         <hamcrest.version>3.0</hamcrest.version>
         <mockito.version>5.23.0</mockito.version>
         <logcaptor.version>2.12.6</logcaptor.version>
@@ -130,6 +130,12 @@ SPDX-License-Identifier: Apache-2.0
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15to18</artifactId>
                 <version>${bcprov.version}</version>
+            </dependency>
+            <!-- jspecify: guava brings 1.0.0; we declare ${jspecify.version} directly. -->
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ SPDX-License-Identifier: Apache-2.0
         <jspecify.version>1.0.1</jspecify.version>
         <lombok.version>1.18.46</lombok.version>
         <bitcoinj.version>0.17.1</bitcoinj.version>
-        <bcprov.version>1.85.1</bcprov.version>
+        <bcprov.version>1.85.2</bcprov.version>
         <protobuf.version>4.35.1</protobuf.version>
         <jsr305.version>3.0.2</jsr305.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
@@ -249,7 +249,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.8</version>
+                    <version>1.25.9</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
## Summary

- Upgrade checker-framework to 4.2.2, bcprov-jdk15to18 to 1.85.2, junit-jupiter to 6.1.3, and pitest-maven to 1.25.9
- Add explicit jspecify dependency declaration to `dependencyManagement` to pin the version (1.0.1) and avoid transitive version conflicts from guava
- Update CLAUDE.md to document the new dependency convergence pinning convention

## Test plan

- [ ] Affected unit / integration tests pass locally
- [ ] CI is green on this branch
- [ ] Docs / CHANGELOG updated where applicable

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01KqVypnKbydSNgmGFfhCMUc