### PR TITLE
Prepare 1.8.0 release: drop -SNAPSHOT, finalize CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-29
+
 ### Added
 - **Results can be broadcast, not just logged** — one message per *checked batch*, sent whether or
   not anything was found. Reporting only hits would leave a client unable to tell "range checked,
@@ -430,7 +432,9 @@ First public pre-release version (Java 8).
 - LMDB database:
   <https://github.com/bernardladenthin/BitcoinAddressFinder#use-my-prepared-database>
 
-[Unreleased]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/bernardladenthin/BitcoinAddressFinder/compare/v1.4.0...v1.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This document provides guidance for AI assistants working on the BitcoinAddressF
 
 - **Group ID:** `net.ladenthin`
 - **Artifact ID:** `bitcoinaddressfinder`
-- **Version:** 1.8.0-SNAPSHOT
+- **Version:** 1.8.0
 - **Java:** 21
 - **License:** Apache 2.0
 - **Author:** Bernard Ladenthin (Copyright 2017–2025)
@@ -600,7 +600,7 @@ Test-only:
 mvn package -P assembly -DskipTests
 
 # Run (replace config path as needed)
-java -jar target/bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+java -jar target/bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
   examples/config_Find_8CPUProducer.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Copyright (c) 2017-2025 Bernard Ladenthin
     * lmdb
       * data.mdb
       * lock.mdb
-    * bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar
+    * bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar
     * logbackConfiguration.xml
     * config_Find_1OpenCLDevice.js
     * run_Find_1OpenCLDevice.bat  *(Windows)* / run_Find_1OpenCLDevice.sh *(Linux/macOS)*

