### PR TITLE
ci: fail the release when an asset is attached unsigned

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -760,6 +760,34 @@ jobs:
         with:
           name: signed-snapshot-assets
           path: snapshot-assets/
+      - name: Report unsigned assets (does not block the upload)
+        # Deliberately NON-blocking, and deliberately BEFORE the upload. Both attach jobs run even
+        # when their publish job failed, because a Central publish-poll timeout must not cost the
+        # GitHub assets: if Central is unreachable these are the ONLY way to get the artifacts at
+        # all. Refusing to attach on a signing failure would defeat exactly that. So annotate here,
+        # upload regardless, and fail the job afterwards. Assets always land; an unsigned release is
+        # still loudly red rather than quietly wrong.
+        # See workspace/policies/fat-jar-release-assets.md, "Attach first, then go red".
+        id: signatures
+        run: |
+          set -uo pipefail
+          dir="snapshot-assets"
+          jars=$(find "$dir" -maxdepth 1 -name '*.jar' | sort)
+          if [ -z "$jars" ]; then
+            echo "::error::no jars in $dir -- the collection step produced nothing"
+            echo "missing=-1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          missing=0
+          for jar in $jars; do
+            if [ ! -e "$jar.asc" ]; then
+              echo "::error::unsigned: $(basename "$jar") has no detached .asc"
+              missing=$((missing + 1))
+            fi
+          done
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+          [ "$missing" -eq 0 ] && echo "all $(echo "$jars" | wc -l) jar(s) signed"
+          exit 0
       - name: Update snapshot pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -773,6 +801,12 @@ jobs:
           gh release upload snapshot snapshot-assets/* \
             --repo ${{ github.repository }} \
             --clobber
+      - name: Fail if anything was attached unsigned
+        # After the upload on purpose: the assets must exist even when the signature does not.
+        if: ${{ always() && steps.signatures.outputs.missing != '0' }}
+        run: |
+          echo "::error::${{ steps.signatures.outputs.missing }} asset(s) attached without a signature (-1 means none were collected at all)"
+          exit 1
 
   publish-release:
     name: Publish Release to Central
@@ -862,7 +896,41 @@ jobs:
         with:
           name: signed-release-assets
           path: release-assets/
+      - name: Report unsigned assets (does not block the upload)
+        # Deliberately NON-blocking, and deliberately BEFORE the upload. Both attach jobs run even
+        # when their publish job failed, because a Central publish-poll timeout must not cost the
+        # GitHub assets: if Central is unreachable these are the ONLY way to get the artifacts at
+        # all. Refusing to attach on a signing failure would defeat exactly that. So annotate here,
+        # upload regardless, and fail the job afterwards. Assets always land; an unsigned release is
+        # still loudly red rather than quietly wrong.
+        # See workspace/policies/fat-jar-release-assets.md, "Attach first, then go red".
+        id: signatures
+        run: |
+          set -uo pipefail
+          dir="release-assets"
+          jars=$(find "$dir" -maxdepth 1 -name '*.jar' | sort)
+          if [ -z "$jars" ]; then
+            echo "::error::no jars in $dir -- the collection step produced nothing"
+            echo "missing=-1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          missing=0
+          for jar in $jars; do
+            if [ ! -e "$jar.asc" ]; then
+              echo "::error::unsigned: $(basename "$jar") has no detached .asc"
+              missing=$((missing + 1))
+            fi
+          done
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+          [ "$missing" -eq 0 ] && echo "all $(echo "$jars" | wc -l) jar(s) signed"
+          exit 0
       - name: Upload release assets
         uses: softprops/action-gh-release@v3
         with:
           files: release-assets/*
+      - name: Fail if anything was attached unsigned
+        # After the upload on purpose: the assets must exist even when the signature does not.
+        if: ${{ always() && steps.signatures.outputs.missing != '0' }}
+        run: |
+          echo "::error::${{ steps.signatures.outputs.missing }} asset(s) attached without a signature (-1 means none were collected at all)"
+          exit 1


### PR DESCRIPTION
## Summary

- The attach jobs collect `target/*.jar.asc` with `|| true`, so a signing step that produced nothing yields an attach that **looks complete and is not**: the jars land on the release without a signature and nothing says so.
- The obvious fix — verify, refuse to attach — would defeat the reason both attach jobs deliberately run when their publish job *failed*: when Central is unreachable, the GitHub assets are the only way to get the build output at all. Withholding them over a missing signature is the worst outcome available.
- So the check is split around the upload: **report** before it (never exits non-zero, one `::error::` per unsigned jar, count to `$GITHUB_OUTPUT`), **upload** unconditionally, **assert** after it. Assets always land; an unsigned release is loudly red instead of quietly wrong. `-1` distinguishes "nothing was collected at all" from a signing failure.

Applied to `github-snapshot` and `github-release`. The two steps are **byte-identical** with the copies now in java-llama.cpp, srcmorph and streambuffer — verified by normalising the asset-directory name and hashing; sync any future edit to all four.

## Test plan

- [x] `publish.yml` parses as YAML; the job graph is unchanged apart from the two added steps
- [x] The guard block is byte-identical across all four sibling repos (checked by hash, not by eye)
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable — rationale lives in [`workspace/policies/fat-jar-release-assets.md`](https://github.com/bernardladenthin/workspace) ("Attach first, then go red"), updated in the companion workspace PR

BAF-relevant note: this guard is about the **attached artifact**, not about the fat jar, so it covers the thin jars too. It does not touch the `-Dmaven.javadoc.skip=true` flags this repo needs for the JPMS module-mode trap.

## Related issues / PRs

Cross-repo rollout; companion PRs in `java-llama.cpp`, `srcmorph`, `streambuffer` and `workspace`.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_