### PR TITLE
Add DECLSPEC definition for native plugin builds

### DIFF
--- a/src/main/resources/copyfromhashcat/inc_vendor.h
+++ b/src/main/resources/copyfromhashcat/inc_vendor.h
@@ -172,12 +172,21 @@ using namespace metal;
 #define HC_NOINLINE
 #endif
 
+// On a device DECLSPEC says how a function is compiled. On the host it says something else, because
+// the host build of these files is compiled into the core and a plugin calls the result: every one
+// of these functions is a host side hash, cipher or helper entry point, so DECLSPEC is where they
+// are put into the plugin contract, once, instead of on a few hundred declarations. IS_NATIVE is
+// set from the include guard of emu_general.h, and that is the header that brings HC_PLUGIN_API in,
+// so the macro is always in hand by the time this is read.
+
 #if defined IS_AMD && defined IS_GPU
 #define DECLSPEC HC_NOINLINE HC_INLINE
 #elif defined IS_CUDA
 #define DECLSPEC __device__ HC_NOINLINE
 #elif defined IS_HIP
 #define DECLSPEC __device__ HC_NOINLINE HC_INLINE
+#elif defined IS_NATIVE
+#define DECLSPEC HC_PLUGIN_API
 #else
 #define DECLSPEC HC_NOINLINE
 #endif


### PR DESCRIPTION
## Summary

- Add `IS_NATIVE` conditional branch to `DECLSPEC` macro definition in `inc_vendor.h`
- When `IS_NATIVE` is defined, `DECLSPEC` now expands to `HC_PLUGIN_API` instead of `HC_NOINLINE`
- Add explanatory comment clarifying the purpose of `DECLSPEC` across device and host builds

## Motivation

The `DECLSPEC` macro is used to annotate function declarations with platform-specific calling conventions and visibility attributes. This change extends support for native plugin builds (when `IS_NATIVE` is defined via `emu_general.h`), ensuring that plugin entry points are correctly marked with `HC_PLUGIN_API` for the plugin contract rather than using the default `HC_NOINLINE` behavior.

## Test plan

- CI is green on this branch
- No new tests required; this is a macro definition change that affects compilation of native plugin builds

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01Lh5eEqhQ5Xq5KL5EqhjJfg