### PR TITLE
build(deps): bump analysis tooling and shared libraries to current

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
     <properties>
         <sonar.organization>bernardladenthin</sonar.organization>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <slf4j.version>2.0.18</slf4j.version>
+        <slf4j.version>2.0.19</slf4j.version>
         <logback.version>1.6.3</logback.version>
         <project.build.outputTimestamp>2026-09-01T07:58:47Z</project.build.outputTimestamp>
         <!-- Test JVM heap: -Xmx2g cap, no eager -Xms. With reuseForks=false a fresh JVM is
@@ -66,16 +66,16 @@ SPDX-License-Identifier: Apache-2.0
              policy) for full context. -->
         <jqwik.version>1.9.3</jqwik.version>
         <archunit.version>1.5.0</archunit.version>
-        <spotbugs.version>4.10.4.0</spotbugs.version>
+        <spotbugs.version>4.10.4.1</spotbugs.version>
         <fb-contrib.version>7.7.4</fb-contrib.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <errorprone.version>2.50.0</errorprone.version>
         <nullaway.version>0.14.1</nullaway.version>
-        <checker.version>4.2.2</checker.version>
+        <checker.version>4.2.3</checker.version>
         <java-websocket.version>1.6.0</java-websocket.version>
         <jeromq.version>0.6.0</jeromq.version>
         <jspecify.version>1.0.1</jspecify.version>
-        <lombok.version>1.18.46</lombok.version>
+        <lombok.version>1.18.48</lombok.version>
         <bitcoinj.version>0.17.1</bitcoinj.version>
         <bcprov.version>1.85.2</bcprov.version>
         <protobuf.version>4.36.1</protobuf.version>
@@ -99,7 +99,7 @@ SPDX-License-Identifier: Apache-2.0
              newest patched stable so the alert clears; see the dependencyManagement entries. -->
         <log4j.version>2.26.1</log4j.version>
         <jmh.version>1.37</jmh.version>
-        <spotless.version>3.10.1</spotless.version>
+        <spotless.version>3.10.2</spotless.version>
         <palantir-java-format.version>2.97.0</palantir-java-format.version>
     </properties>
 
@@ -113,7 +113,7 @@ SPDX-License-Identifier: Apache-2.0
     <dependencyManagement>
         <dependencies>
             <!-- slf4j-api: bitcoinj brings 2.0.16, Java-WebSocket brings 2.0.13,
-                 logback-classic brings 2.0.17; we declare 2.0.18 directly. -->
+                 logback-classic brings 2.0.17; we declare 2.0.19 directly. -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -200,7 +200,7 @@ SPDX-License-Identifier: Apache-2.0
                 <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>10.0.0</version>
+                    <version>10.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

Pure version maintenance, no behaviour change. One of four coordinated PRs (jllama / srcmorph / BAF / streambuffer).

**This repo already carries the cross-repo group** — `maven-compiler-plugin` 3.16.0, `maven-surefire-plugin` 3.6.0 and `nullaway` 0.14.1 landed here via Dependabot (#357–#360) and are exactly what the three sibling repos are now being brought up to. What is left is the group **all four** were behind on:

| | before | after |
|---|---|---|
| `git-commit-id-maven-plugin` | 10.0.0 | **10.0.1** |
| `spotless-maven-plugin` | 3.10.1 | **3.10.2** |
| `spotbugs-maven-plugin` | 4.10.4.0 | **4.10.4.1** |
| `checker` / `checker-qual` | 4.2.2 | **4.2.3** |
| `lombok` | 1.18.46 | **1.18.48** |
| `slf4j-api` | 2.0.18 | **2.0.19** |

The **checker bump moves one property that feeds both the annotation processor and the qualifiers**, and that coupling is the point: the Nullness Checker resolves its own qualifiers through javac's symbol table, so the two must share a major version — the lesson from the 3.55.1 pin reverted in java-llama.cpp.

The comment above the `slf4j-api` pin named the old version *in prose* ("logback-classic brings 2.0.17; we declare 2.0.18 directly"); it now names 2.0.19, so the rationale cannot drift away from the value it explains. `logback-classic` stays at **1.6.3**, which is current.

**Deliberately NOT bumped: `jqwik` stays at 1.9.3.** Releases from 1.10.0 on print a prompt-injection string aimed at AI coding agents, and the [workspace policy](https://github.com/bernardladenthin/workspace/blob/main/policies/jqwik-prompt-injection.md) requires rejecting any PR that moves it. Dependabot will keep proposing it.

## Test plan

- [x] `mvn clean verify` green — **2214 tests**, 0 failures
- [x] Class-file gate clean over a real `-P assembly` fat jar: **15779 classes, 0 above major 65**
- [x] `spotless` 3.10.2 reformats nothing — the working tree after `spotless:apply` holds only the pom edit
- [ ] CI is green on this branch
- [x] No source or test change; pom only

## ⚠️ One pre-existing `main` failure, not touched here

`ExampleRunScriptJarVersionTest` fails because **24 `examples/run_*.sh|.bat` files and `docs/tuning-your-gpu.md` still reference `1.8.0`** while the project is at `1.9.0-SNAPSHOT`. I confirmed it is pre-existing by running that test on an **unmodified `main`** — it fails there identically, so it is not caused by these bumps.

Whether those scripts should track the SNAPSHOT or stay on the last released version is a release-process decision, not a dependency one, so I left it for a separate change. The verification above therefore excluded that single test and nothing else. Say the word and I'll fix it — it is a mechanical `1.8.0 → 1.9.0-SNAPSHOT` across 25 files, but the right *target* value is yours to pick.

## Related PRs

Same change in [java-llama.cpp](https://github.com/bernardladenthin/java-llama.cpp/pull/416), [srcmorph](https://github.com/bernardladenthin/srcmorph/pull/205) and [streambuffer](https://github.com/bernardladenthin/streambuffer/pull/155) — those three additionally carry the compiler/surefire/nullaway bumps this repo already has.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_