### PR TITLE
Fix the concurrency group, bump tooling, align nullaway

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
           cache: maven
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.8
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -50,6 +50,6 @@ jobs:
         run: mvn --batch-mode --no-transfer-progress compile
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.8
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,25 @@ on:
 #
 # cancel-in-progress is deliberately scoped to pull_request ONLY. A push to main or
 # to a v* tag is a release path: cancelling one midway could leave a partially
-# published set of artifacts, so those always run to completion even if another push
-# lands behind them.
+# published set of artifacts.
+#
+# cancel-in-progress: false is NOT sufficient on its own to protect a release run.
+# GitHub cancels a *pending* run whenever a newer run joins the same group behind an
+# in-progress one -- that rule is independent of cancel-in-progress. So with a plain
+# `workflow-ref` group, a queued `publish_to_central` dispatch on main could be
+# silently dropped by a later push to main, both sharing `Publish-refs/heads/main`.
+# Giving every non-PR run its own group (via the unique run_id) means such a run is
+# never queued behind a sibling and therefore can never be cancelled, while PR runs
+# still share a group per ref and supersede each other as intended.
+#
+# One-time effect when this expression changes: GitHub reads `concurrency` from the
+# workflow file at each run's own ref, so a run started before the change sits in the
+# old group and a run started after it sits in the new one. They are different groups,
+# so the new push does NOT supersede the in-flight old run -- exactly once, on the
+# commit that lands this. It self-heals from the next push on. Expect the same overlap
+# when porting this to a sibling repo; it is not a sign the expression is wrong.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4.37.8
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@ SPDX-License-Identifier: Apache-2.0
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <errorprone.version>2.50.0</errorprone.version>
-        <nullaway.version>0.13.8</nullaway.version>
+        <nullaway.version>0.14.0</nullaway.version>
         <checker.version>4.2.2</checker.version>
         <java-websocket.version>1.6.0</java-websocket.version>
         <jeromq.version>0.6.0</jeromq.version>
@@ -91,7 +91,7 @@ SPDX-License-Identifier: Apache-2.0
         <junit.version>6.1.3</junit.version>
         <hamcrest.version>3.0</hamcrest.version>
         <mockito.version>5.23.0</mockito.version>
-        <logcaptor.version>2.12.6</logcaptor.version>
+        <logcaptor.version>2.12.7</logcaptor.version>
         <!-- log4j-api / log4j-to-slf4j arrive ONLY as test-scope transitives of
              io.github.hakky54:logcaptor, which requests 2.25.3. That version is affected by
              CVE-2026-49844 (GHSA-qv9r-c865-cp47, moderate): MapMessage.asJson() emits bare
@@ -99,8 +99,8 @@ SPDX-License-Identifier: Apache-2.0
              newest patched stable so the alert clears; see the dependencyManagement entries. -->
         <log4j.version>2.26.1</log4j.version>
         <jmh.version>1.37</jmh.version>
-        <spotless.version>3.10.0</spotless.version>
-        <palantir-java-format.version>2.96.0</palantir-java-format.version>
+        <spotless.version>3.10.1</spotless.version>
+        <palantir-java-format.version>2.97.0</palantir-java-format.version>
     </properties>
 
     <!--
@@ -269,7 +269,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.25.9</version>
+                    <version>1.30.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
## Summary

- **The `concurrency:` block did not do what its comment claimed.** It said a push to `main` or a `v*` tag *"always runs to completion even if another push lands behind them"*, on the strength of `cancel-in-progress` being scoped to `pull_request`. GitHub does not work that way: it cancels a **pending** run whenever a newer run joins the same group behind an in-progress one, and **that rule is independent of `cancel-in-progress`**. With a plain `${{ github.workflow }}-${{ github.ref }}` group, a queued `publish-snapshot` run on `main` could be dropped silently by a later push to `main` — both sit in `Publish-refs/heads/main`. **This repo is the least hypothetical of the four**: its `publish.yml` has a real snapshot-publish path on `main`. Appending the unique `github.run_id` for every non-PR run gives each release run its own group; PR runs keep sharing a group per ref and still supersede each other.
- **`github/codeql-action` unpinned** from `@v4.37.8` back to `@v4` across `codeql.yml` and `scorecard.yml` (`init`, `analyze`, `upload-sarif`) — the pin was accidental and 4.37.9 is already out.
- **Build tooling bumped**: nullaway `0.13.8 → 0.14.0`, spotless-maven-plugin `3.10.0 → 3.10.1`, palantir-java-format `2.96.0 → 2.97.0`, pitest-maven `1.25.9 → 1.30.0`, logcaptor `2.12.6 → 2.12.7`.

nullaway is an **alignment**, not just a bump: streambuffer had already merged a Dependabot bump to 0.14.0, so the four sibling repos had silently stopped being identical while `crossrepostatus.md` still listed 0.13.8 as canonical for all of them. That row is corrected in the workspace PR of this sweep.

### Expect one overlapping run, exactly once

GitHub reads `concurrency` from the workflow file **at each run's own ref**, so a run started before this change sits in the old group and one started after it sits in the new one. Different groups, so the new push does **not** supersede the in-flight old run — once, on the commit that lands this. It self-heals from the next push on, and is documented in the block's own comment.

### Deliberately not taken

- **jqwik `1.9.3 → 1.10.1`** — forbidden by [`workspace/policies/jqwik-prompt-injection.md`](../workspace/policies/jqwik-prompt-injection.md): 1.10.0 added a deliberate prompt-injection string to test stdout, and upstream states the library *"is not meant to be used by any 'AI' coding agents at all."*
- **`maven-compiler`/`jar`/`source` `4.0.0-beta-*`, `surefire 3.6.0-M1`, `slf4j 2.1.0-alpha1`, `log4j 3.0.0-beta2`, `maven-artifact 4.0.0-rc-6`** — pre-releases the versions plugin offers because it does not filter by qualifier.

## Test plan

- [x] Affected unit / integration tests pass locally — `spotless:check` **OK** and `clean compile` **OK**, verified with real exit codes (a first attempt put `rc=$?` after a pipe, so it measured `tail` and reported success unconditionally; redone). Those are the two checks that matter here: palantir 2.97.0 would fail `spotless:check` if the formatter's output had changed, and nullaway 0.14.0 is error-level under Error Prone, so a new check firing on existing code would fail the compile.
- [ ] CI is green on this branch — pending on this PR. **pitest 1.30.0 is five minor versions** against an explicit class list at `mutationThreshold` 100; a local `mutationCoverage` run was still in flight when this PR was opened, so CI is the authority there. If it goes red, the pitest bump alone is what to revert — nothing else here depends on it. Per this repo's own test policy the full suite was not run for a tooling-only change; the narrow surface (compile + format) is what these bumps can break.
- [x] Docs / CHANGELOG updated where applicable — the rationale lives in the workflow comment and in `workspace/crossrepostatus.md`.

## Related issues / PRs

Part of a cross-repo sweep also landing in `java-llama.cpp`, `srcmorph`, `streambuffer`, `BroomCabinet` and `workspace`.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_