--- a/docs/tuning-your-gpu.md
+++ b/docs/tuning-your-gpu.md
@@ -90,7 +90,7 @@ Run it with the supplied launcher (`run_OpenCLInfo.bat` on Windows, `run_OpenCLI
 or directly:
 
 ```bash
-java -jar bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar config_OpenCLInfo.json
+java -jar bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar config_OpenCLInfo.json
 ```
 
 No database is involved here, so nothing beyond the plain command is needed.
@@ -454,7 +454,7 @@ the arm as failed and continues, so this is not fatal during tuning. If it happe
 start from the `SUGGESTED START CONFIG` values that `OpenCLInfo` printed.
 
 **`InaccessibleObjectException` at startup.**
-Your jar predates the manifest that carries the required `Add-Opens` (added in 1.8.0-SNAPSHOT). Use
+Your jar predates the manifest that carries the required `Add-Opens` (added in 1.8.0). Use
 the launcher script, which passes the same flags on the command line, or rebuild from a current
 checkout.
 

--- a/examples/run_AddressFilesToLMDB.bat
+++ b/examples/run_AddressFilesToLMDB.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx512m ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_AddressFilesToLMDB.json
 rem >> log_AddressFilesToLMDB.txt 2>&1

--- a/examples/run_AddressFilesToLMDB.sh
+++ b/examples/run_AddressFilesToLMDB.sh
@@ -33,6 +33,6 @@ java \
 -Xmx512m \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_AddressFilesToLMDB.json
 # >> log_AddressFilesToLMDB.txt 2>&1

--- a/examples/run_CompactLMDB.bat
+++ b/examples/run_CompactLMDB.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx512m ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_CompactLMDB.json
 rem >> log_CompactLMDB.txt 2>&1

--- a/examples/run_CompactLMDB.sh
+++ b/examples/run_CompactLMDB.sh
@@ -33,6 +33,6 @@ java \
 -Xmx512m \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_CompactLMDB.json
 # >> log_CompactLMDB.txt 2>&1

--- a/examples/run_Find_1CPUProducerBip39.bat
+++ b/examples/run_Find_1CPUProducerBip39.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_Find_1CPUProducerBip39.json
 rem >> log_Find_1CPUProducerBip39.txt 2>&1

--- a/examples/run_Find_1CPUProducerBip39.sh
+++ b/examples/run_Find_1CPUProducerBip39.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_Find_1CPUProducerBip39.json
 # >> log_Find_1CPUProducerBip39.txt 2>&1

--- a/examples/run_Find_1OpenCLDevice.bat
+++ b/examples/run_Find_1OpenCLDevice.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_Find_1OpenCLDevice.json
 rem >> log_Find_1OpenCLDevice.txt 2>&1

--- a/examples/run_Find_1OpenCLDevice.sh
+++ b/examples/run_Find_1OpenCLDevice.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_Find_1OpenCLDevice.json
 # >> log_Find_1OpenCLDevice.txt 2>&1

--- a/examples/run_Find_1OpenCLDeviceAnd2CPUProducer.bat
+++ b/examples/run_Find_1OpenCLDeviceAnd2CPUProducer.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_Find_1OpenCLDeviceAnd2CPUProducer.json
 rem >> log_Find_1OpenCLDeviceAnd2CPUProducer.txt 2>&1

--- a/examples/run_Find_1OpenCLDeviceAnd2CPUProducer.sh
+++ b/examples/run_Find_1OpenCLDeviceAnd2CPUProducer.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_Find_1OpenCLDeviceAnd2CPUProducer.json
 # >> log_Find_1OpenCLDeviceAnd2CPUProducer.txt 2>&1

--- a/examples/run_Find_8CPUProducer.bat
+++ b/examples/run_Find_8CPUProducer.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_Find_8CPUProducer.json
 rem >> log_Find_8CPUProducer.txt 2>&1

--- a/examples/run_Find_8CPUProducer.sh
+++ b/examples/run_Find_8CPUProducer.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_Find_8CPUProducer.json
 # >> log_Find_8CPUProducer.txt 2>&1

--- a/examples/run_Find_SecretsFile.bat
+++ b/examples/run_Find_SecretsFile.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_Find_SecretsFile.json
 rem >> log_Find_SecretsFile.txt 2>&1

--- a/examples/run_Find_SecretsFile.sh
+++ b/examples/run_Find_SecretsFile.sh
@@ -33,6 +33,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_Find_SecretsFile.json
 # >> log_Find_SecretsFile.txt 2>&1

--- a/examples/run_Find_WebSocketUi.bat
+++ b/examples/run_Find_WebSocketUi.bat
@@ -36,6 +36,6 @@ java ^
 -Xmx16G ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_Find_WebSocketUi.json
 rem >> log_Find_WebSocketUi.txt 2>&1

--- a/examples/run_Find_WebSocketUi.sh
+++ b/examples/run_Find_WebSocketUi.sh
@@ -37,6 +37,6 @@ java \
 -Xmx16G \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_Find_WebSocketUi.json
 # >> log_Find_WebSocketUi.txt 2>&1

--- a/examples/run_LMDBDelta.bat
+++ b/examples/run_LMDBDelta.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx512m ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_LMDBDelta.json
 rem >> log_LMDBDelta.txt 2>&1

--- a/examples/run_LMDBDelta.sh
+++ b/examples/run_LMDBDelta.sh
@@ -33,6 +33,6 @@ java \
 -Xmx512m \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_LMDBDelta.json
 # >> log_LMDBDelta.txt 2>&1

--- a/examples/run_LMDBToAddressFile.bat
+++ b/examples/run_LMDBToAddressFile.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx512m ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_LMDBToAddressFile.json
 rem >> log_LMDBToAddressFile.txt 2>&1

--- a/examples/run_LMDBToAddressFile.sh
+++ b/examples/run_LMDBToAddressFile.sh
@@ -33,6 +33,6 @@ java \
 -Xmx512m \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_LMDBToAddressFile.json
 # >> log_LMDBToAddressFile.txt 2>&1

--- a/examples/run_OpenCLInfo.bat
+++ b/examples/run_OpenCLInfo.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx512m ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_OpenCLInfo.json
 rem >> log_OpenCLInfo.txt 2>&1

--- a/examples/run_OpenCLInfo.sh
+++ b/examples/run_OpenCLInfo.sh
@@ -33,6 +33,6 @@ java \
 -Xmx512m \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_OpenCLInfo.json
 # >> log_OpenCLInfo.txt 2>&1

--- a/examples/run_TuneConfiguration.bat
+++ b/examples/run_TuneConfiguration.bat
@@ -32,6 +32,6 @@ java ^
 -Xmx8g ^
 -Dlogback.configurationFile=logbackConfiguration.xml ^
 -jar ^
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar ^
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar ^
 config_TuneConfiguration.json
 rem >> log_TuneConfiguration.txt 2>&1

--- a/examples/run_TuneConfiguration.sh
+++ b/examples/run_TuneConfiguration.sh
@@ -33,6 +33,6 @@ java \
 -Xmx8g \
 -Dlogback.configurationFile=logbackConfiguration.xml \
 -jar \
-bitcoinaddressfinder-1.8.0-SNAPSHOT-jar-with-dependencies.jar \
+bitcoinaddressfinder-1.8.0-jar-with-dependencies.jar \
 config_TuneConfiguration.json
 # >> log_TuneConfiguration.txt 2>&1

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <groupId>net.ladenthin</groupId>
     <artifactId>bitcoinaddressfinder</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
     <packaging>jar</packaging>
 
     <name>bitcoinaddressfinder</name>


### PR DESCRIPTION
## Summary

Step 1 of the [canonical release procedure](../workspace/workflows/release-process.md). Merge this, then create the `v1.8.0` tag and run **Publish** with `publish_to_central=true`.

- **`1.8.0-SNAPSHOT` → `1.8.0`** in `pom.xml` — a plain `-SNAPSHOT` strip.
- **Every other version site updated**: `CLAUDE.md` (2), `README.md`, `docs/tuning-your-gpu.md` (2), and **24 `examples/run_*.{sh,bat}` launcher scripts**.
- **CHANGELOG finalized**, plus a repair — see below.

## The launcher scripts are release-tracking, and the previous release missed them

The `v1.7.0` prep (`98e6f6c`) touched only `CLAUDE.md` and `pom.xml`. But `v1.7.0` **shipped** its launchers naming `bitcoinaddressfinder-1.7.0-jar-with-dependencies.jar`, so they do track the release — and leaving them at `-SNAPSHOT` would point every documented run command in the README at a jar that does not exist.

This is already guarded: **`ExampleRunScriptJarVersionTest`** reads the first `<version>` from `pom.xml` and asserts every `…-<version>-jar-with-dependencies.jar` reference under `examples/` and `docs/` matches it. Bumping the pom **reds the build** until the scripts follow, which is exactly what happened here. That test is the model the other repos should copy.

## The CHANGELOG footer needed two repairs, not one

`v1.7.0` wrote its `## [1.7.0]` heading but **never added the `[1.7.0]` compare-link**, and left `[Unreleased]` pointing at `v1.6.1` — so the link chain skipped a shipped version entirely. This PR adds both the `1.8.0` link and the missing `1.7.0` one, and re-points `[Unreleased]` to `v1.8.0...HEAD`.

Released headings, footer links and tags are now the same set.

## Test plan

- [x] **`ExampleRunScriptJarVersionTest` passes** — `Tests run: 1, Failures: 0, BUILD SUCCESS`, verified with a real Maven exit code (an earlier `-q` run reported `rc=0` from the grep pipeline rather than from Maven, which proves nothing; redone).
- [x] No `1.8.0-SNAPSHOT` remains anywhere in the repo (`--exclude-dir=target`).
- [x] CHANGELOG headings / footer links / tags cross-checked mechanically.
- [ ] CI green on this branch — pending on this PR. This is a version/docs-only change on top of the already-merged #351; per this repo's test policy the full ~5-minute suite was not re-run locally for it, and the one test that *can* break on a version bump is the guard above, which was run.

## An audit came out of this, landing in `workspace`

The footer omission is not isolated — **nothing builds, tests or renders the compare-link footer**, so it ships silently and compounds:

- **BAF `v1.7.0`** — missing link + stale `[Unreleased]`. Fixed here.
- **srcmorph `v1.1.0`** — tagged and released with **no CHANGELOG section at all**. Open, recorded in `crossrepostatus.md`.
- **java-llama.cpp and streambuffer** — clean.

The hardened checklist, a mechanical headings/links/tags check, and a per-repo table of the version sites that actually drift now live in `workspace/workflows/release-process.md`.

## Related issues / PRs

Follows #351 (concurrency fix + tooling bumps). `java-llama.cpp` 5.1.0 is prepared in parallel; cross-repo findings in the `workspace` PR of this sweep.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_