### PR TITLE
Add fat-jar smoke test to CI pipeline

### DIFF
--- a/.github/smoke-fatjar-cli.sh
+++ b/.github/smoke-fatjar-cli.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# Cross-repo shared script — kept BYTE-IDENTICAL in BitcoinAddressFinder and srcmorph (sync any
+# edit to both, and to the checksum table in workspace/crossrepostatus.md). Smoke-tests a runnable
+# fat jar (jar-with-dependencies) by actually launching it: `java -jar <jar> <args>` must exit 0
+# and print an expected success marker.
+#
+# Why: the fat jar is a GitHub-Release asset (workspace/policies/fat-jar-release-assets.md), and
+# the convention is that no release asset is attached that CI has not run. An uber jar can be built
+# and GPG-signed perfectly while being unrunnable — a missing Main-Class, a shade-mangled or
+# duplicated resource, an absent SLF4J binding, a native library that will not load. None of that
+# is visible to `mvn package` or to the unit tests, which run off target/classes and never touch
+# the assembled artifact. Signing an artifact proves who built it, not that it works.
+#
+# The exit code alone is a weak assertion (a JVM that starts and does nothing also exits 0), so a
+# success marker from the program's own output is required too.
+#
+# Usage: smoke-fatjar-cli.sh <jar-dir> <jar-glob> <work-dir> <success-marker> [args...]
+#   <jar-dir>         directory to search for the jar (searched recursively, so a downloaded
+#                     multi-module artifact that preserved its <module>/target/ layout works)
+#   <jar-glob>        filename glob; must match EXACTLY ONE jar (an ambiguous match is an error,
+#                     not a "pick the first" — that is how the wrong artifact gets tested)
+#   <work-dir>        working directory for the run; example configs use relative paths, so this
+#                     is what makes the smoke reproduce the documented invocation
+#   <success-marker>  extended regex that must appear in the program's output
+#   [args...]         passed to the program after `-jar <jar>`
+#
+# Output goes to smoke-out.log / smoke-err.log in the CALLER's working directory (uploaded by the
+# CI job on failure). Deliberately a plain `java -jar` with no extra JVM flags: the contract under
+# test is that the published artifact runs as-is.
+
+set -euo pipefail
+
+JAR_DIR="${1:?usage: smoke-fatjar-cli.sh <jar-dir> <jar-glob> <work-dir> <success-marker> [args...]}"
+JAR_GLOB="${2:?usage: smoke-fatjar-cli.sh <jar-dir> <jar-glob> <work-dir> <success-marker> [args...]}"
+WORK_DIR="${3:?usage: smoke-fatjar-cli.sh <jar-dir> <jar-glob> <work-dir> <success-marker> [args...]}"
+MARKER="${4:?usage: smoke-fatjar-cli.sh <jar-dir> <jar-glob> <work-dir> <success-marker> [args...]}"
+shift 4
+
+# Generous ceiling: this bounds a hang (a CLI waiting on stdin, a server that never returns), it is
+# not a performance budget. A healthy run of either repo's smoke config finishes in seconds.
+TIMEOUT_SECONDS=600
+
+OUT_LOG="$(pwd)/smoke-out.log"
+ERR_LOG="$(pwd)/smoke-err.log"
+
+fail() {
+    echo "::error::$*" >&2
+    [ -s "$OUT_LOG" ] && { echo "--- smoke-out.log (tail) ---" >&2; tail -50 "$OUT_LOG" >&2; }
+    [ -s "$ERR_LOG" ] && { echo "--- smoke-err.log (tail) ---" >&2; tail -50 "$ERR_LOG" >&2; }
+    exit 1
+}
+
+[ -d "$JAR_DIR" ] || fail "jar directory '$JAR_DIR' does not exist"
+[ -d "$WORK_DIR" ] || fail "working directory '$WORK_DIR' does not exist"
+
+jars=()
+while IFS= read -r j; do jars+=("$j"); done < <(find "$JAR_DIR" -type f -name "$JAR_GLOB" | sort)
+[ "${#jars[@]}" -eq 1 ] \
+    || fail "expected exactly 1 jar matching '$JAR_GLOB' under '$JAR_DIR', got ${#jars[@]}: ${jars[*]:-none}"
+JAR="$(cd "$(dirname "${jars[0]}")" && pwd)/$(basename "${jars[0]}")"
+
+echo "smoke jar : $JAR"
+echo "work dir  : $WORK_DIR"
+echo "arguments : $*"
+
+set +e
+(cd "$WORK_DIR" && timeout "$TIMEOUT_SECONDS" java -jar "$JAR" "$@") > "$OUT_LOG" 2> "$ERR_LOG"
+STATUS=$?
+set -e
+
+[ "$STATUS" -ne 124 ] || fail "the fat jar did not terminate within ${TIMEOUT_SECONDS}s"
+[ "$STATUS" -eq 0 ] || fail "the fat jar exited with status $STATUS (expected 0)"
+
+grep -hqE "$MARKER" "$OUT_LOG" "$ERR_LOG" \
+    || fail "success marker '$MARKER' not found in the output — the jar started but did not complete its run"
+
+echo "smoke test PASSED"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -461,6 +461,51 @@ jobs:
             *.hprof
           if-no-files-found: ignore
 
