### PR TITLE
Sync copyfromhashcat with the upstream secp256k1 PR (hashcat/hashcat#4763)

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -751,7 +751,7 @@ with the arithmetic-heavy affine walk" trend seen on NVIDIA, though it stays wel
 OpenCL 2.0 AMD-APP, wave32.
 
 > **Methodology caveat — the sweep tables above are measured with `noinline` (§9).** The RX 7900 XTX
-> sweep uses `-D AMD_NOINLINE_HELPERS` because the inlined kernel takes 8–16+ min to compile on AMD (§9),
+> sweep uses `-D FORCE_NO_INLINE` because the inlined kernel takes 8–16+ min to compile on AMD (§9),
 > so those out-of-line absolutes are *understated* relative to the **inlined AMD build, which is much
 > faster.** An earlier edition could only *speculate* the inlined ceiling (≈ 288 M keys/s, extrapolated
 > from a `batch=20, kpwi=64` re-sweep, §10 "Track B"); the **2026-07-23 inline A/B supersedes it**: at the
@@ -1840,13 +1840,13 @@ does not share LLVM's per-function scaling, which is why CUDA was always fast.
   uninterrupted. Every earlier attempt was killed before it could populate the cache.
 
 **The fix — force the helpers out-of-line (`noinline`).** Build the kernel with
-`-D AMD_NOINLINE_HELPERS`, which makes the vendored `DECLSPEC` expand to
+`-D FORCE_NO_INLINE`, which makes the vendored `DECLSPEC` expand to
 `__attribute__((noinline))` (`copyfromhashcat/inc_vendor.h`). The kernel is then **partitioned into
 many small functions**, each compiling in roughly linear time, instead of one quadratic-cost giant.
 Note removing the `inline` *keyword* alone does nothing — LLVM still inlines at `-O3`; only the hard
 `noinline` attribute stops it.
 
-| Cold compile (fresh `comgr` cache), RX 7900 XTX | inlined (`noInlineHelpers=false`) | out-of-line (`-D AMD_NOINLINE_HELPERS`, AMD auto-default) |
+| Cold compile (fresh `comgr` cache), RX 7900 XTX | inlined (`noInlineHelpers=false`) | out-of-line (`-D FORCE_NO_INLINE`, AMD auto-default) |
 |---|--:|--:|
 | Stripped (no hash160, legacy inverse) | 8m 02s | **2.99 s** |
 | **Full (both hash160 chains + safegcd)** | **>16 min (never finished)** | **3.09 s** |

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducerOpenCL.java
@@ -192,7 +192,7 @@ public class CProducerOpenCL extends CProducer {
      *       {@code OpenCLContext.resolveEffectiveNoInlineHelpers(...)}. This is the recommended
      *       setting: AMD gets the compile-time fix automatically, NVIDIA keeps full throughput.</li>
      *   <li>{@link Boolean#TRUE} — <b>force on</b> regardless of vendor: the kernel is always built
-     *       with {@code -D AMD_NOINLINE_HELPERS}.</li>
+     *       with {@code -D FORCE_NO_INLINE}.</li>
      *   <li>{@link Boolean#FALSE} — <b>force off</b> regardless of vendor: the define is never added,
      *       even on AMD (a slow-compile warning is logged). Needed to A/B inlined vs. out-of-line on
      *       an AMD device.</li>
@@ -202,7 +202,7 @@ public class CProducerOpenCL extends CProducer {
      * allocation + SelectionDAG scheduling) scales ~super-linearly per function, so the single giant
      * {@code generateKeysKernel_grid} takes <b>8–16+ minutes</b> to build on AMD RDNA3 (the full kernel
      * did not finish within 16&nbsp;min on an RX&nbsp;7900&nbsp;XTX / gfx1100). The {@code -D
-     * AMD_NOINLINE_HELPERS} define makes the vendored {@code DECLSPEC} helpers
+     * FORCE_NO_INLINE} define makes the vendored {@code DECLSPEC} helpers
      * {@code __attribute__((noinline))}, partitioning the back-end work into many small functions and
      * cutting the cold compile to <b>≈3&nbsp;s</b>. (Removing the {@code inline} hint alone does nothing
      * — LLVM still inlines at {@code -O3}; only a hard {@code noinline} stops it.)

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/opencl/OpenCLContext.java
@@ -161,7 +161,7 @@ public class OpenCLContext implements ReleaseCLObject {
      * runtime cost on other vendors (≈4.5× slower on NVIDIA). See {@code docs/performance.md}.
      */
     @VisibleForTesting
-    static final String NO_INLINE_HELPERS_BUILD_OPTION = "-D AMD_NOINLINE_HELPERS";
+    static final String NO_INLINE_HELPERS_BUILD_OPTION = "-D FORCE_NO_INLINE";
 
     /**
      * Returns whether an OpenCL {@code CL_DEVICE_VENDOR} string denotes an AMD device. Case-insensitive
@@ -218,9 +218,9 @@ public class OpenCLContext implements ReleaseCLObject {
         final String source = (configured == null) ? "auto" : "explicit configuration";
 
         if (effective) {
-            // OUT-OF-LINE (-D AMD_NOINLINE_HELPERS): compiles fast (~3 s) but is ~4x slower at runtime.
+            // OUT-OF-LINE (-D FORCE_NO_INLINE): compiles fast (~3 s) but is ~4x slower at runtime.
             LOGGER.warn(
-                    "noInlineHelpers -> OUT-OF-LINE kernel (-D AMD_NOINLINE_HELPERS) on device '{}' (vendor '{}', "
+                    "noInlineHelpers -> OUT-OF-LINE kernel (-D FORCE_NO_INLINE) on device '{}' (vendor '{}', "
                             + "source: {}): the DECLSPEC helpers are out-of-lined, so the kernel compiles fast (~3 s) "
                             + "but runs ~4x SLOWER (measured ~3.6x on AMD RDNA3, ~4.5x on NVIDIA; see "
                             + "docs/performance.md sections 9-10). Set noInlineHelpers=false for the full-speed inlined "

--- a/src/main/resources/copyfromhashcat/inc_ecc_secp256k1.cl
+++ b/src/main/resources/copyfromhashcat/inc_ecc_secp256k1.cl
@@ -602,15 +602,9 @@ DECLSPEC void mul_mod (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, PRIVATE_AS co
   u32 t1 = 0;
   u32 c  = 0;
 
-  // Schoolbook multiply: limb t[i] = Sum a[j]*b[i-j] over j in [max(0,i-7), min(7,i)].
-  // The two index halves (i<8: j in [0,i]; i>=8: j in [i-7,7]) are folded into one loop;
-  // with the compile-time bounds and #pragma unroll the compiler emits the same unrolled code.
-  #pragma unroll
-  for (u32 i = 0; i < 15; i++)
+  for (u32 i = 0; i < 8; i++)
   {
-    u32 jStart = (i > 7) ? (i - 7) : 0; // ternary, not i-7, to avoid u32 underflow for i<7
-    u32 jEnd   = (i < 8) ? i : 7;
-    for (u32 j = jStart; j <= jEnd; j++)
+    for (u32 j = 0; j <= i; j++)
     {
       u64 p = ((u64) a[j]) * b[i - j];
 
@@ -622,6 +616,30 @@ DECLSPEC void mul_mod (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, PRIVATE_AS co
       t1 = d >> 32;
 
       c += d < p; // carry
+    }
+
+    t[i] = t0;
+
+    t0 = t1;
+    t1 = c;
+
+    c = 0;
+  }
+
+  for (u32 i = 8; i < 15; i++)
+  {
+    for (u32 j = i - 7; j < 8; j++)
+    {
+      u64 p = ((u64) a[j]) * b[i - j];
+
+      u64 d = ((u64) t1) << 32 | t0;
+
+      d += p;
+
+      t0 = (u32) d;
+      t1 = d >> 32;
+
+      c += d < p;
     }
 
     t[i] = t0;
@@ -650,7 +668,6 @@ DECLSPEC void mul_mod (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, PRIVATE_AS co
   // Note: SECP256K1_P = 2^256 - 2^32 - 977 (0x03d1 = 977)
   // multiply t[8]...t[15] by omega:
 
-  #pragma unroll
   for (u32 i = 0, j = 8; i < 8; i++, j++)
   {
     u64 p = ((u64) 0x03d1) * t[j] + c;
@@ -677,7 +694,6 @@ DECLSPEC void mul_mod (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *a, PRIVATE_AS co
 
   // memset (t, 0, sizeof (t));
 
-  #pragma unroll
   for (u32 i = 0, j = 8; i < 8; i++, j++)
   {
     u64 p = ((u64) 0x3d1) * tmp[j] + c2;
@@ -779,25 +795,17 @@ DECLSPEC void sqrt_mod (PRIVATE_AS u32 *r)
 
 // (inverse (a, p) * a) % p == 1 (or think of a * a^-1 = a / a = 1)
 
-DECLSPEC void inv_mod (PRIVATE_AS u32 *a)
+DECLSPEC void inv_mod_binary_gcd (PRIVATE_AS u32 *a)
 {
-#ifndef USE_LEGACY_BINARY_GCD_INV_MOD
-  // Default: route every modular inverse through the fixed-iteration safegcd path (see
-  // inv_mod_safegcd below). Measured ~+45% kernel throughput at keysPerWorkItem=128 on an RTX 3070
-  // vs. the binary-GCD code below, because safegcd runs a fixed 600 divsteps for every lane (no
-  // warp divergence) where the binary GCD's iteration count is input-dependent. Same result.
-  // Build with -D USE_LEGACY_BINARY_GCD_INV_MOD to fall back to the binary GCD (A/B, or for a
-  // device where safegcd's signed arithmetic-shift assumption does not hold).
-  inv_mod_safegcd (a);
-  return;
-#else
   // Guard against a == 0 (the z-coordinate of the point at infinity, produced by
-  // point_add of P + (-P) or the P == Q doubling case in the keysPerWorkItem>1 path).
-  // Without this the binary-GCD loop below never terminates: t0 = 0 is always even,
-  // so shifting keeps it 0 and the exit condition (t0 == p) is never reached. On a
-  // CPU OpenCL device (pocl) the work-item then spins forever and clFinish hangs;
-  // GPUs happen to mask it. Cheap, branch-predictable early-out (7 ORs + 1 compare).
+  // point_add of P + (-P) or by feeding point_mul_xy a zero scalar).
+  // Without this the loop below never terminates: t0 = 0 is always even, so shifting
+  // keeps it 0 and the exit condition (t0 == p) is never reached. On a CPU OpenCL
+  // device (pocl) the work-item then spins forever and clFinish hangs; GPUs happen to
+  // mask it. Cheap, branch-predictable early-out (7 ORs + 1 compare).
+
   const u32 a_is_zero = (a[0] | a[1] | a[2] | a[3] | a[4] | a[5] | a[6] | a[7]) == 0;
+
   if (a_is_zero) return;
 
   u32 t0[8];
@@ -1026,28 +1034,42 @@ DECLSPEC void inv_mod (PRIVATE_AS u32 *a)
   a[5] = t2[5];
   a[6] = t2[6];
   a[7] = t2[7];
-#endif // USE_LEGACY_BINARY_GCD_INV_MOD
 }
 
 /*
  * safegcd modular inverse (Bernstein-Yang "divsteps"), a faithful port of libsecp256k1's
  * CONSTANT-TIME modinv32 (bitcoin-core/secp256k1, src/modinv32_impl.h, MIT). Drop-in alternative to
- * inv_mod() above with the SAME signature (u32 a[8] little-endian, value in [0, p), replaced by its
- * inverse mod p). Self-contained: depends only on the field prime p (encoded below) and 32/64-bit
- * integer math already used by mul_mod — no project-specific helpers — so it is upstreamable.
+ * inv_mod_binary_gcd() above with the SAME signature (u32 a[8] little-endian, value in [0, p),
+ * replaced by its inverse mod p). Self-contained: depends only on the field prime p (encoded below)
+ * and 32/64-bit integer math already used by mul_mod, no other helpers.
  *
- * Why this exists: inv_mod() above is a binary extended GCD whose iteration count DEPENDS ON THE
- * INPUT. Under SIMT every lane in a warp runs to the slowest lane's count (warp divergence). safegcd
- * runs a FIXED 20*30 = 600 divsteps for every input, so a warp finishes in lock-step.
+ * Why this exists: inv_mod_binary_gcd() above is a binary extended GCD whose iteration count DEPENDS
+ * ON THE INPUT. Under SIMT every lane in a warp runs to the slowest lane's count (warp divergence).
+ * safegcd runs a FIXED 20*30 = 600 divsteps for every input, so a warp finishes in lock-step.
  *
  * Representation: 9 signed 30-bit limbs (value = sum v[i]*2^(30*i)). 30-bit limbs keep every
- * intermediate product inside a 64-bit accumulator (`long`), avoiding the 128-bit math the 62-bit
- * variant needs.
+ * intermediate product inside a 64-bit accumulator (safegcd_i64), avoiding the 128-bit math the
+ * 62-bit variant needs.
  *
  * Shift note: like the reference, this relies on ARITHMETIC (sign-extending) right shift of signed
- * `int`/`long`. NVIDIA and pocl both implement that; the parity test (test_inv_mod_safegcd) guards
- * any device that disagrees.
+ * `int`/safegcd_i64. Every backend hashcat targets implements that; a device that does not would
+ * need -D USE_LEGACY_BINARY_GCD_INV_MOD.
  */
+
+// Signed 64-bit accumulator. hashcat has no signed counterpart to u64, and plain `long` is not
+// portable here: under CUDA `long` follows the host ABI and is 32-bit on Windows (the same reason
+// inc_types.h spells ullong as `unsigned long long`), and this file is additionally compiled on the
+// host by src/emu_inc_ecc_secp256k1.c. So pick the width per backend, keyed off the same macros
+// inc_vendor.h selects: OpenCL C guarantees a 64-bit `long`, CUDA and HIP need `long long`, and the
+// native/host build has stdint.
+
+#if defined IS_OPENCL || defined IS_METAL
+typedef long safegcd_i64;
+#elif defined IS_CUDA || defined IS_HIP
+typedef signed long long safegcd_i64;
+#else
+typedef int64_t safegcd_i64;
+#endif
 
 #define SAFEGCD_M30 0x3fffffff
 // secp256k1 field prime p = 2^256 - 2^32 - 977 in signed-30 limbs, and -p^-1 mod 2^30 helper.
@@ -1094,7 +1116,7 @@ DECLSPEC void modinv32_update_de_30 (PRIVATE_AS int *d, PRIVATE_AS int *e, PRIVA
   const int modulus[9] = SAFEGCD_P_INIT;
   const int u = t[0], v = t[1], q = t[2], r = t[3];
   int di, ei, md, me, sd, se;
-  long cd, ce;
+  safegcd_i64 cd, ce;
 
   sd = d[8] >> 31;
   se = e[8] >> 31;
@@ -1102,23 +1124,23 @@ DECLSPEC void modinv32_update_de_30 (PRIVATE_AS int *d, PRIVATE_AS int *e, PRIVA
   me = (q & sd) + (r & se);
   di = d[0];
   ei = e[0];
-  cd = (long) u * di + (long) v * ei;
-  ce = (long) q * di + (long) r * ei;
+  cd = (safegcd_i64) u * di + (safegcd_i64) v * ei;
+  ce = (safegcd_i64) q * di + (safegcd_i64) r * ei;
   // choose md,me so the low 30 bits of t*[d,e]+p*[md,me] vanish
   md -= (int) ((SAFEGCD_P_INV30 * (u32) cd + (u32) md) & SAFEGCD_M30);
   me -= (int) ((SAFEGCD_P_INV30 * (u32) ce + (u32) me) & SAFEGCD_M30);
-  cd += (long) modulus[0] * md;
-  ce += (long) modulus[0] * me;
+  cd += (safegcd_i64) modulus[0] * md;
+  ce += (safegcd_i64) modulus[0] * me;
   cd >>= 30;
   ce >>= 30;
   for (int i = 1; i < 9; i++)
   {
     di = d[i];
     ei = e[i];
-    cd += (long) u * di + (long) v * ei;
-    ce += (long) q * di + (long) r * ei;
-    cd += (long) modulus[i] * md;
-    ce += (long) modulus[i] * me;
+    cd += (safegcd_i64) u * di + (safegcd_i64) v * ei;
+    ce += (safegcd_i64) q * di + (safegcd_i64) r * ei;
+    cd += (safegcd_i64) modulus[i] * md;
+    ce += (safegcd_i64) modulus[i] * me;
     d[i - 1] = (int) cd & SAFEGCD_M30; cd >>= 30;
     e[i - 1] = (int) ce & SAFEGCD_M30; ce >>= 30;
   }
@@ -1131,20 +1153,20 @@ DECLSPEC void modinv32_update_fg_30 (PRIVATE_AS int *f, PRIVATE_AS int *g, PRIVA
 {
   const int u = t[0], v = t[1], q = t[2], r = t[3];
   int fi, gi;
-  long cf, cg;
+  safegcd_i64 cf, cg;
 
   fi = f[0];
   gi = g[0];
-  cf = (long) u * fi + (long) v * gi;
-  cg = (long) q * fi + (long) r * gi;
+  cf = (safegcd_i64) u * fi + (safegcd_i64) v * gi;
+  cg = (safegcd_i64) q * fi + (safegcd_i64) r * gi;
   cf >>= 30;
   cg >>= 30;
   for (int i = 1; i < 9; i++)
   {
     fi = f[i];
     gi = g[i];
-    cf += (long) u * fi + (long) v * gi;
-    cg += (long) q * fi + (long) r * gi;
+    cf += (safegcd_i64) u * fi + (safegcd_i64) v * gi;
+    cg += (safegcd_i64) q * fi + (safegcd_i64) r * gi;
     f[i - 1] = (int) cf & SAFEGCD_M30; cf >>= 30;
     g[i - 1] = (int) cg & SAFEGCD_M30; cg >>= 30;
   }
@@ -1243,7 +1265,7 @@ DECLSPEC void modinv32_to_u32x8 (PRIVATE_AS u32 *a, PRIVATE_AS const int *d)
   }
 }
 
-// Drop-in modular inverse: a (u32[8], in [0, p)) <- a^-1 mod p. inv_mod(0) == 0 (matches inv_mod).
+// Drop-in modular inverse: a (u32[8], in [0, p)) <- a^-1 mod p. Maps 0 to 0, as the binary GCD does.
 DECLSPEC void inv_mod_safegcd (PRIVATE_AS u32 *a)
 {
   int d[9] = { 0 };
@@ -1265,6 +1287,38 @@ DECLSPEC void inv_mod_safegcd (PRIVATE_AS u32 *a)
   // g has reached 0; f == +/-1 (== gcd); d holds +/- the inverse. Normalize using sign of f.
   modinv32_normalize_30 (d, f[8]);
   modinv32_to_u32x8 (a, d);
+}
+
+// Both implementations above compute the same thing; this picks which one the EC code uses.
+//
+// safegcd is the default because its iteration count is fixed, while the binary GCD's depends on
+// the input: under SIMT that makes every lane in a warp wait for the slowest one. Build with
+// -D USE_LEGACY_BINARY_GCD_INV_MOD to go back to the binary GCD, either to A/B the two or for a
+// device whose signed right shift is not arithmetic (safegcd assumes it is, the binary GCD does not).
+
+DECLSPEC void inv_mod (PRIVATE_AS u32 *a)
+{
+  #ifdef USE_LEGACY_BINARY_GCD_INV_MOD
+  inv_mod_binary_gcd (a);
+  #else
+  inv_mod_safegcd (a);
+  #endif
+}
+
+// Jacobian (x, y, z) -> affine (x, y), in place: x_affine = x / z^2, y_affine = y / z^3.
+// z is used as scratch and is destroyed.
+
+DECLSPEC void point_to_affine (PRIVATE_AS u32 *x, PRIVATE_AS u32 *y, PRIVATE_AS u32 *z)
+{
+  inv_mod (z);
+
+  u32 z2[8];
+
+  mul_mod (z2, z, z); // z^2
+  mul_mod (x, x, z2); // x / z^2
+
+  mul_mod (z, z2, z); // z^3
+  mul_mod (y, y, z);  // y / z^3
 }
 
 /*
@@ -1794,13 +1848,7 @@ DECLSPEC void point_get_coords (PRIVATE_AS secp256k1_t *r, PRIVATE_AS const u32 
 
   // to affine:
 
-  inv_mod (rz);
-
-  mul_mod (neg, rz, rz); // neg is temporary variable (z^2)
-  mul_mod (rx,  rx, neg);
-
-  mul_mod (rz, neg, rz);
-  mul_mod (ry, ry, rz);
+  point_to_affine (rx, ry, rz);
 
   r->xy[24] = rx[0];
   r->xy[25] = rx[1];
@@ -1859,13 +1907,7 @@ DECLSPEC void point_get_coords (PRIVATE_AS secp256k1_t *r, PRIVATE_AS const u32 
 
   // to affine:
 
-  inv_mod (rz);
-
-  mul_mod (neg, rz, rz);
-  mul_mod (rx,  rx, neg);
-
-  mul_mod (rz, neg, rz);
-  mul_mod (ry, ry, rz);
+  point_to_affine (rx, ry, rz);
 
   r->xy[48] = rx[0];
   r->xy[49] = rx[1];
@@ -1924,13 +1966,7 @@ DECLSPEC void point_get_coords (PRIVATE_AS secp256k1_t *r, PRIVATE_AS const u32 
 
   // to affine:
 
-  inv_mod (rz);
-
-  mul_mod (neg, rz, rz);
-  mul_mod (rx,  rx, neg);
-
-  mul_mod (rz, neg, rz);
-  mul_mod (ry, ry, rz);
+  point_to_affine (rx, ry, rz);
 
   r->xy[72] = rx[0];
   r->xy[73] = rx[1];
@@ -2101,7 +2137,7 @@ DECLSPEC void point_mul_xy (PRIVATE_AS u32 *x1, PRIVATE_AS u32 *y1, PRIVATE_AS c
 
   // Guard the first-window read against a zero digit (happens when the scalar k reduces to 0).
   // Without this, (multiplier - 1) underflows and x_pos below indexes ~3.2e9 words past tmps->xy[]
-  // — an out-of-bounds read (CPU OpenCL devices fault with SIGSEGV; GPUs silently read garbage).
+  // that is an out-of-bounds read (CPU OpenCL devices fault with SIGSEGV; GPUs read garbage).
   // k == 0 is not a valid private key, so clamping to 1 (the base point G) just keeps it in bounds.
   const u32 multiplier = (multiplier_raw == 0) ? 1 : multiplier_raw;
 
@@ -2217,15 +2253,7 @@ DECLSPEC void point_mul_xy (PRIVATE_AS u32 *x1, PRIVATE_AS u32 *y1, PRIVATE_AS c
    *
    */
 
-  inv_mod (z1);
-
-  u32 z2[8];
-
-  mul_mod (z2, z1, z1); // z1^2
-  mul_mod (x1, x1, z2); // x1_affine
-
-  mul_mod (z1, z2, z1); // z1^3
-  mul_mod (y1, y1, z1); // y1_affine
+  point_to_affine (x1, y1, z1);
 
   // return values are already in x1 and y1
 }
@@ -2484,135 +2512,4 @@ DECLSPEC void set_precomputed_basepoint_g (PRIVATE_AS secp256k1_t *r)
   r->xy[93] = SECP256K1_G_PRE_COMPUTED_93;
   r->xy[94] = SECP256K1_G_PRE_COMPUTED_94;
   r->xy[95] = SECP256K1_G_PRE_COMPUTED_95;
-}
-
-DECLSPEC void point_to_affine (PRIVATE_AS u32 *x, PRIVATE_AS u32 *y, PRIVATE_AS u32 *z)
-{
-  // (x, y, z) Jacobian -> (x, y) affine: x_affine = x / z^2, y_affine = y / z^3.
-  inv_mod (z);
-
-  u32 z2[8];
-
-  mul_mod (z2, z, z); // z^2
-  mul_mod (x, x, z2); // x / z^2
-
-  mul_mod (z, z2, z); // z^3
-  mul_mod (y, y, z);  // y / z^3
-}
-
-/*
- * Fixed-base precompute kernels (self-contained).
- *
- * These build, on the device, the lookup tables used by a fixed-base-comb + affine-addition-walk
- * key generator (the BitCrack / VanitySearch design). They depend only on this library's generic
- * primitives (point_add, point_double, point_to_affine) and the public base point G
- * (SECP256K1_G0..G7, SECP256K1_GY0..GY7) — no wNAF precomputed table, no host upload. Each table
- * point is stored as [x(8 u32 words)][y(8 u32 words)] in device word order (8 little-endian limbs
- * per coordinate), i.e. 16 words per entry. Launch each with a single work-item; this is one-time
- * init work, off the hot path.
- */
-
-// iG_table[m-1] = m*G (affine), for m = 1..count. Built from G by repeated mixed point_add.
-__kernel void precompute_ig_table (__global u32 *iG_table, const u32 count)
-{
-  // affine base point G: x = SECP256K1_G0..G7; y = SECP256K1_G_PRE_COMPUTED_08..15 (the y1 of the
-  // precomputed table, i.e. y(G)) — reused so no constant is duplicated.
-  u32 gx[8] = { SECP256K1_G0, SECP256K1_G1, SECP256K1_G2, SECP256K1_G3,
-                SECP256K1_G4, SECP256K1_G5, SECP256K1_G6, SECP256K1_G7 };
-  u32 gy[8] = { SECP256K1_G_PRE_COMPUTED_08, SECP256K1_G_PRE_COMPUTED_09,
-                SECP256K1_G_PRE_COMPUTED_10, SECP256K1_G_PRE_COMPUTED_11,
-                SECP256K1_G_PRE_COMPUTED_12, SECP256K1_G_PRE_COMPUTED_13,
-                SECP256K1_G_PRE_COMPUTED_14, SECP256K1_G_PRE_COMPUTED_15 };
-
-  // running point P = G in Jacobian coordinates (z = 1)
-  u32 px[8], py[8], pz[8] = { 0 };
-  pz[0] = 1;
-  for (int i = 0; i < 8; i++) { px[i] = gx[i]; py[i] = gy[i]; }
-
-  for (u32 m = 1; m <= count; m++)
-  {
-    // affine(P) -> entry m-1
-    u32 ax[8], ay[8], az[8];
-    for (int i = 0; i < 8; i++) { ax[i] = px[i]; ay[i] = py[i]; az[i] = pz[i]; }
-    point_to_affine (ax, ay, az);
-
-    const u32 out = (m - 1) * 16; // 16 words per entry: [x(8)][y(8)]
-    for (int i = 0; i < 8; i++) { iG_table[out + i] = ax[i]; iG_table[out + 8 + i] = ay[i]; }
-
-    // Advance P to (m+1)*G. The first step (m==1) is G+G, a doubling, which the mixed
-    // point_add cannot handle; every later step adds the (distinct) base G.
-    if (m < count)
-    {
-      if (m == 1) point_double (px, py, pz);      // 1*G -> 2*G
-      else        point_add (px, py, pz, gx, gy); // m*G -> (m+1)*G
-    }
-  }
-}
-
-// Signed-digit comb table: comb_table[pos][mag-1] = (mag * 2^(4*pos)) * G (affine),
-// pos = 0..64, mag = 1..8. Entry (pos, mag) starts at word offset (pos*8 + (mag-1))*16.
-//
-// Only magnitudes 1..8 are stored (8 slots/position), not the full digit set 0..15: the consuming
-// comb routine recodes each 4-bit window into a SIGNED digit b in {-8..+7} (carry-propagated), and
-// gets the negative entries for free as -P = (x, p - y). This halves the table vs. the unsigned
-// 0..15 layout. A signed recode of a 256-bit scalar can carry out of the top window, so there is
-// one extra position (64): it only ever holds magnitude 1 = 2^256 * G, but all 8 slots are built
-// uniformly. Built from G with a per-position 2^4 doubling step and a per-magnitude addition.
-__kernel void precompute_comb_table (__global u32 *comb_table)
-{
-  // affine base point G: x = SECP256K1_G0..G7; y = SECP256K1_G_PRE_COMPUTED_08..15 (the y1 of the
-  // precomputed table, i.e. y(G)) — reused so no constant is duplicated.
-  u32 gx[8] = { SECP256K1_G0, SECP256K1_G1, SECP256K1_G2, SECP256K1_G3,
-                SECP256K1_G4, SECP256K1_G5, SECP256K1_G6, SECP256K1_G7 };
-  u32 gy[8] = { SECP256K1_G_PRE_COMPUTED_08, SECP256K1_G_PRE_COMPUTED_09,
-                SECP256K1_G_PRE_COMPUTED_10, SECP256K1_G_PRE_COMPUTED_11,
-                SECP256K1_G_PRE_COMPUTED_12, SECP256K1_G_PRE_COMPUTED_13,
-                SECP256K1_G_PRE_COMPUTED_14, SECP256K1_G_PRE_COMPUTED_15 };
-
-  // base = 2^(4*pos) * G in Jacobian coordinates, starting at G (pos = 0)
-  u32 bx[8], by[8], bz[8] = { 0 };
-  bz[0] = 1;
-  for (int i = 0; i < 8; i++) { bx[i] = gx[i]; by[i] = gy[i]; }
-
-  for (u32 pos = 0; pos < 65; pos++)
-  {
-    // affine base for this position: abx,aby = (2^(4*pos)) * G
-    u32 abx[8], aby[8], abz[8];
-    for (int i = 0; i < 8; i++) { abx[i] = bx[i]; aby[i] = by[i]; abz[i] = bz[i]; }
-    point_to_affine (abx, aby, abz);
-
-    const u32 row = pos * 8; // 8 magnitude slots per position
-
-    // mag 1 -> slot 0: 1 * base
-    const u32 o1 = row * 16;
-    for (int i = 0; i < 8; i++) { comb_table[o1 + i] = abx[i]; comb_table[o1 + 8 + i] = aby[i]; }
-
-    // mag 2..8 -> slots 1..7: accumulate mag * base. mag 2 is a doubling (point_add cannot double);
-    // mag >= 3 adds the (distinct) affine base to the running multiple.
-    u32 cx[8], cy[8], cz[8] = { 0 };
-    cz[0] = 1;
-    for (int i = 0; i < 8; i++) { cx[i] = abx[i]; cy[i] = aby[i]; } // cur = 1 * base (affine)
-
-    for (u32 mag = 2; mag <= 8; mag++)
-    {
-      if (mag == 2) point_double (cx, cy, cz);
-      else          point_add (cx, cy, cz, abx, aby);
-
-      u32 ax[8], ay[8], az[8];
-      for (int i = 0; i < 8; i++) { ax[i] = cx[i]; ay[i] = cy[i]; az[i] = cz[i]; }
-      point_to_affine (ax, ay, az);
-
-      const u32 od = (row + (mag - 1)) * 16;
-      for (int i = 0; i < 8; i++) { comb_table[od + i] = ax[i]; comb_table[od + 8 + i] = ay[i]; }
-    }
-
-    // advance base to the next position: base *= 2^4 (four doublings)
-    if (pos < 64)
-    {
-      point_double (bx, by, bz);
-      point_double (bx, by, bz);
-      point_double (bx, by, bz);
-      point_double (bx, by, bz);
-    }
-  }
 }

--- a/src/main/resources/copyfromhashcat/inc_ecc_secp256k1.h
+++ b/src/main/resources/copyfromhashcat/inc_ecc_secp256k1.h
@@ -227,13 +227,4 @@ DECLSPEC void point_mul (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *k, SECP256K1_T
 
 DECLSPEC void set_precomputed_basepoint_g (PRIVATE_AS secp256k1_t *r);
 
-// Converts a Jacobian point (x, y, z) to affine in place (x <- x/z^2, y <- y/z^3); z is destroyed.
-// Reused by the fixed-base table precompute kernels below.
-DECLSPEC void point_to_affine (PRIVATE_AS u32 *x, PRIVATE_AS u32 *y, PRIVATE_AS u32 *z);
-
-// safegcd modular inverse (libsecp256k1 modinv32 port); drop-in alternative to inv_mod with the same
-// signature. Forward-declared so inv_mod can delegate to it (the default; build with
-// -D USE_LEGACY_BINARY_GCD_INV_MOD to fall back to the binary GCD).
-DECLSPEC void inv_mod_safegcd (PRIVATE_AS u32 *a);
-
 #endif // INC_ECC_SECP256K1_H

--- a/src/main/resources/copyfromhashcat/inc_vendor.h
+++ b/src/main/resources/copyfromhashcat/inc_vendor.h
@@ -145,31 +145,41 @@ using namespace metal;
  * fast but pure kernels on rocm is a good example
  */
 
-#ifdef NO_INLINE
+#if defined NO_INLINE || defined FORCE_NO_INLINE
 #define HC_INLINE
 #else
 #define HC_INLINE inline static
 #endif
 
-#if defined IS_AMD && defined IS_GPU
-#define DECLSPEC HC_INLINE
-#elif defined IS_CUDA
-#define DECLSPEC __device__
-#elif defined IS_HIP
-#define DECLSPEC __device__ HC_INLINE
-#elif defined AMD_NOINLINE_HELPERS
-// AMD/OpenCL compile-time experiment (opt-in via -D AMD_NOINLINE_HELPERS). On the generic OpenCL
-// path DECLSPEC is normally empty, so helpers carry no `inline` hint -- but LLVM (AMD's "LC"/comgr
-// back-end) still inlines them at -O3, megamerging the entire secp256k1 + double-hash160 + safegcd
-// kernel into one giant function. The LLVM back-end (greedy regalloc + SelectionDAG scheduling)
-// scales ~super-linearly per function, so that single huge function takes 8-16+ min to build on AMD
-// RDNA3 (vs seconds on NVIDIA's separate ptxas). Forcing the heavy DECLSPEC helpers out-of-line
-// partitions the back-end work into many smaller functions. See docs/performance.md ("slow AMD
-// compile"). Trade-off: out-of-line calls can cost runtime throughput, so this is opt-in and must be
-// validated with an NVIDIA A/B + the parity gate before becoming a default.
-#define DECLSPEC __attribute__((noinline))
+/**
+ * NO_INLINE only drops the `inline static` hint. That is enough for some runtimes, but LLVM-based
+ * OpenCL back-ends (AMD's "LC" / comgr stack) still inline every DECLSPEC helper at -O3 and merge a
+ * kernel built from many large helpers into one huge function. Several LLVM back-end passes (greedy
+ * register allocation, SelectionDAG scheduling) scale ~super-linearly per function, so that single
+ * function can take minutes to compile. FORCE_NO_INLINE emits the hard noinline attribute, which
+ * partitions the kernel back into many small functions.
+ *
+ * This is deliberately a separate switch from NO_INLINE: the two are not interchangeable, and
+ * NO_INLINE already has a meaning that -m 33000 relies on. Out-of-line calls cost runtime
+ * throughput, so FORCE_NO_INLINE stays opt-in per module/device and must never become a global
+ * default. Note -cl-opt-disable is not an alternative: it fails to link the static/DECLSPEC helpers
+ * (`ld.lld: undefined hidden symbol`).
+ */
+
+#ifdef FORCE_NO_INLINE
+#define HC_NOINLINE __attribute__ ((noinline))
 #else
-#define DECLSPEC
+#define HC_NOINLINE
+#endif
+
+#if defined IS_AMD && defined IS_GPU
+#define DECLSPEC HC_NOINLINE HC_INLINE
+#elif defined IS_CUDA
+#define DECLSPEC __device__ HC_NOINLINE
+#elif defined IS_HIP
+#define DECLSPEC __device__ HC_NOINLINE HC_INLINE
+#else
+#define DECLSPEC HC_NOINLINE
 #endif
 
 /**

--- a/src/main/resources/inc_ecc_secp256k1custom.cl
+++ b/src/main/resources/inc_ecc_secp256k1custom.cl
@@ -1591,3 +1591,120 @@ __kernel void bench_fe_mul(__global u32 *out, const u32 iterations, const u32 us
 
     out[gid] = checksum;
 }
+
+/*
+ * Fixed-base precompute kernels (self-contained).
+ *
+ * These build, on the device, the lookup tables used by a fixed-base-comb + affine-addition-walk
+ * key generator (the BitCrack / VanitySearch design). They depend only on this library's generic
+ * primitives (point_add, point_double, point_to_affine) and the public base point G
+ * (SECP256K1_G0..G7, SECP256K1_GY0..GY7) — no wNAF precomputed table, no host upload. Each table
+ * point is stored as [x(8 u32 words)][y(8 u32 words)] in device word order (8 little-endian limbs
+ * per coordinate), i.e. 16 words per entry. Launch each with a single work-item; this is one-time
+ * init work, off the hot path.
+ */
+
+// iG_table[m-1] = m*G (affine), for m = 1..count. Built from G by repeated mixed point_add.
+__kernel void precompute_ig_table (__global u32 *iG_table, const u32 count)
+{
+  // affine base point G: x = SECP256K1_G0..G7; y = SECP256K1_G_PRE_COMPUTED_08..15 (the y1 of the
+  // precomputed table, i.e. y(G)) — reused so no constant is duplicated.
+  u32 gx[8] = { SECP256K1_G0, SECP256K1_G1, SECP256K1_G2, SECP256K1_G3,
+                SECP256K1_G4, SECP256K1_G5, SECP256K1_G6, SECP256K1_G7 };
+  u32 gy[8] = { SECP256K1_G_PRE_COMPUTED_08, SECP256K1_G_PRE_COMPUTED_09,
+                SECP256K1_G_PRE_COMPUTED_10, SECP256K1_G_PRE_COMPUTED_11,
+                SECP256K1_G_PRE_COMPUTED_12, SECP256K1_G_PRE_COMPUTED_13,
+                SECP256K1_G_PRE_COMPUTED_14, SECP256K1_G_PRE_COMPUTED_15 };
+
+  // running point P = G in Jacobian coordinates (z = 1)
+  u32 px[8], py[8], pz[8] = { 0 };
+  pz[0] = 1;
+  for (int i = 0; i < 8; i++) { px[i] = gx[i]; py[i] = gy[i]; }
+
+  for (u32 m = 1; m <= count; m++)
+  {
+    // affine(P) -> entry m-1
+    u32 ax[8], ay[8], az[8];
+    for (int i = 0; i < 8; i++) { ax[i] = px[i]; ay[i] = py[i]; az[i] = pz[i]; }
+    point_to_affine (ax, ay, az);
+
+    const u32 out = (m - 1) * 16; // 16 words per entry: [x(8)][y(8)]
+    for (int i = 0; i < 8; i++) { iG_table[out + i] = ax[i]; iG_table[out + 8 + i] = ay[i]; }
+
+    // Advance P to (m+1)*G. The first step (m==1) is G+G, a doubling, which the mixed
+    // point_add cannot handle; every later step adds the (distinct) base G.
+    if (m < count)
+    {
+      if (m == 1) point_double (px, py, pz);      // 1*G -> 2*G
+      else        point_add (px, py, pz, gx, gy); // m*G -> (m+1)*G
+    }
+  }
+}
+
+// Signed-digit comb table: comb_table[pos][mag-1] = (mag * 2^(4*pos)) * G (affine),
+// pos = 0..64, mag = 1..8. Entry (pos, mag) starts at word offset (pos*8 + (mag-1))*16.
+//
+// Only magnitudes 1..8 are stored (8 slots/position), not the full digit set 0..15: the consuming
+// comb routine recodes each 4-bit window into a SIGNED digit b in {-8..+7} (carry-propagated), and
+// gets the negative entries for free as -P = (x, p - y). This halves the table vs. the unsigned
+// 0..15 layout. A signed recode of a 256-bit scalar can carry out of the top window, so there is
+// one extra position (64): it only ever holds magnitude 1 = 2^256 * G, but all 8 slots are built
+// uniformly. Built from G with a per-position 2^4 doubling step and a per-magnitude addition.
+__kernel void precompute_comb_table (__global u32 *comb_table)
+{
+  // affine base point G: x = SECP256K1_G0..G7; y = SECP256K1_G_PRE_COMPUTED_08..15 (the y1 of the
+  // precomputed table, i.e. y(G)) — reused so no constant is duplicated.
+  u32 gx[8] = { SECP256K1_G0, SECP256K1_G1, SECP256K1_G2, SECP256K1_G3,
+                SECP256K1_G4, SECP256K1_G5, SECP256K1_G6, SECP256K1_G7 };
+  u32 gy[8] = { SECP256K1_G_PRE_COMPUTED_08, SECP256K1_G_PRE_COMPUTED_09,
+                SECP256K1_G_PRE_COMPUTED_10, SECP256K1_G_PRE_COMPUTED_11,
+                SECP256K1_G_PRE_COMPUTED_12, SECP256K1_G_PRE_COMPUTED_13,
+                SECP256K1_G_PRE_COMPUTED_14, SECP256K1_G_PRE_COMPUTED_15 };
+
+  // base = 2^(4*pos) * G in Jacobian coordinates, starting at G (pos = 0)
+  u32 bx[8], by[8], bz[8] = { 0 };
+  bz[0] = 1;
+  for (int i = 0; i < 8; i++) { bx[i] = gx[i]; by[i] = gy[i]; }
+
+  for (u32 pos = 0; pos < 65; pos++)
+  {
+    // affine base for this position: abx,aby = (2^(4*pos)) * G
+    u32 abx[8], aby[8], abz[8];
+    for (int i = 0; i < 8; i++) { abx[i] = bx[i]; aby[i] = by[i]; abz[i] = bz[i]; }
+    point_to_affine (abx, aby, abz);
+
+    const u32 row = pos * 8; // 8 magnitude slots per position
+
+    // mag 1 -> slot 0: 1 * base
+    const u32 o1 = row * 16;
+    for (int i = 0; i < 8; i++) { comb_table[o1 + i] = abx[i]; comb_table[o1 + 8 + i] = aby[i]; }
+
+    // mag 2..8 -> slots 1..7: accumulate mag * base. mag 2 is a doubling (point_add cannot double);
+    // mag >= 3 adds the (distinct) affine base to the running multiple.
+    u32 cx[8], cy[8], cz[8] = { 0 };
+    cz[0] = 1;
+    for (int i = 0; i < 8; i++) { cx[i] = abx[i]; cy[i] = aby[i]; } // cur = 1 * base (affine)
+
+    for (u32 mag = 2; mag <= 8; mag++)
+    {
+      if (mag == 2) point_double (cx, cy, cz);
+      else          point_add (cx, cy, cz, abx, aby);
+
+      u32 ax[8], ay[8], az[8];
+      for (int i = 0; i < 8; i++) { ax[i] = cx[i]; ay[i] = cy[i]; az[i] = cz[i]; }
+      point_to_affine (ax, ay, az);
+
+      const u32 od = (row + (mag - 1)) * 16;
+      for (int i = 0; i < 8; i++) { comb_table[od + i] = ax[i]; comb_table[od + 8 + i] = ay[i]; }
+    }
+
+    // advance base to the next position: base *= 2^4 (four doublings)
+    if (pos < 64)
+    {
+      point_double (bx, by, bz);
+      point_double (bx, by, bz);
+      point_double (bx, by, bz);
+      point_double (bx, by, bz);
+    }
+  }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
@@ -537,7 +537,7 @@ public class ProbeAddressesOpenCLTest {
     }
 
     /**
-     * Byte-identical parity with {@code noInlineHelpers = true} ({@code -D AMD_NOINLINE_HELPERS}).
+     * Byte-identical parity with {@code noInlineHelpers = true} ({@code -D FORCE_NO_INLINE}).
      *
      * <p>The {@code noinline} build forces the kernel's {@code DECLSPEC} helpers out-of-line to fix
      * the multi-minute AMD/LLVM compile (see {@code docs/performance.md} §9). It is a pure compile

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/benchmark/GpuFuse8FilterBenchmark.java
@@ -220,7 +220,7 @@ public class GpuFuse8FilterBenchmark {
 
     /**
      * Forces the kernel's {@code DECLSPEC} helpers out-of-line ({@link CProducerOpenCL#noInlineHelpers},
-     * build define {@code -D AMD_NOINLINE_HELPERS}). {@code false} = normal fully-inlined kernel
+     * build define {@code -D FORCE_NO_INLINE}). {@code false} = normal fully-inlined kernel
      * (default); {@code true} = helpers built {@code __attribute__((noinline))}. This is purely a
      * compile-time fix for AMD's LLVM/comgr back-end (minutes → seconds; see {@code docs/performance.md}
      * §9) and is correctness-neutral. Sweep both (e.g. {@code -p noInlineHelpers=false,true}, both


### PR DESCRIPTION
## Summary

- Makes all **12 vendored files under `src/main/resources/copyfromhashcat/` byte-identical to hashcat again**. The kernel changes are the ones submitted upstream as [hashcat/hashcat#4763](https://github.com/hashcat/hashcat/pull/4763), so this repo and that PR no longer drift.
- Moves `precompute_ig_table()` and `precompute_comb_table()` out of the vendored file into `inc_ecc_secp256k1custom.cl`, where they belong — they are ours, not hashcat's. That is what makes byte-identity possible at all.
- Renames the out-of-line build define `AMD_NOINLINE_HELPERS` → `FORCE_NO_INLINE` to match the name used upstream.

### What came in from upstream

| | |
|---|---|
| `inv_mod()` | split into `inv_mod_binary_gcd()` and `inv_mod_safegcd()` plus a selector. safegcd stays the default; `-D USE_LEGACY_BINARY_GCD_INV_MOD` still selects the binary GCD. |
| `point_to_affine()` | now replaces the four verbatim Jacobian-to-affine copies in `point_get_coords()` and `point_mul_xy()` |
| `safegcd_i64` | the 64-bit accumulator is a typedef keyed off the backend macros instead of a bare `long`, which is 32-bit under CUDA on Windows and in a host build |

### What we lose

The `mul_mod` loop merge is gone, since upstream does not carry it. It measured as no gain (`docs/performance.md`, Stage 0), so this costs nothing.

## Test plan

- [x] Affected unit / integration tests pass locally
- [x] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable

Run in this exact state:

| environment | device | result |
|---|---|---|
| Windows, native | NVIDIA RTX 3070 Laptop GPU | **113 tests, 0 failures** |
| Docker `maven:3.9-eclipse-temurin-21` | pocl 3.0 CPU (Ryzen 7 5800H) | **58 tests, 0 failures** |

Covered: `OpenCLContextTest`, `CProducerOpenCLTest`, `OpenCLPrecomputeKernelTest`, `OpenCLKernelModeMatrixTest`, `OpenCLFe10x26ParityTest`, `ProbeAddressesOpenCLTest`.

`OpenCLPrecomputeKernelTest#invModSafegcd_…` cross-checks safegcd against the binary GCD **and** `x·x⁻¹ ≡ 1 (mod p)` over 4096 random inputs; the precompute tables are checked entry by entry against bitcoinj; `ProbeAddressesOpenCLTest` byte-compares derived keys against bitcoinj.

The `NO_INLINE_HELPERS_BUILD_OPTION` tests assert against the constant, not the literal string, so the rename does not touch them.

## Related issues / PRs

Refs hashcat/hashcat#4763

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] My commits follow Conventional Commits — see note below
- [x] No security-sensitive changes

**Note on Conventional Commits:** the single commit is titled `Sync copyfromhashcat with the upstream secp256k1 PR`, which does not carry a type prefix. Recent history in this repo is mixed on that point. Say the word and it becomes `chore(kernel): sync copyfromhashcat with the upstream secp256k1 PR` before merge.
