### PR TITLE
Bump dependencies and CI actions to latest stable

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,14 +34,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
           cache: maven
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.7
+        uses: github/codeql-action/init@v4.37.8
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -50,6 +50,6 @@ jobs:
         run: mvn --batch-mode --no-transfer-progress compile
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.7
+        uses: github/codeql-action/analyze@v4.37.8
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/issue50-lmdb-crash-repro.yml
+++ b/.github/workflows/issue50-lmdb-crash-repro.yml
@@ -91,7 +91,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,7 +173,7 @@ jobs:
     environment: maven-central
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: temurin
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: temurin
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -286,7 +286,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -404,7 +404,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -488,7 +488,7 @@ jobs:
         with:
           name: jars
           path: fatjar/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -514,7 +514,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -567,7 +567,7 @@ jobs:
     environment: maven-central
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -678,7 +678,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4.37.7
+        uses: github/codeql-action/upload-sarif@v4.37.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: 21
           distribution: 'zulu'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TuneConfiguration`); only the rendered field changed.
 
 ### Fixed
+- **CVE-2026-49844** (GHSA-qv9r-c865-cp47, moderate): `org.apache.logging.log4j:log4j-api`
+  2.25.3 arrives as a **test-scope** transitive of `io.github.hakky54:logcaptor` 2.12.6, and
+  Dependabot could not update it on its own. Pinned `log4j-api` **and** `log4j-to-slf4j` to
+  **2.26.1** in `dependencyManagement` — both together, since `log4j-to-slf4j` requires a
+  matching `log4j-api` and the two must not skew. Neither reaches a published artifact.
 - **A run fed by a blocking key producer could not be shut down** — `Finder.interrupt()` waited for
   the producers to stop *before* waking the key producers. A producer waiting for its next secret is
   parked inside the key producer, and one configured to block indefinitely (`timeoutMillis: -1`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single GPU.
 
 ### Changed
+- Dependencies bumped to latest stable: `com.google.protobuf:protobuf-javalite` 4.35.1 → 4.36.0
+  (4.36.0 left RC), `org.lwjgl:lwjgl` / `lwjgl-opencl` 3.4.2 → 3.4.3 (including every `natives-*`
+  classifier), `com.github.spotbugs:spotbugs-maven-plugin` 4.10.3.0 → 4.10.4.0.
+- CI actions bumped to latest: `actions/setup-java` v5 → v6, `github/codeql-action/*` v4.37.7 →
+  v4.37.8.
 - **The OpenCL binding moved from JOCL to LWJGL 3** (`org.lwjgl:lwjgl` + `lwjgl-opencl` 3.4.2);
   `org.jocl` is gone from the build. Calls no longer reach the binding directly: a new
   `opencl/binding/` package carries an instance-based `ClApi` (mockable, unlike the binding's static

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,7 +454,7 @@ OpenCL kernels live in `src/main/resources/` as `.cl` and `.h` files:
 | `inc_platform.cl` | Platform-specific abstractions |
 | `inc_types.h` | OpenCL type definitions |
 
-GPU code is bound through **LWJGL 3** (`lwjgl` + `lwjgl-opencl` 3.4.2). Every call into the binding
+GPU code is bound through **LWJGL 3** (`lwjgl` + `lwjgl-opencl` 3.4.3). Every call into the binding
 goes through the `opencl/binding/` seam — never directly:
 
 | Type | Role |
@@ -570,21 +570,21 @@ No other sibling repo has OpenCL code, so this distinction is BAF-only.
 |---|---|---|
 | `bitcoinj-core` | 0.17.1 | Bitcoin crypto, address derivation |
 | `bcprov-jdk15to18` | 1.85.2 | Bouncy Castle crypto provider (bitcoinj transitive; pinned to fix GHSA-c3fc-8qff-9hwx, GHSA-p93r-85wp-75v3) |
-| `protobuf-javalite` | 4.35.1 | Protocol Buffers (bitcoinj transitive; pinned to latest) |
+| `protobuf-javalite` | 4.36.0 | Protocol Buffers (bitcoinj transitive; pinned to latest) |
 | `jsr305` | 3.0.2 | Findbugs nullability annotations (bitcoinj transitive, runtime) |
 | `jcip-annotations` | 1.0 | JCIP concurrency annotations (bitcoinj transitive, runtime) |
 | `lmdbjava` | 0.9.3 | LMDB database bindings |
-| `lwjgl` / `lwjgl-opencl` | 3.4.2 | Java OpenCL bindings (plus per-platform `natives-*` classifiers) |
-| `jackson-databind` | 2.22.1 | JSON config parsing |
-| `jackson-dataformat-yaml` | 2.22.1 | YAML config parsing |
-| `guava` | 33.6.0-jre | Google core utilities |
-| `commons-codec` | 1.22.0 | Base58, hex encoding |
+| `lwjgl` / `lwjgl-opencl` | 3.4.3 | Java OpenCL bindings (plus per-platform `natives-*` classifiers) |
+| `jackson-databind` | 2.22.2 | JSON config parsing |
+| `jackson-dataformat-yaml` | 2.22.2 | YAML config parsing |
+| `guava` | 33.7.1-jre | Google core utilities |
+| `commons-codec` | 1.22.1 | Base58, hex encoding |
 | `commons-io` | 2.22.0 | I/O utilities |
 | `Java-WebSocket` | 1.6.0 | WebSocket producer |
 | `jeromq` | 0.6.0 | ZeroMQ producer |
-| `jspecify` | 1.0.0 | Nullness annotations |
+| `jspecify` | 1.0.1 | Nullness annotations |
 | `slf4j-api` | 2.0.18 | Logging facade |
-| `logback-classic` | 1.6.1 | SLF4J implementation |
+| `logback-classic` | 1.6.3 | SLF4J implementation |
 
 Test-only:
 | `junit-jupiter` | 6.1.3 | JUnit 6 (Jupiter) test framework |

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ SPDX-License-Identifier: Apache-2.0
              policy) for full context. -->
         <jqwik.version>1.9.3</jqwik.version>
         <archunit.version>1.5.0</archunit.version>
-        <spotbugs.version>4.10.3.0</spotbugs.version>
+        <spotbugs.version>4.10.4.0</spotbugs.version>
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <errorprone.version>2.50.0</errorprone.version>
@@ -78,13 +78,13 @@ SPDX-License-Identifier: Apache-2.0
         <lombok.version>1.18.46</lombok.version>
         <bitcoinj.version>0.17.1</bitcoinj.version>
         <bcprov.version>1.85.2</bcprov.version>
-        <protobuf.version>4.35.1</protobuf.version>
+        <protobuf.version>4.36.0</protobuf.version>
         <jsr305.version>3.0.2</jsr305.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <guava.version>33.7.1-jre</guava.version>
         <jackson.version>2.22.2</jackson.version>
         <lmdbjava.version>0.9.3</lmdbjava.version>
-        <lwjgl.version>3.4.2</lwjgl.version>
+        <lwjgl.version>3.4.3</lwjgl.version>
         <commons-io.version>2.22.0</commons-io.version>
         <commons-codec.version>1.22.1</commons-codec.version>
         <maven-artifact.version>3.9.16</maven-artifact.version>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@ SPDX-License-Identifier: Apache-2.0
         <hamcrest.version>3.0</hamcrest.version>
         <mockito.version>5.23.0</mockito.version>
         <logcaptor.version>2.12.6</logcaptor.version>
+        <!-- log4j-api / log4j-to-slf4j arrive ONLY as test-scope transitives of
+             io.github.hakky54:logcaptor, which requests 2.25.3. That version is affected by
+             CVE-2026-49844 (GHSA-qv9r-c865-cp47, moderate): MapMessage.asJson() emits bare
+             NaN/Infinity tokens for non-finite floats, producing non-RFC-8259 JSON. Pinned to the
+             newest patched stable so the alert clears; see the dependencyManagement entries. -->
+        <log4j.version>2.26.1</log4j.version>
         <jmh.version>1.37</jmh.version>
         <spotless.version>3.10.0</spotless.version>
         <palantir-java-format.version>2.96.0</palantir-java-format.version>
@@ -136,6 +142,20 @@ SPDX-License-Identifier: Apache-2.0
                 <groupId>org.jspecify</groupId>
                 <artifactId>jspecify</artifactId>
                 <version>${jspecify.version}</version>
+            </dependency>
+            <!-- log4j-api + log4j-to-slf4j: io.github.hakky54:logcaptor (test scope) brings 2.25.3,
+                 which is affected by CVE-2026-49844; we declare ${log4j.version} directly. Both are
+                 pinned together because log4j-to-slf4j depends on log4j-api of the same version and
+                 the two must not skew. Test-scope only — neither reaches a published artifact. -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

- Updated build and runtime dependencies to latest stable versions: `protobuf-javalite` 4.35.1 → 4.36.0, `lwjgl`/`lwjgl-opencl` 3.4.2 → 3.4.3, `spotbugs-maven-plugin` 4.10.3.0 → 4.10.4.0.
- Upgraded CI actions: `actions/setup-java` v5 → v6, `github/codeql-action/*` v4.37.7 → v4.37.8.
- **Fixed CVE-2026-49844** (GHSA-qv9r-c865-cp47, moderate): pinned `log4j-api` and `log4j-to-slf4j` to 2.26.1 in `dependencyManagement` to override the vulnerable 2.25.3 that arrives as a test-scope transitive of `logcaptor` 2.12.6. Both log4j artifacts are pinned together since `log4j-to-slf4j` requires a matching `log4j-api` version; neither reaches a published artifact.

## Test plan

- [x] CI is green on this branch
- [x] Docs / CHANGELOG updated

## Related issues / PRs

Dependabot CVE-2026-49844 alert.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (CVE fix is documented in CHANGELOG)

https://claude.ai/code/session_015736Ef93fk9VcaxpBs8C9J