+  # ---------------------------------------------------------------------------
+  # Fat-jar smoke test — cross-repo standard job, kept in the same shape in srcmorph and
+  # java-llama.cpp (see workspace/policies/fat-jar-release-assets.md, "No release asset is
+  # attached that CI has not run"). The fat jar is a GitHub-Release asset, and unit tests never
+  # touch it: they run off target/classes, so an unrunnable uber jar — no Main-Class, a
+  # shade-mangled resource, a missing SLF4J binding — is built and GPG-signed without anything
+  # noticing. Signing proves who built it, not that it works.
+  #
+  # BAF-specific: config_AddressFilesToLMDB.json imports the bundled sample address files into a
+  # fresh LMDB under examples/, so this also exercises the lmdbjava NATIVE library out of the fat
+  # jar — the closest analogue to what jllama's smoke checks — with no network and no GPU. It is
+  # deliberately a plain `java -jar`: examples/run_AddressFilesToLMDB.sh passes a long
+  # --add-opens/--add-exports list for lmdbjava's internal-JDK reflection, but the import runs
+  # clean without it on JDK 21, and the contract under test is that the published artifact runs
+  # as-is. Keep this job on the OpenCL-free runner: it must not depend on an ICD being installed.
+  # ---------------------------------------------------------------------------
+
+  smoke-fatjar:
+    name: Smoke test fat jar
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: jars
+          path: fatjar/
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+      - name: Run fat-jar smoke test
+        run: |
+          .github/smoke-fatjar-cli.sh fatjar 'bitcoinaddressfinder-*-jar-with-dependencies.jar' \
+            examples 'Main#run end\.' config_AddressFilesToLMDB.json
+      - name: Upload smoke logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-fatjar-logs
+          path: |
+            smoke-out.log
+            smoke-err.log
+          if-no-files-found: warn
+
   report:
     name: Report
     needs: [test, test-opencl]
@@ -516,7 +561,7 @@ jobs:
 
   publish-snapshot:
     name: Publish Snapshot to Central
-    needs: [check-snapshot, code-style]
+    needs: [check-snapshot, code-style, smoke-fatjar]
     if: needs.check-snapshot.result == 'success' && inputs.publish_to_central
     runs-on: ubuntu-latest
     environment: maven-central
@@ -625,7 +670,7 @@ jobs:
 
   publish-release:
     name: Publish Release to Central
-    needs: [check-tag, code-style]
+    needs: [check-tag, code-style, smoke-fatjar]
     if: needs.check-tag.result == 'success' && inputs.publish_to_central
     runs-on: ubuntu-latest
     environment: maven-central

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -694,6 +694,19 @@ second `mvn -P release,assembly verify` (which stops before `deploy`, so `centra
 uploads it). The cross-repo convention + per-repo shapes are documented in
 [`../workspace/policies/fat-jar-release-assets.md`](../workspace/policies/fat-jar-release-assets.md).
 
+**BAF-specific smoke.** The cross-repo rule "no release asset is attached that CI has not run" is
+implemented here by the `smoke-fatjar` job (`needs: [build]`, gates both publish jobs): it downloads
+the `jars` artifact and runs the **byte-identical shared** `.github/smoke-fatjar-cli.sh` (synced with
+srcmorph — see the checksum table in `crossrepostatus.md`) against
+`examples/config_AddressFilesToLMDB.json`, asserting exit 0 plus `Main#run end.` in the output. That
+config imports the bundled sample address files into a fresh LMDB under `examples/`, so it also
+exercises the **lmdbjava native library out of the fat jar** — the BAF analogue of what jllama's
+smoke checks. Two BAF-specific notes: it is deliberately a plain `java -jar` even though
+`examples/run_AddressFilesToLMDB.sh` passes the long `--add-opens`/`--add-exports` list (the import
+runs clean without it on JDK 21, and the contract under test is that the published artifact runs
+as-is), and the job must stay on the **OpenCL-free** `ubuntu-latest` runner — it must never come to
+depend on an ICD being installed.
+
 ## Dependency Convergence Pinning
 
 `dependencyConvergence` is enabled (maven-enforcer). Convention for pinning a direct-vs-transitive


### PR DESCRIPTION
## Summary

- Add `.github/smoke-fatjar-cli.sh`, a cross-repo shared script that smoke-tests the fat JAR by actually running it with `java -jar` and verifying exit code + success marker in output
- Integrate the smoke test into the publish workflow as a new `smoke-fatjar` job that gates both snapshot and release publishes
- Document the BAF-specific smoke test configuration in CLAUDE.md

## Rationale

The fat JAR is a GitHub Release asset, but unit tests run off `target/classes` and never touch the assembled artifact. An unrunnable uber JAR—missing Main-Class, shade-mangled resources, absent SLF4J binding, native library load failures—can be built and GPG-signed without detection. This smoke test exercises the actual published artifact by importing sample address files into LMDB via `config_AddressFilesToLMDB.json`, which also validates that the lmdbjava native library loads correctly from the fat JAR.

The script is byte-identical across BitcoinAddressFinder and srcmorph (per `workspace/policies/fat-jar-release-assets.md`), with checksums tracked in `crossrepostatus.md`.

## Test plan

- CI is green on this branch (the new `smoke-fatjar` job runs after `build` and gates both publish jobs)
- The smoke test runs a plain `java -jar` with no extra JVM flags, matching the documented invocation contract
- Logs are uploaded on failure for debugging

## Related issues / PRs

See `workspace/policies/fat-jar-release-assets.md` for the cross-repo convention.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01Tzo7Yi8SXP6WxhqZXXbsco